### PR TITLE
Implement credit check helpers

### DIFF
--- a/Backend/services/limit_service.py
+++ b/Backend/services/limit_service.py
@@ -64,3 +64,46 @@ def verificar_limite_uso(
     
     print(f"INFO: Verificação de limite para usuário {user.id} ({tipo_geracao_principal}): {usos_no_mes}/{limite_mensal} usos.")
     return True
+
+
+async def verificar_creditos_disponiveis_geracao_ia(
+    db: Session,
+    user_id: int,
+    creditos_necessarios: int = 1,
+) -> bool:
+    """Verifica se o usuário possui créditos suficientes para a geração de IA.
+
+    A função consulta o limite mensal de geração de IA definido para o usuário
+    (campo ``limite_geracao_ia`` ou o valor herdado do plano) e compara com a
+    quantidade de usos registrados no mês corrente. Caso o limite seja zero ou
+    ``None`` considera-se que o usuário possui uso ilimitado.
+    """
+
+    user = crud.get_user(db, user_id=user_id)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Usuário não encontrado")
+
+    limite_mensal = user.limite_geracao_ia
+    if limite_mensal in (None, 0) and user.plano:
+        limite_mensal = user.plano.limite_geracao_ia
+
+    if limite_mensal is None or limite_mensal <= 0:
+        return True
+
+    usos_no_mes = crud.get_geracoes_ia_count_no_mes_corrente(db, user_id=user_id)
+    return usos_no_mes + creditos_necessarios <= limite_mensal
+
+
+async def verificar_e_consumir_creditos_geracao_ia(
+    db: Session,
+    user_id: int,
+    creditos_necessarios: int = 1,
+) -> bool:
+    """Verifica (e reserva) créditos de geração de IA.
+
+    Atualmente a função apenas verifica se há créditos disponíveis. O consumo
+    efetivo é registrado quando um ``RegistroUsoIA`` é criado pelo serviço de IA.
+    """
+
+    disponivel = await verificar_creditos_disponiveis_geracao_ia(db, user_id, creditos_necessarios)
+    return disponivel

--- a/tests/test_limit_service.py
+++ b/tests/test_limit_service.py
@@ -1,0 +1,32 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from Backend.database import Base
+from Backend import models
+from Backend.services import limit_service
+
+@pytest.mark.asyncio
+async def test_verificar_e_consumir_creditos_geracao_ia():
+    engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+    Session = sessionmaker(bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = Session()
+
+    user = models.User(email="test@example.com", hashed_password="x", limite_geracao_ia=5)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+
+    for _ in range(4):
+        db.add(models.RegistroUsoIA(user_id=user.id, tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO))
+    db.commit()
+
+    assert await limit_service.verificar_e_consumir_creditos_geracao_ia(db, user.id, 1)
+
+    db.add(models.RegistroUsoIA(user_id=user.id, tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO))
+    db.commit()
+
+    assert not await limit_service.verificar_e_consumir_creditos_geracao_ia(db, user.id, 1)
+
+    db.close()


### PR DESCRIPTION
## Summary
- add async helpers to verify and (conceptually) consume IA generation credits
- test credit limits using in-memory database

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684360af5c6c832fab982e34282338e8