### PR TITLE
Fix Gemini API key usage

### DIFF
--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -64,6 +64,7 @@ class Settings(BaseSettings):
     UPLOAD_DIRECTORY: str = os.getenv("UPLOAD_DIRECTORY", "static/uploads")
 
     OPENAI_API_KEY: Optional[str] = os.getenv("OPENAI_API_KEY")
+    # Chave para acessar a API Google Gemini (modelo generativo)
     GOOGLE_GEMINI_API_KEY: Optional[str] = os.getenv("GOOGLE_GEMINI_API_KEY")
     
     ALLOW_USERS_TO_EDIT_GLOBAL_PRODUCT_TYPES: bool = Field(default=False, validation_alias=env_var_name_with_prefix('ALLOW_USERS_TO_EDIT_GLOBAL_PRODUCT_TYPES'))

--- a/Backend/services/ia_generation_service.py
+++ b/Backend/services/ia_generation_service.py
@@ -45,9 +45,10 @@ async def get_gemini_api_key(db: Session, user: models.User) -> Optional[str]:
     if user.chave_google_gemini_pessoal:
         logger.info(f"Usando chave Gemini pessoal para usuário ID: {user.id}")
         return user.chave_google_gemini_pessoal
-    if settings.GOOGLE_GEMINI_API_KEY_GLOBAL: # Supondo que GOOGLE_GEMINI_API_KEY_GLOBAL exista em settings
+    # A chave global agora é definida em settings.GOOGLE_GEMINI_API_KEY
+    if settings.GOOGLE_GEMINI_API_KEY:
         logger.info("Usando chave Gemini global do sistema.")
-        return settings.GOOGLE_GEMINI_API_KEY_GLOBAL
+        return settings.GOOGLE_GEMINI_API_KEY
     logger.warning("Nenhuma chave Gemini encontrada (nem pessoal, nem global).")
     return None
 

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ ACCESS_TOKEN_EXPIRE_MINUTES=60
 
 # OpenAI
 OPENAI_API_KEY="sk-..."
+# Google Gemini API
+GOOGLE_GEMINI_API_KEY="..."
 
 # Google Search API
 GOOGLE_CSE_ID="..."


### PR DESCRIPTION
## Summary
- use `settings.GOOGLE_GEMINI_API_KEY` in Gemini helper
- document Gemini API key in config
- add Gemini key example to README

## Testing
- `python -m py_compile Backend/services/ia_generation_service.py Backend/core/config.py`

------
https://chatgpt.com/codex/tasks/task_e_684360b20f44832fa07f5fa2ba44ee48