### PR TITLE
Add refresh token secret setting

### DIFF
--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -26,6 +26,7 @@ class Settings(BaseSettings):
     SQLITE_DB_FILE: str = os.getenv("SQLITE_DB_FILE", "tdai_app.db")
 
     SECRET_KEY: str = os.getenv("SECRET_KEY", "super-secret-key-deve-ser-alterada-imediatamente")
+    REFRESH_SECRET_KEY: str = os.getenv("REFRESH_SECRET_KEY", "change-me")
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 60 * 24 * 1)) # Default 1 dia
     REFRESH_TOKEN_EXPIRE_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", 7))

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ DATABASE_URL="postgresql://usuario:senha@localhost:5432/tdai_db"
 
 # Segurança
 SECRET_KEY="sua_chave_forte"
+REFRESH_SECRET_KEY="change-me"
 ALGORITHM="HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 

--- a/README.txt
+++ b/README.txt
@@ -143,6 +143,7 @@ Snippet de código
 # Backend/core/config.py espera estas variáveis
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DB_NAME" # Ex: postgresql://postgres:password@localhost:5432/tdai_db
 SECRET_KEY="sua_chave_secreta_super_forte_aqui" # Importante para JWT
+REFRESH_SECRET_KEY="change-me"
 ALGORITHM="HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 


### PR DESCRIPTION
## Summary
- add `REFRESH_SECRET_KEY` in backend settings
- document `REFRESH_SECRET_KEY` usage in READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68436891b588832fb611e5f1abdd38df