### PR TITLE
Add minimal testing frameworks

### DIFF
--- a/Backend/tests/test_health.py
+++ b/Backend/tests/test_health.py
@@ -1,0 +1,9 @@
+from fastapi.testclient import TestClient
+from main import app
+
+client = TestClient(app)
+
+def test_health_endpoint():
+    response = client.get('/health')
+    assert response.status_code == 200
+    assert response.json() == {'status': 'ok'}

--- a/Frontend/app/babel.config.cjs
+++ b/Frontend/app/babel.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ]
+};

--- a/Frontend/app/jest.config.cjs
+++ b/Frontend/app/jest.config.cjs
@@ -1,0 +1,9 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(js|jsx)$': 'babel-jest'
+  },
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  }
+};

--- a/Frontend/app/package.json
+++ b/Frontend/app/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "jest"
   },
   "dependencies": {
     "axios": "^1.9.0",
@@ -27,7 +28,15 @@
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "@babel/preset-env": "^7.24.1",
+    "@babel/preset-react": "^7.24.1",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.3",
+    "@testing-library/user-event": "^14.4.3",
+    "identity-obj-proxy": "^3.0.0"
   }
 }
 

--- a/Frontend/app/src/components/common/__tests__/PaginationControls.test.jsx
+++ b/Frontend/app/src/components/common/__tests__/PaginationControls.test.jsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import PaginationControls from '../PaginationControls.jsx';
+
+test('shows current page information', () => {
+  render(<PaginationControls currentPage={0} totalPages={3} onPageChange={() => {}} isLoading={false} />);
+  expect(screen.getByText(/Página 1 de 3/)).toBeInTheDocument();
+});

--- a/README.md
+++ b/README.md
@@ -243,6 +243,19 @@ npm run dev                 # Roda o frontend em http://localhost:5173
 
 ---
 
+### 6. **Testes**
+
+```sh
+# Backend
+pytest
+
+# Frontend
+cd Frontend/app
+npm test
+```
+
+---
+
 ## ⚙️ Variáveis de Ambiente – Exemplo `.env`
 
 ```


### PR DESCRIPTION
## Summary
- set up Jest with React Testing Library
- add Babel/Jest config for frontend tests
- provide example PaginationControls test
- include simple FastAPI health check test
- document how to run frontend and backend tests in README

## Testing
- `pytest Backend/tests/test_health.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684369a41d2c832f863d164b2f551a55