### PR TITLE
Add lint setup guidance

### DIFF
--- a/Frontend/app/README.md
+++ b/Frontend/app/README.md
@@ -11,3 +11,7 @@ Currently, two official plugins are available:
 
 If you are developing a production application, we recommend using TypeScript with type-aware lint rules enabled. Check out the [TS template](https://github.com/vitejs/vite/tree/main/packages/create-vite/template-react-ts) for information on how to integrate TypeScript and [`typescript-eslint`](https://typescript-eslint.io) in your project.
 
+## Lint
+
+After running `npm install`, make sure all dev dependencies (including `@eslint/js`) were installed before executing `npm run lint`. The script `prelint` in `package.json` warns you if ESLint packages are missing.
+

--- a/Frontend/app/check-eslint.js
+++ b/Frontend/app/check-eslint.js
@@ -1,0 +1,8 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const eslintPath = path.join(__dirname, 'node_modules', '@eslint', 'js');
+if (!fs.existsSync(eslintPath)) {
+  console.warn('Aviso: dependências do ESLint não encontradas. Execute "npm install" para instalar os pacotes de desenvolvimento.');
+}

--- a/Frontend/app/package.json
+++ b/Frontend/app/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "prelint": "node check-eslint.js",
     "lint": "eslint .",
     "preview": "vite preview"
   },

--- a/README.md
+++ b/README.md
@@ -227,6 +227,9 @@ python run_backend.py       # Inicia o backend (http://localhost:8000)
 ```sh
 cd Frontend/app
 npm install
+# Certifique-se de que as dependências de desenvolvimento (como @eslint/js)
+# foram instaladas. Elas são necessárias para o comando de lint.
+npm run lint            # Opcional: verifica padrões de código
 npm run dev                 # Roda o frontend em http://localhost:5173
 ```
 
@@ -299,6 +302,8 @@ ADMIN_PASSWORD="adminpassword"
 
 * **Iniciar Frontend:**
   `npm run dev` (na pasta `Frontend/app`)
+* **Verificar código com ESLint:**
+  `npm run lint` (exige dependências de desenvolvimento instaladas)
 
 * **Explorar Endpoints API:**
 


### PR DESCRIPTION
## Summary
- clarify that ESLint dev dependencies are required before running `npm run lint`
- show lint command in Quick Install steps and command list
- document lint prerequisites in frontend README
- add `prelint` script with simple dependency check

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' ...)*

------
https://chatgpt.com/codex/tasks/task_e_684369a5d770832f956061b0e0da9575