### PR TITLE
Add editorconfig for newline enforcement

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary
- add `.editorconfig` to enforce final newline in all files
- verify that all files under `Backend/` and `Frontend/` already end with a newline

## Testing
- `find Backend Frontend -type f -exec sh -c 'last=$(tail -c1 "$1" | od -An -t u1 | tr -d " "); [ "$last" = "10" ] || echo "$1"' _ {} \; | head`

------
https://chatgpt.com/codex/tasks/task_e_684369dd1824832f8517cae2467467e5