### PR TITLE
Guard frontend logs

### DIFF
--- a/Frontend/app/src/App.jsx
+++ b/Frontend/app/src/App.jsx
@@ -19,13 +19,14 @@ import ProtectedRoute from './components/ProtectedRoute';
 // Importe outras páginas e componentes necessários
 
 import './App.css';
+import logger from './utils/logger';
 
 function AppContent() {
   const { isAuthenticated, isLoading } = useAuth();
   const location = useLocation();
 
   useEffect(() => {
-    console.log("App.jsx: Auth state changed - isAuthenticated:", isAuthenticated, "isLoading:", isLoading, "path:", location.pathname);
+    logger.log("App.jsx: Auth state changed - isAuthenticated:", isAuthenticated, "isLoading:", isLoading, "path:", location.pathname);
   }, [isAuthenticated, isLoading, location.pathname]);
 
   // Se ainda estiver carregando a informação de autenticação, pode mostrar um loader global
@@ -72,7 +73,7 @@ function AppContent() {
 
 function App() {
   useEffect(() => {
-    console.log("App.jsx está a ser renderizado com AuthProvider e ProductTypeProvider");
+    logger.log("App.jsx está a ser renderizado com AuthProvider e ProductTypeProvider");
   }, []);
 
   return (

--- a/Frontend/app/src/components/ProtectedRoute.jsx
+++ b/Frontend/app/src/components/ProtectedRoute.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import logger from '../utils/logger';
 
 const ProtectedRoute = ({ children, allowedRoles }) => {
     const { isAuthenticated, user, isLoading } = useAuth();
@@ -17,7 +18,7 @@ const ProtectedRoute = ({ children, allowedRoles }) => {
     if (!isAuthenticated) {
         // Usuário não está logado, redireciona para a página de login.
         // Salva a localização atual para que possamos enviar o usuário de volta após o login.
-        console.log("ProtectedRoute: Usuário não autenticado. Redirecionando para /login.");
+        logger.log("ProtectedRoute: Usuário não autenticado. Redirecionando para /login.");
         return <Navigate to="/login" state={{ from: location }} replace />;
     }
 
@@ -33,7 +34,7 @@ const ProtectedRoute = ({ children, allowedRoles }) => {
 
     if (allowedRoles && allowedRoles.length > 0) {
         if (!userRole || !allowedRoles.includes(userRole)) {
-            console.log(`ProtectedRoute: Usuário autenticado mas sem permissão. Role: ${userRole}, Permitidas: ${allowedRoles}. Redirecionando para /nao-autorizado ou dashboard.`);
+            logger.log(`ProtectedRoute: Usuário autenticado mas sem permissão. Role: ${userRole}, Permitidas: ${allowedRoles}. Redirecionando para /nao-autorizado ou dashboard.`);
             // Redireciona para uma página de "Não Autorizado" ou para o dashboard como fallback
             return <Navigate to="/dashboard" state={{ from: location }} replace />; // Ou para uma página específica de "Não Autorizado"
         }

--- a/Frontend/app/src/components/Topbar.jsx
+++ b/Frontend/app/src/components/Topbar.jsx
@@ -1,7 +1,8 @@
 // Frontend/app/src/components/Topbar.jsx
 import React, { useState, useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
-import authService from '../services/authService'; 
+import authService from '../services/authService';
+import logger from '../utils/logger';
 // Se você criar um AuthContext, importe-o:
 // import { AuthContext } from '../contexts/AuthContext'; 
 
@@ -36,23 +37,23 @@ function Topbar({ viewTitle }) {
   useEffect(() => {
     const fetchUserData = async () => {
       const token = localStorage.getItem('accessToken');
-      console.log('Topbar useEffect: token from localStorage:', token); // DEBUG
+      logger.log('Topbar useEffect: token from localStorage:', token); // DEBUG
       if (token) { 
         setLoadingUser(true);
         try {
-          console.log('Topbar: Fetching user data...'); // DEBUG
+          logger.log('Topbar: Fetching user data...'); // DEBUG
           const user = await authService.getCurrentUser(); 
-          console.log('Topbar: User data fetched:', user); // DEBUG
+          logger.log('Topbar: User data fetched:', user); // DEBUG
           if (user) {
             setCurrentUser(user);
           } else {
-            console.log('Topbar: No user data returned from getCurrentUser, logging out.'); // DEBUG
+            logger.log('Topbar: No user data returned from getCurrentUser, logging out.'); // DEBUG
             handleLogout(navigate, setCurrentUser); 
           }
         } catch (error) {
           console.error("Topbar: Erro ao buscar dados do usuário:", error.response || error.message || error); // DEBUG
           if (error.response && error.response.status === 401) {
-            console.log('Topbar: 401 error on fetching user, logging out.'); // DEBUG
+            logger.log('Topbar: 401 error on fetching user, logging out.'); // DEBUG
             handleLogout(navigate, setCurrentUser);
           }
           // Mesmo se não for 401, mas houver erro, talvez seja melhor deslogar
@@ -62,7 +63,7 @@ function Topbar({ viewTitle }) {
           setLoadingUser(false);
         }
       } else {
-        console.log('Topbar: No token found, user not logged in or already logged out.'); // DEBUG
+        logger.log('Topbar: No token found, user not logged in or already logged out.'); // DEBUG
         setLoadingUser(false); 
         // Não é necessário redirecionar aqui, ProtectedRoute deve cuidar disso
       }

--- a/Frontend/app/src/components/produtos/ProductTable.jsx
+++ b/Frontend/app/src/components/produtos/ProductTable.jsx
@@ -1,8 +1,9 @@
 // Frontend/app/src/components/produtos/ProductTable.jsx
 import React from 'react';
 import './ProductTable.css'; // Seu CSS para a tabela. Deve existir em src/components/produtos/ProductTable.css
-import { format } from 'date-fns'; 
-import { ptBR } from 'date-fns/locale'; 
+import { format } from 'date-fns';
+import { ptBR } from 'date-fns/locale';
+import logger from '../../utils/logger';
 
 const StatusIcon = ({ status }) => {
   let iconClass = "status-icon ";
@@ -32,9 +33,9 @@ function ProductTable({
   onSelectAllProdutos, 
   loading, 
 }) {
-  console.log('ProductTable: Props recebidos - produtos:', produtos); 
-  console.log('ProductTable: Props recebidos - loading:', loading); 
-  console.log('ProductTable: Props recebidos - selectedProdutos:', selectedProdutos); 
+  logger.log('ProductTable: Props recebidos - produtos:', produtos);
+  logger.log('ProductTable: Props recebidos - loading:', loading);
+  logger.log('ProductTable: Props recebidos - selectedProdutos:', selectedProdutos);
 
   const getSortDirectionIcon = (key) => {
     if (sortConfig.key === key) {

--- a/Frontend/app/src/contexts/AuthContext.jsx
+++ b/Frontend/app/src/contexts/AuthContext.jsx
@@ -3,6 +3,7 @@ import React, { createContext, useContext, useState, useEffect, useCallback } fr
 import { useNavigate, useLocation } from 'react-router-dom';
 import authService from '../services/authService';
 import apiClient from '../services/apiClient'; // Para configurar o header padrão globalmente
+import logger from '../utils/logger';
 
 const AuthContext = createContext(null);
 
@@ -18,7 +19,7 @@ export const AuthProvider = ({ children }) => {
     setIsAuthenticated(false);
     localStorage.removeItem('accessToken'); // Chave corrigida
     delete apiClient.defaults.headers.common['Authorization'];
-    console.log("AuthContext: clearAuthData chamado, token removido e header limpo.");
+    logger.log("AuthContext: clearAuthData chamado, token removido e header limpo.");
     setIsLoading(false);
   }, []);
 
@@ -28,7 +29,7 @@ export const AuthProvider = ({ children }) => {
     if (token) {
         localStorage.setItem('accessToken', token); // Chave corrigida
         apiClient.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-        console.log("AuthContext: setAuthData chamado, token salvo e header configurado.", userData);
+        logger.log("AuthContext: setAuthData chamado, token salvo e header configurado.", userData);
     } else {
         console.warn("AuthContext: setAuthData chamado sem token. UserData:", userData);
     }
@@ -36,19 +37,19 @@ export const AuthProvider = ({ children }) => {
   }, []);
 
   const checkUserSession = useCallback(async () => {
-    console.log("AuthContext: Verificando sessão do usuário...");
+    logger.log("AuthContext: Verificando sessão do usuário...");
     setIsLoading(true);
     const token = localStorage.getItem('accessToken'); // Chave corrigida
     const tokenSnippet = token ? `${token.substring(0, 15)}...${token.substring(token.length - 15)}` : "N/A";
-    console.log(`AuthContext: Token encontrado no localStorage (snippet): ${tokenSnippet}`);
+    logger.log(`AuthContext: Token encontrado no localStorage (snippet): ${tokenSnippet}`);
 
     if (token) {
       apiClient.defaults.headers.common['Authorization'] = `Bearer ${token}`;
       try {
-        console.log("AuthContext: Token encontrado, tentando buscar dados do usuário atual...");
+        logger.log("AuthContext: Token encontrado, tentando buscar dados do usuário atual...");
         const userData = await authService.getCurrentUser();
         if (userData) {
-          console.log("AuthContext: Dados do usuário recuperados com sucesso:", userData);
+          logger.log("AuthContext: Dados do usuário recuperados com sucesso:", userData);
           setAuthData(userData, token);
         } else {
           console.warn("AuthContext: getCurrentUser não retornou dados do usuário. Limpando...");
@@ -63,7 +64,7 @@ export const AuthProvider = ({ children }) => {
         clearAuthData();
       }
     } else {
-      console.log("AuthContext: Nenhum token no localStorage. Sessão não iniciada.");
+      logger.log("AuthContext: Nenhum token no localStorage. Sessão não iniciada.");
       clearAuthData();
     }
   }, [setAuthData, clearAuthData]);
@@ -73,28 +74,28 @@ export const AuthProvider = ({ children }) => {
   }, [checkUserSession]);
 
   const login = async (email, password) => {
-    console.log("AuthContext: Tentando login...");
+    logger.log("AuthContext: Tentando login...");
     setIsLoading(true);
     try {
       const response = await authService.login(email, password);
       if (response && response.access_token) {
         const token = response.access_token;
         const tokenSnippetLogin = `${token.substring(0, 15)}...${token.substring(token.length - 15)}`;
-        console.log(`AuthContext: Login bem-sucedido, token recebido (snippet): ${tokenSnippetLogin}`);
+        logger.log(`AuthContext: Login bem-sucedido, token recebido (snippet): ${tokenSnippetLogin}`);
         
         localStorage.setItem('accessToken', token); // Chave corrigida
         apiClient.defaults.headers.common['Authorization'] = `Bearer ${token}`;
-        console.log("AuthContext: Token salvo no localStorage e configurado no header do apiClient.");
+        logger.log("AuthContext: Token salvo no localStorage e configurado no header do apiClient.");
 
-        console.log("AuthContext: Buscando dados do usuário após login...");
+        logger.log("AuthContext: Buscando dados do usuário após login...");
         const userData = await authService.getCurrentUser();
         
         if (userData) {
-          console.log("AuthContext: Dados do usuário obtidos após login:", userData);
+          logger.log("AuthContext: Dados do usuário obtidos após login:", userData);
           setAuthData(userData, token);
           
           const from = location.state?.from?.pathname || '/dashboard';
-          console.log(`AuthContext: Redirecionando para ${from}`);
+          logger.log(`AuthContext: Redirecionando para ${from}`);
           navigate(from, { replace: true });
           return true;
         } else {
@@ -117,14 +118,14 @@ export const AuthProvider = ({ children }) => {
         throw new Error(errorMsg);
       }
     } finally {
-      console.log("AuthContext: Processo de login finalizado (finally).");
+      logger.log("AuthContext: Processo de login finalizado (finally).");
     }
   };
 
   const logout = async (redirectTo = "/login") => {
-    console.log("AuthContext: Efetuando logout...");
+    logger.log("AuthContext: Efetuando logout...");
     clearAuthData();
-    console.log(`AuthContext: Redirecionando para ${redirectTo} após logout.`);
+    logger.log(`AuthContext: Redirecionando para ${redirectTo} após logout.`);
     navigate(redirectTo);
   };
 

--- a/Frontend/app/src/pages/EnriquecimentoPage.jsx
+++ b/Frontend/app/src/pages/EnriquecimentoPage.jsx
@@ -5,6 +5,7 @@ import usoIAService from '../services/usoIAService';
 import ProductTable from '../components/produtos/ProductTable';
 import PaginationControls from '../components/common/PaginationControls';
 import { showSuccessToast, showErrorToast, showInfoToast, showWarningToast } from '../utils/notifications';
+import logger from '../utils/logger';
 
 function EnriquecimentoPage() {
   const [produtos, setProdutos] = useState([]);
@@ -180,7 +181,7 @@ function EnriquecimentoPage() {
   };
 
   const handleRowClick = (produto) => {
-    console.log("Produto clicado:", produto);
+    logger.log("Produto clicado:", produto);
     // Tenta mostrar o log do enriquecimento web primeiro
     if (produto.log_enriquecimento_web && produto.log_enriquecimento_web.historico_mensagens && produto.log_enriquecimento_web.historico_mensagens.length > 0) {
       const logMessages = produto.log_enriquecimento_web.historico_mensagens.join("\n");

--- a/Frontend/app/src/pages/HistoricoPage.jsx
+++ b/Frontend/app/src/pages/HistoricoPage.jsx
@@ -8,6 +8,7 @@ import { showSuccessToast, showErrorToast, showInfoToast } from '../utils/notifi
 import PaginationControls from '../components/common/PaginationControls';
 import { format, parseISO } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
+import logger from '../utils/logger';
 
 function HistoricoPage() {
   const { user, isLoading: isAuthLoading } = useAuth();
@@ -23,12 +24,12 @@ function HistoricoPage() {
 
   const fetchHistorico = useCallback(async () => {
     if (isAuthLoading) {
-      console.log("HistoricoPage: Auth está carregando, aguardando...");
+      logger.log("HistoricoPage: Auth está carregando, aguardando...");
       return;
     }
 
     if (!user) {
-      console.log("HistoricoPage: Usuário não autenticado, não buscando histórico.");
+      logger.log("HistoricoPage: Usuário não autenticado, não buscando histórico.");
       setHistorico([]);
       setTotalHistoricoCount(0);
       setLoading(false);

--- a/Frontend/app/src/pages/LoginPage.jsx
+++ b/Frontend/app/src/pages/LoginPage.jsx
@@ -3,6 +3,7 @@ import { useNavigate, useLocation, Link } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { toast } from 'react-toastify';
 import './LoginPage.css'; // Mantenha seu CSS
+import logger from '../utils/logger';
 
 const LoginPage = () => {
     const [email, setEmail] = useState('');
@@ -16,7 +17,7 @@ const LoginPage = () => {
     // Redireciona se já estiver autenticado
     useEffect(() => {
         if (isAuthenticated && !authIsLoading) {
-            console.log("LoginPage: Usuário já autenticado, redirecionando...");
+            logger.log("LoginPage: Usuário já autenticado, redirecionando...");
             const from = location.state?.from?.pathname || '/dashboard'; // Ou para a rota principal
             navigate(from, { replace: true });
         }

--- a/Frontend/app/src/services/apiClient.js
+++ b/Frontend/app/src/services/apiClient.js
@@ -1,5 +1,6 @@
 // Frontend/app/src/services/apiClient.js
 import axios from 'axios';
+import logger from '../utils/logger';
 
 const API_BASE_URL = '/api/v1'; // Conforme configuração com proxy do Vite
 
@@ -15,14 +16,14 @@ apiClient.interceptors.request.use(
     const token = localStorage.getItem('accessToken');
     const tokenSnippet = token ? `${token.substring(0, 15)}...${token.substring(token.length - 15)}` : "N/A";
 
-    console.log(`apiClient: Interceptando requisição para ${config.url}. Token no localStorage (snippet): ${tokenSnippet}`);
+    logger.log(`apiClient: Interceptando requisição para ${config.url}. Token no localStorage (snippet): ${tokenSnippet}`);
 
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
       // LOG DETALHADO DO HEADER (PARA DEBUG - REMOVER DEPOIS)
-      console.log(`apiClient: Header Authorization DEFINIDO para ${config.url}: "${config.headers.Authorization.substring(0,30)}..."`);
+      logger.log(`apiClient: Header Authorization DEFINIDO para ${config.url}: "${config.headers.Authorization.substring(0,30)}..."`);
     } else {
-      console.log(`apiClient: Nenhum token encontrado no localStorage para ${config.url}.`);
+      logger.log(`apiClient: Nenhum token encontrado no localStorage para ${config.url}.`);
       // Garantir que o header de autorização seja removido se não houver token
       delete config.headers.Authorization;
     }
@@ -38,7 +39,7 @@ apiClient.interceptors.response.use(
   response => response,
   error => {
     // Log mais detalhado do erro, incluindo a config da requisição que falhou
-    console.log(
+    logger.log(
         `apiClient: Interceptor de resposta pegou um erro. URL: ${error.config?.url}`,
         `Status: ${error.response?.status}`,
         `Data: ${JSON.stringify(error.response?.data)}`,

--- a/Frontend/app/src/services/authService.js
+++ b/Frontend/app/src/services/authService.js
@@ -1,6 +1,7 @@
 // Frontend/app/src/services/authService.js
 import apiClient from './apiClient';
 import { showSuccessToast, showErrorToast } from '../utils/notifications'; // Assumindo que você quer usar toasts aqui também
+import logger from '../utils/logger';
 
 const authService = {
   async login(email, password) {
@@ -14,7 +15,7 @@ const authService = {
           'Content-Type': 'application/x-www-form-urlencoded',
         },
       });
-      console.log("authService: Login response data:", response.data);
+      logger.log("authService: Login response data:", response.data);
       // O token é salvo no AuthContext após esta chamada ser bem-sucedida
       return response.data;
     } catch (error) {
@@ -25,11 +26,11 @@ const authService = {
   },
 
   async getCurrentUser() {
-    console.log("authService: Tentando buscar getCurrentUser...");
+    logger.log("authService: Tentando buscar getCurrentUser...");
     try {
       // CORREÇÃO: Remover a barra final para corresponder à definição do endpoint FastAPI
       const response = await apiClient.get('/auth/users/me'); // ANTES: '/auth/users/me/'
-      console.log("authService: getCurrentUser response data:", response.data);
+      logger.log("authService: getCurrentUser response data:", response.data);
       return response.data;
     } catch (error) {
       console.error('Error fetching current user (authService):', error.response?.data || error.message);

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -1,5 +1,6 @@
 // Frontend/app/src/services/fornecedorService.js
 import axios from 'axios';
+import logger from '../utils/logger';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/v1';
 
@@ -23,8 +24,8 @@ apiClient.interceptors.request.use(config => {
 export const getFornecedores = async (params = {}) => { // params pode incluir skip, limit, termo_busca
   try {
     // O backend agora deve retornar { items: [], total_items: X, limit: Y, skip: Z }
-    const response = await apiClient.get('/fornecedores/', { params }); 
-    console.log('API Response in fornecedorService (getFornecedores):', response.data); // Para depuração
+    const response = await apiClient.get('/fornecedores/', { params });
+    logger.log('API Response in fornecedorService (getFornecedores):', response.data); // Para depuração
     return response.data; // Retorna o objeto completo
   } catch (error) {
     console.error('Error fetching fornecedores (SERVICE LEVEL):', JSON.stringify(error.response?.data || error.message || error));

--- a/Frontend/app/src/services/productService.js
+++ b/Frontend/app/src/services/productService.js
@@ -1,5 +1,6 @@
 // Frontend/app/src/services/productService.js
 import axios from 'axios';
+import logger from '../utils/logger';
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/v1';
 
@@ -24,7 +25,7 @@ export const getProdutos = async (params = {}) => {
   try {
     // ADICIONADA BARRA FINAL AQUI
     const response = await apiClient.get('/produtos/', { params });
-    console.log('API Response in productService (getProdutos):', response.data);
+    logger.log('API Response in productService (getProdutos):', response.data);
     return response.data;
   } catch (error) {
     console.error('Error fetching produtos:', error.response?.data || error.message);
@@ -36,7 +37,7 @@ export const getProdutoById = async (produtoId) => {
   try {
     // ADICIONADA BARRA FINAL AQUI
     const response = await apiClient.get(`/produtos/${produtoId}/`);
-    console.log('API Response in productService (getProdutoById):', response.data);
+    logger.log('API Response in productService (getProdutoById):', response.data);
     return response.data;
   } catch (error) {
     console.error(`Error fetching produto ${produtoId}:`, error.response?.data || error.message);

--- a/Frontend/app/src/utils/logger.js
+++ b/Frontend/app/src/utils/logger.js
@@ -1,0 +1,21 @@
+const isDev = import.meta.env.DEV;
+
+const logger = {
+  log: (...args) => {
+    if (isDev) {
+      console.log(...args);
+    }
+  },
+  warn: (...args) => {
+    if (isDev) {
+      console.warn(...args);
+    }
+  },
+  error: (...args) => {
+    if (isDev) {
+      console.error(...args);
+    }
+  }
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- add `logger` helper that prints only in development
- replace `console.log` calls across React components and services with `logger.log`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684369df6918832f821ac4292ab7207a