### PR TITLE
Add test skeleton with pytest

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+fastapi
+uvicorn
+sqlalchemy
+pydantic
+pydantic-settings
+python-dotenv
+passlib[bcrypt]
+python-jose[cryptography]
+authlib
+pytest

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,39 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from Backend.database import Base
+import Backend.crud as crud
+import Backend.schemas as schemas
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+@pytest.fixture()
+def db_session():
+    engine = create_engine(
+        SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+    )
+    TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+
+    # Create default role and plan needed for user creation
+    crud.create_role(db, schemas.RoleCreate(name="user", description="User role"))
+    crud.create_plano(
+        db,
+        schemas.PlanoCreate(
+            nome="Gratuito",
+            descricao="Plano básico gratuito",
+            preco_mensal=0.0,
+            limite_produtos=50,
+            limite_enriquecimento_web=10,
+            limite_geracao_ia=20,
+            permite_api_externa=False,
+            suporte_prioritario=False,
+        ),
+    )
+
+    yield db
+
+    db.close()
+    Base.metadata.drop_all(bind=engine)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,0 +1,7 @@
+import asyncio
+from Backend.main import health_check
+
+
+def test_health_check():
+    result = asyncio.run(health_check())
+    assert result == {"status": "ok"}

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,13 @@
+from Backend.main import create_new_user
+import Backend.schemas as schemas
+
+
+def test_user_registration(db_session):
+    user_in = schemas.UserCreate(
+        email="test@example.com",
+        password="secret",
+        nome_completo="Test User",
+    )
+    new_user = create_new_user(user_in=user_in, db=db_session)
+    assert new_user.email == user_in.email
+    assert new_user.id is not None


### PR DESCRIPTION
## Summary
- add `requirements.txt` with pytest and backend dependencies
- set up basic pytest fixtures using SQLite
- add simple health check and user registration tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684369e09610832fa68c9bfc7286572b