### PR TITLE
Fix SQLAlchemy notin_ use

### DIFF
--- a/Backend/crud.py
+++ b/Backend/crud.py
@@ -866,7 +866,7 @@ def get_geracoes_ia_count_no_mes_corrente(db: Session, user_id: Optional[int] = 
     
     query = db.query(func.count(RegistroUsoIA.id)).filter(
         RegistroUsoIA.created_at >= start_of_month,  # CORRIGIDO de .timestamp
-        RegistroUsoIA.tipo_acao.not_in([TipoAcaoIAEnum.ENRIQUECIMENTO_WEB_PRODUTO]) # Exclui enriquecimento
+        RegistroUsoIA.tipo_acao.notin_([TipoAcaoIAEnum.ENRIQUECIMENTO_WEB_PRODUTO]) # Exclui enriquecimento
     )
     if user_id:
         query = query.filter(RegistroUsoIA.user_id == user_id)


### PR DESCRIPTION
## Summary
- use SQLAlchemy `notin_` filter in CRUD operations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68437410b500832f880852186e2eae73