### PR TITLE
Fix openai call in extractor

### DIFF
--- a/Backend/services/web_data_extractor_service.py
+++ b/Backend/services/web_data_extractor_service.py
@@ -225,8 +225,8 @@ async def extrair_dados_produto_com_llm(
         return {"erro_llm": "Chave API OpenAI não configurada"}
 
     try:
-        # A função _call_openai_api está em ia_generation_service
-        json_str_resposta = await ia_generation_service._call_openai_api( 
+        # A função call_openai_api está em ia_generation_service
+        json_str_resposta = await ia_generation_service.call_openai_api(
             prompt=prompt,
             api_key=api_key_para_usar,
             model="gpt-3.5-turbo-0125", # Exemplo de modelo, pode ser configurável


### PR DESCRIPTION
## Summary
- use the public `call_openai_api` helper instead of the private function in `web_data_extractor_service`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6843741370b4832fa08b0f70d6807d6b