### PR TITLE
Add log enrichment field

### DIFF
--- a/Backend/alembic/versions/7b4809b4d9af_add_log_enriquecimento_web.py
+++ b/Backend/alembic/versions/7b4809b4d9af_add_log_enriquecimento_web.py
@@ -1,0 +1,24 @@
+"""add log_enriquecimento_web column to Produto
+
+Revision ID: 7b4809b4d9af
+Revises: 522dce3cd6aa
+Create Date: 2025-06-07 15:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '7b4809b4d9af'
+down_revision: Union[str, None] = '522dce3cd6aa'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('produtos', sa.Column('log_enriquecimento_web', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('produtos', 'log_enriquecimento_web')

--- a/Backend/crud.py
+++ b/Backend/crud.py
@@ -601,12 +601,18 @@ def create_produto(db: Session, produto: schemas.ProdutoCreate, user_id: int) ->
             produto_data['dynamic_attributes'] = json.loads(produto_data['dynamic_attributes'])
         except json.JSONDecodeError:
             raise ValueError("dynamic_attributes não é um JSON string válido.")
-            
-    if 'dados_brutos' in produto_data and isinstance(produto_data['dados_brutos'], str):
+
+    if 'dados_brutos_web' in produto_data and isinstance(produto_data['dados_brutos_web'], str):
         try:
-            produto_data['dados_brutos'] = json.loads(produto_data['dados_brutos'])
+            produto_data['dados_brutos_web'] = json.loads(produto_data['dados_brutos_web'])
         except json.JSONDecodeError:
-            raise ValueError("dados_brutos não é um JSON string válido.")
+            raise ValueError("dados_brutos_web não é um JSON string válido.")
+
+    if 'log_enriquecimento_web' in produto_data and isinstance(produto_data['log_enriquecimento_web'], str):
+        try:
+            produto_data['log_enriquecimento_web'] = json.loads(produto_data['log_enriquecimento_web'])
+        except json.JSONDecodeError:
+            raise ValueError("log_enriquecimento_web não é um JSON string válido.")
 
     # Se imagens_secundarias_urls for uma string JSON, converter para lista
     # (Pydantic List[HttpUrl] deve tratar isso na entrada se o cliente enviar JSON string,
@@ -758,10 +764,10 @@ def count_produtos_by_user(
 def update_produto(db: Session, db_produto: Produto, produto_update: schemas.ProdutoUpdate) -> Produto:
     update_data = produto_update.model_dump(exclude_unset=True)
 
-    # Lógica para campos JSON (dynamic_attributes, dados_brutos, imagens_secundarias_urls)
+    # Lógica para campos JSON (dynamic_attributes, dados_brutos_web, log_enriquecimento_web, imagens_secundarias_urls)
     # Pydantic deve entregar dict/list se o schema estiver correto (não Json[Type])
     # O modelo SQLAlchemy aceita dict/list para colunas JSON.
-    for field in ['dynamic_attributes', 'dados_brutos', 'imagens_secundarias_urls']:
+    for field in ['dynamic_attributes', 'dados_brutos_web', 'log_enriquecimento_web', 'imagens_secundarias_urls']:
         if field in update_data and update_data[field] is not None:
             # Se o schema já garante o tipo correto (dict/list), apenas atribua
             # Se o schema ainda for Json[Type] e vier uma string, precisa de json.loads aqui

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -258,6 +258,10 @@ class Produto(Base):
     dados_brutos_web = Column(MutableDict.as_mutable(JSON), nullable=True, comment="JSON com dados extraídos da web (textos, metadados)")
     dynamic_attributes = Column(MutableDict.as_mutable(JSON), nullable=True, comment="Atributos dinâmicos preenchidos baseados no ProductType (JSON)")
 
+    # Histórico de mensagens do processo de enriquecimento web/IA.
+    # Estrutura flexível armazenada como JSON (lista ou dict).
+    log_enriquecimento_web = Column(JSON, nullable=True, comment="Log de enriquecimento web do produto")
+
     # Log de Processamento (simplificado, pode ser uma tabela separada para logs detalhados)
     log_processamento = Column(MutableList.as_mutable(JSON), nullable=True, comment="Lista de mensagens/eventos de log para este produto")
     # Ex: [{"timestamp": "2023-10-26T10:00:00Z", "actor": "system/user_X", "action": "Enriquecimento Web Concluído", "details": "..."}]

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -287,6 +287,10 @@ class ProdutoBase(BaseModel):
     dados_brutos_web: Optional[Dict[str, Any]] = Field(None, description="JSON com dados extraídos da web (textos, metadados).")
     dynamic_attributes: Optional[Dict[str, Any]] = Field(None, description="Atributos dinâmicos baseados no ProductType (JSON).")
 
+    # Log de enriquecimento web; estrutura flexível (lista ou dict) mantida como JSON.
+    log_enriquecimento_web: Optional[Any] = Field(
+        None, description="Log do processo de enriquecimento web.")
+
     log_processamento: Optional[List[Dict[str, Any]]] = Field(None, description="Log de eventos de processamento do produto.")
 
 
@@ -303,6 +307,7 @@ class ProdutoResponse(ProdutoBase):
     updated_at: datetime
     fornecedor: Optional[FornecedorResponse] = None
     product_type: Optional[ProductTypeResponse] = None
+    log_enriquecimento_web: Optional[Any] = None
     
     class Config:
         from_attributes = True


### PR DESCRIPTION
## Summary
- add `log_enriquecimento_web` column to `Produto`
- expose new log field in schemas
- handle JSON conversion in CRUD
- generate alembic migration for new column

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68437415ec2c832f993d406c1eeac3de