### PR TITLE
Add REFRESH_SECRET_KEY configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,38 @@
+# Banco de Dados
+DATABASE_URL="postgresql://usuario:senha@localhost:5432/tdai_db"
+
+# Segurança
+SECRET_KEY="sua_chave_forte"
+REFRESH_SECRET_KEY="sua_chave_refresh_forte"
+ALGORITHM="HS256"
+ACCESS_TOKEN_EXPIRE_MINUTES=60
+
+# OpenAI
+OPENAI_API_KEY="sk-..."
+# Google Gemini API
+GOOGLE_GEMINI_API_KEY="..."
+
+# Google Search API
+GOOGLE_CSE_ID="..."
+GOOGLE_CSE_API_KEY="..."
+
+# SMTP/Email
+SMTP_SERVER="smtp.seuprovedor.com"
+SMTP_PORT=587
+SMTP_USER="seu@email.com"
+SMTP_PASSWORD="senha"
+EMAIL_FROM="TDAI Platform <nao-responda@tdai.com>"
+
+# Frontend
+FRONTEND_URL="http://localhost:5173"
+
+# OAuth2 (Google/Facebook)
+GOOGLE_CLIENT_ID="..."
+GOOGLE_CLIENT_SECRET="..."
+FACEBOOK_CLIENT_ID="..."
+FACEBOOK_CLIENT_SECRET="..."
+
+# Admin padrão
+ADMIN_EMAIL="admin@email.com"
+ADMIN_PASSWORD="adminpassword"
+

--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -26,6 +26,10 @@ class Settings(BaseSettings):
     SQLITE_DB_FILE: str = os.getenv("SQLITE_DB_FILE", "tdai_app.db")
 
     SECRET_KEY: str = os.getenv("SECRET_KEY", "super-secret-key-deve-ser-alterada-imediatamente")
+    REFRESH_SECRET_KEY: str = os.getenv(
+        "REFRESH_SECRET_KEY",
+        "super-refresh-secret-key-deve-ser-alterada-imediatamente",
+    )
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 60 * 24 * 1)) # Default 1 dia
     REFRESH_TOKEN_EXPIRE_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", 7))

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ DATABASE_URL="postgresql://usuario:senha@localhost:5432/tdai_db"
 
 # Segurança
 SECRET_KEY="sua_chave_forte"
+REFRESH_SECRET_KEY="sua_chave_refresh_forte"
 ALGORITHM="HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 

--- a/README.txt
+++ b/README.txt
@@ -143,6 +143,7 @@ Snippet de código
 # Backend/core/config.py espera estas variáveis
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DB_NAME" # Ex: postgresql://postgres:password@localhost:5432/tdai_db
 SECRET_KEY="sua_chave_secreta_super_forte_aqui" # Importante para JWT
+REFRESH_SECRET_KEY="sua_chave_refresh_super_forte_aqui"
 ALGORITHM="HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES=60
 


### PR DESCRIPTION
## Summary
- load `REFRESH_SECRET_KEY` from environment in backend settings
- add `.env.example` file with sample variables
- document `REFRESH_SECRET_KEY` in README and README.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68437419a2e4832f91ea1c516f53a87b