### PR TITLE
Fix ProductType index condition

### DIFF
--- a/Backend/models.py
+++ b/Backend/models.py
@@ -170,7 +170,7 @@ class ProductType(Base):
 
     __table_args__ = (
         UniqueConstraint('user_id', 'key_name', name='_user_key_name_uc'),
-        Index('ix_product_types_global_key_name_unique', 'key_name', unique=True, postgresql_where=(Column('user_id') == None)),
+        Index('ix_product_types_global_key_name_unique', 'key_name', unique=True, postgresql_where=(user_id.is_(None))),
         Index('ix_product_types_user_id_key_name', 'user_id', 'key_name'),
     )
 


### PR DESCRIPTION
## Summary
- fix ProductType partial index to use column object

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68437429ae48832f842fd65a2892af10