### PR TITLE
Fix IA usage router

### DIFF
--- a/Backend/routers/uso_ia.py
+++ b/Backend/routers/uso_ia.py
@@ -17,9 +17,9 @@ router = APIRouter(
 )
 
 # Endpoint para registrar um novo uso de IA
-@router.post("/", response_model=schemas.RegistroUsoIAResponse, status_code=status.HTTP_201_CREATED) # CORRIGIDO AQUI
-def create_uso_ia_endpoint( 
-    uso_ia_data: schemas.RegistroUsoIACreate, 
+@router.post("/", response_model=schemas.RegistroUsoIAResponse, status_code=status.HTTP_201_CREATED)  # CORRIGIDO AQUI
+def create_uso_ia_endpoint(
+    uso_ia_data: schemas.RegistroUsoIACreate,
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user),
 ):
@@ -28,7 +28,8 @@ def create_uso_ia_endpoint(
     """
     try:
         # A função no CRUD foi nomeada como create_registro_uso_ia
-        return crud.create_registro_uso_ia(db=db, uso_ia=uso_ia_data, user_id=current_user.id) 
+        uso_ia_data.user_id = current_user.id
+        return crud.create_registro_uso_ia(db=db, registro_uso=uso_ia_data)
     except HTTPException as e:
         raise e
     except Exception as e:
@@ -36,7 +37,7 @@ def create_uso_ia_endpoint(
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Erro interno ao registrar uso de IA.")
 
 # Endpoint para listar os registros de uso de IA para o usuário logado
-@router.get("/", response_model=schemas.RegistroUsoIABase) 
+@router.get("/", response_model=schemas.UsoIAPage)
 def read_usos_ia_usuario_logado(
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user),


### PR DESCRIPTION
## Summary
- set `user_id` directly in `create_uso_ia_endpoint`
- return `UsoIAPage` model for listing records

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68437676f968832fa8f7898f7402cb86