### PR TITLE
Extend enrichment status enum

### DIFF
--- a/Backend/alembic/versions/5c0e48ff0b75_extend_status_enrichment_enum.py
+++ b/Backend/alembic/versions/5c0e48ff0b75_extend_status_enrichment_enum.py
@@ -1,0 +1,35 @@
+"""extend StatusEnriquecimentoEnum with additional values
+
+Revision ID: 5c0e48ff0b75
+Revises: 7b4809b4d9af
+Create Date: 2025-06-08 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '5c0e48ff0b75'
+down_revision: Union[str, None] = '7b4809b4d9af'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    status_enum_name = 'statusenriquecimentoenum'
+    new_values = [
+        'CONCLUIDO_SUCESSO',
+        'CONCLUIDO_COM_DADOS_PARCIAIS',
+        'FALHOU',
+        'FALHA_API_EXTERNA',
+        'FALHA_CONFIGURACAO_API_EXTERNA',
+        'NENHUMA_FONTE_ENCONTRADA'
+    ]
+    conn = op.get_bind()
+    for value in new_values:
+        conn.execute(sa.text(f"ALTER TYPE {status_enum_name} ADD VALUE IF NOT EXISTS '{value}'"))
+
+
+def downgrade() -> None:
+    # Enum value removal is not supported in a simple way.
+    pass

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -13,8 +13,14 @@ class StatusEnriquecimentoEnum(str, enum.Enum):
     NAO_INICIADO = "NAO_INICIADO"
     PENDENTE = "PENDENTE" # Adicionado, se necessário para indicar que está na fila
     EM_PROGRESSO = "EM_PROGRESSO"
+    CONCLUIDO_SUCESSO = "CONCLUIDO_SUCESSO"
+    CONCLUIDO_COM_DADOS_PARCIAIS = "CONCLUIDO_COM_DADOS_PARCIAIS"
     CONCLUIDO = "CONCLUIDO"
+    FALHOU = "FALHOU"
+    FALHA_API_EXTERNA = "FALHA_API_EXTERNA"
+    FALHA_CONFIGURACAO_API_EXTERNA = "FALHA_CONFIGURACAO_API_EXTERNA"
     FALHA = "FALHA"
+    NENHUMA_FONTE_ENCONTRADA = "NENHUMA_FONTE_ENCONTRADA"
     NAO_APLICAVEL = "NAO_APLICAVEL" # Para produtos onde enriquecimento web não se aplica
 
 class StatusGeracaoIAEnum(str, enum.Enum):


### PR DESCRIPTION
## Summary
- add additional statuses to `StatusEnriquecimentoEnum`
- create Alembic migration to update enum values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `alembic revision --autogenerate -m "extend status enum"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437677f130832fa9ca98ffe3b26f89