### PR TITLE
Update ProductType index condition

### DIFF
--- a/Backend/alembic/versions/bdaeb62ae8de_update_product_type_index.py
+++ b/Backend/alembic/versions/bdaeb62ae8de_update_product_type_index.py
@@ -1,0 +1,40 @@
+"""update product type index condition
+
+Revision ID: bdaeb62ae8de
+Revises: 7b4809b4d9af
+Create Date: 2025-06-08 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'bdaeb62ae8de'
+down_revision: Union[str, None] = '7b4809b4d9af'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index('ix_product_types_global_key_name_unique', table_name='product_types')
+    op.create_index(
+        'ix_product_types_global_key_name_unique',
+        'product_types',
+        ['key_name'],
+        unique=True,
+        postgresql_where=sa.text('user_id IS NULL')
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_product_types_global_key_name_unique', table_name='product_types')
+    op.create_index(
+        'ix_product_types_global_key_name_unique',
+        'product_types',
+        ['key_name'],
+        unique=True,
+        postgresql_where=sa.text('user_id IS NULL')
+    )
+

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -170,7 +170,12 @@ class ProductType(Base):
 
     __table_args__ = (
         UniqueConstraint('user_id', 'key_name', name='_user_key_name_uc'),
-        Index('ix_product_types_global_key_name_unique', 'key_name', unique=True, postgresql_where=(user_id.is_(None))),
+        Index(
+            'ix_product_types_global_key_name_unique',
+            'key_name',
+            unique=True,
+            postgresql_where=lambda: ProductType.user_id.is_(None)
+        ),
         Index('ix_product_types_user_id_key_name', 'user_id', 'key_name'),
     )
 


### PR DESCRIPTION
## Summary
- use `ProductType.user_id` in the partial index definition
- add migration regenerating the product type index

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6843767c8584832fbf49676904133833