### PR TITLE
Fix parameters for OAuth user creation

### DIFF
--- a/Backend/auth.py
+++ b/Backend/auth.py
@@ -285,8 +285,8 @@ async def _get_or_create_social_user(
         
         created_user = crud.create_user_oauth(
             db=db,
-            user_data=user_in_create,
-            plano_id=default_plano.id if default_plano else None,
+            user_oauth=user_in_create,
+            plano_id_default=default_plano.id if default_plano else None,
         )
         logger.info("Novo usuário criado via %s: %s", provider, email)
         return created_user


### PR DESCRIPTION
## Summary
- update `crud.create_user_oauth` call to use latest parameter names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68437c4d22dc832f98d93157c6236619