### PR TITLE
Remove leftover markers and unify logging

### DIFF
--- a/Backend/auth.py
+++ b/Backend/auth.py
@@ -7,16 +7,14 @@ from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm # P
 
 from jose import JWTError, jwt
 # passlib.context.CryptContext é importado de core.config como pwd_context
-from authlib.integrations.starlette_client import OAuth, OAuthError # type: ignore
-from starlette.config import Config as AuthlibConfig 
+from authlib.integrations.starlette_client import OAuth, OAuthError  # type: ignore
+from starlette.config import Config as AuthlibConfig
 from sqlalchemy.orm import Session
 
-refatorar-print-para-logging
 from core.config import settings, pwd_context
 from core.logging_config import get_logger
 
 logger = get_logger(__name__)
-from core.config import settings, pwd_context, logger
 
 import schemas 
 import models 
@@ -294,31 +292,20 @@ async def _get_or_create_social_user(
 async def process_google_login(db: Session, google_userinfo: Dict[str, Any]) -> Optional[models.User]:
     email = google_userinfo.get('email')
     if not email:
-        refatorar-print-para-logging
         logger.error("Email do Google não encontrado nas informações do usuário.")
         return None
     if not google_userinfo.get('email_verified', False):
         logger.warning("Email %s do Google não está verificado.", email)
 
-        logger.warning("Email do Google não encontrado nas informações do usuário.")
-        return None
-    if not google_userinfo.get('email_verified', False):
-        logger.info("Email %s do Google não está verificado.", email)
-
-    
     nome_completo = google_userinfo.get('name')
     if not nome_completo:
         primeiro_nome = google_userinfo.get('given_name', '')
         ultimo_nome = google_userinfo.get('family_name', '')
         nome_completo = f"{primeiro_nome} {ultimo_nome}".strip()
     
-    google_user_id = google_userinfo.get('sub') 
+    google_user_id = google_userinfo.get('sub')
     if not google_user_id:
-        refatorar-print-para-logging
         logger.error("ID de usuário do Google (sub) não encontrado.")
-
-        logger.warning("ID de usuário do Google (sub) não encontrado.")
-
         return None
 
     return await _get_or_create_social_user(db, email, nome_completo, "Google", google_user_id)
@@ -326,21 +313,18 @@ async def process_google_login(db: Session, google_userinfo: Dict[str, Any]) -> 
 async def process_facebook_login(db: Session, facebook_userinfo: Dict[str, Any]) -> Optional[models.User]:
     email = facebook_userinfo.get('email')
     if not email:
-        refatorar-print-para-logging
         logger.error(
             "Email do Facebook não fornecido. Não é possível prosseguir com login/registro baseado em email."
         )
-        logger.warning("Email do Facebook não fornecido. Não é possível prosseguir com login/registro baseado em email.")
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Email não fornecido pelo Facebook. Verifique suas permissões.")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Email não fornecido pelo Facebook. Verifique suas permissões.",
+        )
         
     nome_completo = facebook_userinfo.get('name', '')
     facebook_user_id = facebook_userinfo.get('id')
     if not facebook_user_id:
-        refatorar-print-para-logging
         logger.error("ID de usuário do Facebook não encontrado.")
-
-        logger.warning("ID de usuário do Facebook não encontrado.")
-
         return None
 
     return await _get_or_create_social_user(db, email, nome_completo, "Facebook", facebook_user_id)

--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -1,6 +1,5 @@
 # Backend/core/config.py
 import os
-import logging
 from dotenv import load_dotenv
 from typing import List, Union, Optional
 from pydantic_settings import BaseSettings
@@ -10,9 +9,6 @@ from .logging_config import get_logger
 
 logger = get_logger(__name__)
 
-logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("tdai")
-
 dotenv_path = Path(__file__).resolve().parent.parent.parent / ".env"
 if dotenv_path.exists():
     load_dotenv(dotenv_path=dotenv_path)
@@ -21,7 +17,6 @@ else:
         "Arquivo .env não encontrado em %s. Usando valores padrão ou variáveis de ambiente do sistema.",
         dotenv_path,
     )
-    refatorar-print-para-logging
 
 
 def env_var_name_with_prefix(field_name: str) -> str:
@@ -107,9 +102,6 @@ if settings.DATABASE_URL is None:
     backend_dir = Path(__file__).resolve().parent.parent
     sqlite_file_path = backend_dir / settings.SQLITE_DB_FILE
     settings.DATABASE_URL = f"sqlite:///{sqlite_file_path.resolve()}"
-    refatorar-print-para-logging
-    logger.info("DATABASE_URL não encontrada no .env. Usando SQLite em: %s", settings.DATABASE_URL)
-
     logger.info(
         "DATABASE_URL não encontrada no .env. Usando SQLite em: %s",
         settings.DATABASE_URL,
@@ -126,11 +118,6 @@ if settings._cors_origins_str:
             try:
                 valid_origins.append(AnyHttpUrl(origin_str))
             except ValidationError:
-                refatorar-print-para-logging
-                logger.warning("Origem CORS inválida '%s' em BACKEND_CORS_ORIGINS. Será ignorada.", origin_str)
-        settings.BACKEND_CORS_ORIGINS = valid_origins
-    except Exception as e:
-        logger.error("Erro ao processar BACKEND_CORS_ORIGINS do .env: %s. Usando fallback.", e)
                 logger.warning(
                     "Origem CORS inválida '%s' em BACKEND_CORS_ORIGINS. Será ignorada.",
                     origin_str,
@@ -138,7 +125,7 @@ if settings._cors_origins_str:
         settings.BACKEND_CORS_ORIGINS = valid_origins
     except Exception as e:
         logger.error(
-            "ERRO ao processar BACKEND_CORS_ORIGINS do .env: %s. Usando fallback.",
+            "Erro ao processar BACKEND_CORS_ORIGINS do .env: %s. Usando fallback.",
             e,
         )
         settings.BACKEND_CORS_ORIGINS = []
@@ -151,22 +138,14 @@ if not settings.BACKEND_CORS_ORIGINS:
         "http://localhost",
     ]
     for origin_url in default_list:
-        try: default_origins_httpurl.append(AnyHttpUrl(origin_url))
-        except ValidationError: pass
+        try:
+            default_origins_httpurl.append(AnyHttpUrl(origin_url))
+        except ValidationError:
+            pass
     settings.BACKEND_CORS_ORIGINS = default_origins_httpurl
-    refatorar-print-para-logging
     logger.info("Usando CORS origins padrão: %s", [str(o) for o in settings.BACKEND_CORS_ORIGINS])
 else:
     logger.info("Usando CORS origins de settings: %s", [str(o) for o in settings.BACKEND_CORS_ORIGINS])
-    logger.info(
-        "Usando CORS origins padrão: %s",
-        [str(o) for o in settings.BACKEND_CORS_ORIGINS],
-    )
-else:
-    logger.info(
-        "Usando CORS origins de settings: %s",
-        [str(o) for o in settings.BACKEND_CORS_ORIGINS],
-    )
 
 from passlib.context import CryptContext
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")

--- a/Backend/core/email_utils.py
+++ b/Backend/core/email_utils.py
@@ -4,12 +4,10 @@ from pydantic import EmailStr
 from typing import List, Dict, Any, Optional # Adicionado Optional
 from pathlib import Path
 
-refatorar-print-para-logging
-logger = get_logger(__name__)
-
-from .config import settings # Importa as configurações (settings)
 from .logging_config import get_logger
-from .config import settings, logger  # Importa as configurações (settings) e logger
+from .config import settings
+
+logger = get_logger(__name__)
 
 # Removido import desnecessário de auth que estava no arquivo do usuário
 # import auth # Cuidado com import circular se auth importar email_utils
@@ -91,9 +89,6 @@ async def send_email(
             logger.error("Falha ao enviar email HTML para %s. Erro: %s", email_to, e)
             pass
     else:
-        refatorar-print-para-logging
-        logger.warning("Tentativa de enviar email para %s sem template_name ou html_content.", email_to)
-
         logger.warning(
             "Tentativa de enviar email para %s sem template_name ou html_content.",
             email_to,
@@ -178,14 +173,6 @@ async def send_new_account_email(email_to: EmailStr, username: str, login_link: 
         await fm.send_message(message, template_name=template_name)
         logger.info("Email de boas-vindas enviado para %s", email_to)
     except Exception as e:
-        refatorar-print-para-logging
         logger.error("Falha ao enviar email de boas-vindas para %s. Erro: %s", email_to, e)
         raise RuntimeError(f"Falha ao enviar email de boas-vindas: {e}")
-
-        codex/refatorar-módulos-para-usar-logging
-        logger.error("Falha ao enviar email de boas-vindas para %s. Erro: %s", email_to, e)
-
-        print(f"ERRO: Falha ao enviar email de boas-vindas para {email_to}. Erro: {e}")
-        Dev
-         raise RuntimeError(f"Falha ao enviar email de boas-vindas: {e}")
 

--- a/Backend/routers/password_recovery.py
+++ b/Backend/routers/password_recovery.py
@@ -6,16 +6,12 @@ from fastapi import APIRouter, Depends, HTTPException, Request, status, Body # A
 from sqlalchemy.orm import Session
 
 import crud
-import schemas # schemas é importado
-import models # models é importado
-from database import get_db # Corrigido para get_db
-refatorar-print-para-logging
-from core.config import settings # Para FRONTEND_URL
-from core.email_utils import send_password_reset_email # Importa a função de envio de email
+import schemas
+import models
+from database import get_db
 from core.logging_config import get_logger
-
-from core.config import settings, logger  # Para FRONTEND_URL e logging
-from core.email_utils import send_password_reset_email  # Importa a função de envio de email
+from core.config import settings
+from core.email_utils import send_password_reset_email
 
 router = APIRouter(
     prefix="/api/v1/auth", # Mantendo o prefixo como no arquivo original, se for este
@@ -39,8 +35,6 @@ async def recover_password(email: str, request: Request, db: Session = Depends(g
         # detail="O email fornecido não foi encontrado em nosso sistema.",
         # )
         # No entanto, para evitar enumeração de usuários, retornamos sucesso mesmo se não encontrado.
-        refatorar-print-para-logging
-        logger.info("Solicitação de recuperação de senha para email não registrado: %s", email)
         logger.info(
             "Solicitação de recuperação de senha para email não registrado: %s",
             email,
@@ -68,9 +62,6 @@ async def recover_password(email: str, request: Request, db: Session = Depends(g
         return {"msg": "Email de recuperação de senha enviado com sucesso."}
     except Exception as e:
         # Logar o erro 'e' aqui seria importante
-        refatorar-print-para-logging
-        logger.error("Falha ao enviar email de recuperação de senha para %s: %s", user.email, e)
-
         logger.error(
             "Falha ao enviar email de recuperação de senha para %s: %s",
             user.email,

--- a/Backend/routers/product_types.py
+++ b/Backend/routers/product_types.py
@@ -9,12 +9,9 @@ import models
 import schemas
 import database
 from . import auth_utils
-refatorar-print-para-logging
 from core.logging_config import get_logger
 
 logger = get_logger(__name__)
-
-from core.config import logger
 
 router = APIRouter(
     prefix="/product-types", 
@@ -29,9 +26,7 @@ def create_product_type_endpoint(
     current_user: models.User = Depends(auth_utils.get_current_active_user)
 ):
     user_id_for_type = None if current_user.is_superuser else current_user.id
-    
-refatorar-print-para-logging
-    logger.info(
+
     logger.debug(
         "ROUTER (create_product_type): Verificando existência de key_name '%s' para user_id: %s",
         product_type_in.key_name,
@@ -46,9 +41,7 @@ refatorar-print-para-logging
 
     if existing_type:
         scope_msg = "globalmente" if existing_type.user_id is None else f"para o usuário ID {existing_type.user_id}"
-        refatorar-print-para-logging
         logger.warning(
-        logger.info(
             "ROUTER (create_product_type): Conflito! Tipo com key_name '%s' já existe %s.",
             product_type_in.key_name,
             scope_msg,
@@ -74,7 +67,6 @@ def read_product_types_endpoint(
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user)
 ):
-    logger.info()
     logger.debug(
         "ROUTER (read_product_types): Buscando tipos de produto para user_id: %s, skip: %s, limit: %s",
         current_user.id,
@@ -82,13 +74,9 @@ def read_product_types_endpoint(
         limit,
     )
     product_types = crud.get_product_types_for_user(db, skip=skip, limit=limit, user_id=current_user.id)
-    refatorar-print-para-logging
-    logger.info(
+    logger.debug(
         "ROUTER (read_product_types): Encontrados %s tipos de produto.",
         len(product_types),
-
-    logger.debug(
-        "ROUTER (read_product_types): Encontrados %s tipos de produto.", len(product_types)
     )
     return product_types
 
@@ -98,9 +86,7 @@ async def read_product_type_details_route(
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user)
 ):
-    identifier = type_id_or_key_path 
-    refatorar-print-para-logging
-    logger.info("ROUTER (read_product_type_details): Iniciando busca por '%s'", identifier)
+    identifier = type_id_or_key_path
     logger.debug(
         "ROUTER (read_product_type_details): Iniciando busca por '%s'",
         identifier,
@@ -109,55 +95,37 @@ async def read_product_type_details_route(
     
     try:
         numeric_id = int(identifier)
-        refatorar-print-para-logging
-        logger.info("ROUTER: Identificador '%s' é numérico. Tentando buscar por ID: %s", identifier, numeric_id)
-        db_product_type = crud.get_product_type(db, product_type_id=numeric_id)
-        if db_product_type:
-            logger.info(
-
         logger.debug(
             "ROUTER: Identificador '%s' é numérico. Tentando buscar por ID: %s",
             identifier,
             numeric_id,
         )
-        db_product_type = crud.get_product_type(db, product_type_id=numeric_id) 
+        db_product_type = crud.get_product_type(db, product_type_id=numeric_id)
         if db_product_type:
             logger.debug(
-
                 "ROUTER: Encontrado por ID: %s - %s",
                 db_product_type.id,
                 db_product_type.friendly_name,
             )
     except ValueError:
-        refatorar-print-para-logging
-        logger.info(
-            "ROUTER: Identificador '%s' não é puramente numérico. Será tratado como key_name.",
-            identifier,
-        )
-        pass
-
-    if not db_product_type: 
-        key_name_to_search = str(identifier)
-        logger.info(
         logger.debug(
             "ROUTER: Identificador '%s' não é puramente numérico. Será tratado como key_name.",
             identifier,
         )
-        pass 
 
-    if not db_product_type: 
-        key_name_to_search = str(identifier) 
+    if not db_product_type:
+        key_name_to_search = str(identifier)
+
+    if not db_product_type:
+        key_name_to_search = str(identifier)
         logger.debug(
             "ROUTER: Não encontrado por ID (ou não era ID numérico válido). Tentando buscar por key_name: '%s' para user_id: %s (específico)",
             key_name_to_search,
             current_user.id,
         )
         db_product_type = crud.get_product_type_by_key_name(db, key_name=key_name_to_search, user_id=current_user.id)
-        
-        if not db_product_type:
-            refatorar-print-para-logging
-            logger.info(
 
+        if not db_product_type:
             logger.debug(
                 "ROUTER: Não encontrado como tipo do usuário. Tentando buscar globalmente por key_name: '%s' (user_id: None)",
                 key_name_to_search,
@@ -183,10 +151,6 @@ async def read_product_type_details_route(
             is_global,
         )
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Não autorizado a visualizar este tipo de produto.")
-    
-refatorar-print-para-logging
-    logger.info(
-
     logger.debug(
 
         "ROUTER: Permissão CONCEDIDA. Retornando tipo de produto ID %s ('%s')",
@@ -204,7 +168,6 @@ def update_product_type_endpoint(
     current_user: models.User = Depends(auth_utils.get_current_active_user)
 ):
 
-    logger.info()
     logger.debug(
         "ROUTER (update_product_type): Tentando atualizar tipo de produto ID %s para usuário ID %s",
         type_id,
@@ -213,8 +176,6 @@ def update_product_type_endpoint(
     updated_type = crud.update_product_type(db=db, product_type_id=type_id, product_type_data=product_type_in, user_id=current_user.id)
     if not updated_type:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tipo de produto não encontrado ou falha na atualização.")
-
-    logger.info("ROUTER (update_product_type): Tipo de produto ID %s atualizado com sucesso.", type_id)
 
     logger.info(
         "ROUTER (update_product_type): Tipo de produto ID %s atualizado com sucesso.",
@@ -228,8 +189,6 @@ def delete_product_type_endpoint(
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user)
 ):
-    logger.info(
-
     logger.debug(
         "ROUTER (delete_product_type): Tentando deletar tipo de produto ID %s para usuário ID %s",
         type_id,
@@ -238,8 +197,6 @@ def delete_product_type_endpoint(
     deleted_type = crud.delete_product_type(db=db, product_type_id=type_id, user_id=current_user.id)
     if not deleted_type:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tipo de Produto não encontrado para deleção ou não pôde ser deletado.")
-
-    logger.info("ROUTER (delete_product_type): Tipo de produto ID %s deletado com sucesso.", type_id)
 
     logger.info(
         "ROUTER (delete_product_type): Tipo de produto ID %s deletado com sucesso.",
@@ -255,7 +212,6 @@ def add_attribute_to_product_type_endpoint(
     current_user: models.User = Depends(auth_utils.get_current_active_user)
 ):
 
-    logger.info(
 
     logger.debug(
 
@@ -290,8 +246,6 @@ def update_attribute_for_product_type_endpoint(
     current_user: models.User = Depends(auth_utils.get_current_active_user)
 ):
 
-    logger.info()
-
     logger.debug(
 
         "ROUTER (update_attribute): Tentando atualizar atributo ID %s do tipo ID %s para usuário ID %s",
@@ -319,8 +273,6 @@ def update_attribute_for_product_type_endpoint(
     if not updated_attribute:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Falha ao atualizar o atributo.")
 
-    logger.info("ROUTER (update_attribute): Atributo ID %s atualizado.", attribute_id)
-
     logger.info(
         "ROUTER (update_attribute): Atributo ID %s atualizado.",
         attribute_id,
@@ -335,7 +287,6 @@ def remove_attribute_from_product_type_endpoint(
     current_user: models.User = Depends(auth_utils.get_current_active_user)
 ):
 
-    logger.info()
 
     logger.debug(
         "ROUTER (delete_attribute): Tentando deletar atributo ID %s do tipo ID %s para usuário ID %s",
@@ -350,8 +301,6 @@ def remove_attribute_from_product_type_endpoint(
     deleted_attribute = crud.delete_attribute_template(db=db, attribute_template_id=attribute_id, user_id=current_user.id)
     if not deleted_attribute: 
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Falha ao deletar o atributo.")
-
-    logger.info("ROUTER (delete_attribute): Atributo ID %s deletado.", attribute_id)
 
     logger.info(
         "ROUTER (delete_attribute): Atributo ID %s deletado.",


### PR DESCRIPTION
## Summary
- clean stray `refatorar-print-para-logging` markers
- consolidate logging imports and remove duplicate log statements
- ensure router modules only use local loggers

## Testing
- `python -m py_compile Backend/auth.py Backend/core/config.py Backend/core/email_utils.py Backend/routers/password_recovery.py Backend/routers/product_types.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68437f00af60832f92a45e34d2fb5cca