### PR TITLE
Fix duplicate health check test

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,11 +1,3 @@
-
-import asyncio
-from Backend.main import health_check
-
-
-def test_health_check():
-    result = asyncio.run(health_check())
-    assert result == {"status": "ok"}
 import pytest
 
 pytest.importorskip("sqlalchemy")


### PR DESCRIPTION
## Summary
- remove duplicate `test_health_check` definition in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68437f033d48832fa9b0f8e9a5c1a1a0