### PR TITLE
Fix duplicated env configs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,6 @@ SQLITE_DB_FILE="tdai_app.db"
 
 # Security settings
 SECRET_KEY="change-me"
-REFRESH_SECRET_KEY="change-me-refresh"
-ACCESS_TOKEN_EXPIRE_MINUTES=1440
-REFRESH_TOKEN_EXPIRE_DAYS=7
-
 # CORS origins (comma separated list)
 BACKEND_CORS_ORIGINS="http://localhost:5173"
 

--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -38,13 +38,7 @@ class Settings(BaseSettings):
     SQLITE_DB_FILE: str = os.getenv("SQLITE_DB_FILE", "tdai_app.db")
 
     SECRET_KEY: str = os.getenv("SECRET_KEY", "super-secret-key-deve-ser-alterada-imediatamente")
-    REFRESH_SECRET_KEY: str = os.getenv("REFRESH_SECRET_KEY", "super-refresh-secret-change-me")
-    REFRESH_SECRET_KEY: str = os.getenv("REFRESH_SECRET_KEY", "super-refresh-secret-change-me")
-      
-    REFRESH_SECRET_KEY: str = os.getenv(
-        "REFRESH_SECRET_KEY",
-        "super-refresh-secret-key-deve-ser-alterada-imediatamente",
-    )
+    REFRESH_SECRET_KEY: str = os.getenv("REFRESH_SECRET_KEY", "super-refresh-secret-key-deve-ser-alterada-imediatamente")
     ALGORITHM: str = "HS256"
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 60 * 24 * 1)) # Default 1 dia
     REFRESH_TOKEN_EXPIRE_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", 7))


### PR DESCRIPTION
## Summary
- remove duplicate env vars from `.env.example`
- use a single `REFRESH_SECRET_KEY` in backend config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68437f01a0c0832fb4c21dd9e16e60f5