### PR TITLE
Fix duplicate test names

### DIFF
--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,23 +1,26 @@
 
 import asyncio
-from Backend.main import health_check
-
-
-def test_health_check():
-    result = asyncio.run(health_check())
-    assert result == {"status": "ok"}
 import pytest
-
-pytest.importorskip("sqlalchemy")
 from fastapi.testclient import TestClient
-from Backend.main import app
+
+from Backend.main import health_check, app
+
 
 # Disable heavy startup events for testing
 app.router.on_startup.clear()
 
+
+def test_health_check_direct():
+    result = asyncio.run(health_check())
+    assert result == {"status": "ok"}
+
+
+pytest.importorskip("sqlalchemy")
+
 client = TestClient(app)
 
-def test_health_check():
+
+def test_health_check_endpoint():
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"status": "ok"}


### PR DESCRIPTION
## Summary
- rename the direct call health check test to `test_health_check_direct`
- rename the endpoint test to `test_health_check_endpoint`
- keep startup events disabled for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68449cde71a4832f9d04ea81e821ff27