### PR TITLE
Fix API base URL handling in frontend

### DIFF
--- a/Frontend/app/src/services/apiClient.js
+++ b/Frontend/app/src/services/apiClient.js
@@ -2,7 +2,10 @@
 import axios from 'axios';
 import logger from '../utils/logger';
 
-const API_BASE_URL = '/api/v1'; // Conforme configuração com proxy do Vite
+// Use VITE_API_BASE_URL if defined (e.g. in production) otherwise fall back to
+// the relative path so Vite's dev proxy can handle API requests during
+// development.
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1';
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -1,25 +1,6 @@
 // Frontend/app/src/services/fornecedorService.js
-import axios from 'axios';
 import logger from '../utils/logger';
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/v1';
-
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  }
-});
-
-apiClient.interceptors.request.use(config => {
-  const token = localStorage.getItem('accessToken');
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-}, error => {
-  return Promise.reject(error);
-});
+import apiClient from './apiClient';
 
 export const getFornecedores = async (params = {}) => { // params pode incluir skip, limit, termo_busca
   try {

--- a/Frontend/app/src/services/productService.js
+++ b/Frontend/app/src/services/productService.js
@@ -1,25 +1,6 @@
 // Frontend/app/src/services/productService.js
-import axios from 'axios';
 import logger from '../utils/logger';
-
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000/api/v1';
-
-const apiClient = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    'Content-Type': 'application/json',
-  }
-});
-
-apiClient.interceptors.request.use(config => {
-  const token = localStorage.getItem('accessToken');
-  if (token) {
-    config.headers.Authorization = `Bearer ${token}`;
-  }
-  return config;
-}, error => {
-  return Promise.reject(error);
-});
+import apiClient from './apiClient';
 
 export const getProdutos = async (params = {}) => {
   try {


### PR DESCRIPTION
## Summary
- use `VITE_API_BASE_URL` in shared `apiClient`
- reuse `apiClient` in product and fornecedor services to avoid duplicate configs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68449cb851cc832fa9f9511e5bda0409