### PR TITLE
Fix run_backend package imports

### DIFF
--- a/run_backend.py
+++ b/run_backend.py
@@ -8,33 +8,29 @@ if __name__ == "__main__":
     project_root = os.path.dirname(os.path.abspath(__file__))
     backend_dir = os.path.join(project_root, "Backend")
 
-    # Adiciona a pasta Backend ao sys.path para ajudar com os imports internos
-    # que podem estar usando "app." (precisaremos verificar isso depois)
-    # Por agora, o mais importante é o Uvicorn encontrar 'main:app'
-    if backend_dir not in sys.path:
-        sys.path.insert(0, backend_dir)
+    # Adiciona o diretório raiz do projeto ao sys.path para que o pacote
+    # "Backend" seja importável usando a sintaxe de pacote completa
+    if project_root not in sys.path:
+        sys.path.insert(0, project_root)
 
-    # Muda o diretório de trabalho atual para a pasta Backend
-    try:
-        os.chdir(backend_dir)
-    except FileNotFoundError:
-        logger.error("ERRO: O diretório Backend não foi encontrado em %s", backend_dir)
-        sys.exit(1)
+    # Não alteramos o diretório de trabalho para evitar que módulos dentro do
+    # pacote sejam carregados como scripts de nível superior. Isso garante que
+    # imports relativos (como os utilizados em crud.py) funcionem corretamente.
 
     logger.debug("--- sys.path atual ---")
     for p in sys.path:
         logger.debug(p)
     logger.debug("----------------------")
     logger.debug("Diretório de Trabalho Atual (CWD): %s", os.getcwd())
-    logger.info("Tentando iniciar Uvicorn com 'main:app' a partir da pasta Backend...")
+    logger.info("Tentando iniciar Uvicorn com 'Backend.main:app' ...")
 
     try:
         uvicorn.run(
-            "main:app",  # Alvo: arquivo main.py, objeto app dentro dele
+            "Backend.main:app",  # Alvo: pacote Backend, módulo main.py, objeto app
             host="127.0.0.1",
             port=8000,
             reload=True,
-            workers=1
+            workers=1,
         )
     except ImportError as e:
         logger.error("Erro de Importação ao tentar carregar a aplicação Uvicorn: %s", e)


### PR DESCRIPTION
## Summary
- avoid changing CWD in `run_backend.py`
- call Uvicorn with `Backend.main:app`

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68461019a59c832f9656fa6a0fb956c1