### PR TITLE
Fix backend imports for package context

### DIFF
--- a/Backend/alembic/env.py
+++ b/Backend/alembic/env.py
@@ -24,7 +24,7 @@ if backend_root_dir not in sys.path:
 # Tenta importar Base e models.
 # Se a execução é a partir do diretório Backend, esses imports devem funcionar.
 try:
-    from database import Base  # Importa a Base definida em Backend/database.py
+    from Backend.database import Base  # Importa a Base definida em Backend/database.py
     import models              # Importa todos os modelos definidos em Backend/models.py
     target_metadata = Base.metadata
     print("INFO: models.Base e models importados com sucesso para Alembic.")
@@ -48,7 +48,7 @@ except ImportError as e:
 
 # Importa as configurações do seu projeto para obter a URL do banco de dados (se necessário)
 try:
-    from core.config import settings as app_settings
+    from Backend.core.config import settings as app_settings
     # Usamos a URL de settings para garantir consistência.
     # alembic.ini também pode ter 'sqlalchemy.url', mas a de settings é preferível.
     SQLALCHEMY_DATABASE_URL = str(app_settings.DATABASE_URL)

--- a/Backend/auth.py
+++ b/Backend/auth.py
@@ -12,16 +12,16 @@ from jose import JWTError, jwt
 from authlib.integrations.starlette_client import OAuth, OAuthError # type: ignore
 from starlette.config import Config as AuthlibConfig 
 from sqlalchemy.orm import Session
-from core.config import settings, pwd_context
-from core.logging_config import get_logger
+from Backend.core.config import settings, pwd_context
+from Backend.core.logging_config import get_logger
 
 logger = get_logger(__name__)
-from core.config import settings, pwd_context, logger
+from Backend.core.config import settings, pwd_context, logger
 
-import schemas 
-import models 
-import crud 
-from database import get_db # Para Depends(get_db)
+from Backend import schemas
+from Backend import models
+from Backend import crud
+from Backend.database import get_db  # Para Depends(get_db)
 
 # Constante para expiração do token de reset de senha
 PASSWORD_RESET_TOKEN_EXPIRE_HOURS = 1 

--- a/Backend/core/security.py
+++ b/Backend/core/security.py
@@ -6,7 +6,7 @@ from jose import jwt, JWTError
 from passlib.context import CryptContext
 from pydantic import BaseModel, ValidationError # Adicionado ValidationError
 
-from core.config import settings # Importa o objeto settings diretamente
+from Backend.core.config import settings # Importa o objeto settings diretamente
 
 pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 

--- a/Backend/crud.py
+++ b/Backend/crud.py
@@ -10,16 +10,16 @@ from sqlalchemy.exc import IntegrityError
 
 from jose import jwt # Para decodificar token se necessário (ex: social_auth)
 
-from core.config import settings # Para JWT_SECRET_KEY, ALGORITHM, etc.
-from core import security # Para hash de senha
+from Backend.core.config import settings  # Para JWT_SECRET_KEY, ALGORITHM, etc.
+from Backend.core import security  # Para hash de senha
 from pathlib import Path
 import uuid
 from fastapi import UploadFile
-from models import ( # Isso está correto
+from Backend.models import (  # Isso está correto
     User, Role, Plano, Produto, Fornecedor, ProductType, AttributeTemplate, RegistroUsoIA,
     StatusEnriquecimentoEnum, StatusGeracaoIAEnum, TipoAcaoIAEnum, AttributeFieldTypeEnum
 )
-import schemas # Importa todos os schemas
+from Backend import schemas # Importa todos os schemas
 
 # Configuração básica de logging
 logging.basicConfig(level=logging.INFO)

--- a/Backend/crud_fornecedores.py
+++ b/Backend/crud_fornecedores.py
@@ -4,8 +4,8 @@ from typing import List, Optional
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
-from models import Fornecedor
-import schemas
+from Backend.models import Fornecedor
+from Backend import schemas
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/Backend/crud_produtos.py
+++ b/Backend/crud_produtos.py
@@ -7,10 +7,10 @@ from typing import List, Optional
 from sqlalchemy import func, or_, desc, asc
 from sqlalchemy.orm import Session, selectinload
 
-from core.config import settings
-from models import Produto, Fornecedor, ProductType, StatusEnriquecimentoEnum, StatusGeracaoIAEnum
+from Backend.core.config import settings
+from Backend.models import Produto, Fornecedor, ProductType, StatusEnriquecimentoEnum, StatusGeracaoIAEnum
 from fastapi import UploadFile
-import schemas
+from Backend import schemas
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/Backend/crud_users.py
+++ b/Backend/crud_users.py
@@ -5,10 +5,10 @@ from datetime import datetime
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import IntegrityError
 
-from core.config import settings
-from core import security
-from models import User, Role, Plano
-import schemas
+from Backend.core.config import settings
+from Backend.core import security
+from Backend.models import User, Role, Plano
+from Backend import schemas
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)

--- a/Backend/database.py
+++ b/Backend/database.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import sessionmaker
 # CORREÇÃO: 'core' é uma subpasta de 'Backend/' (onde este arquivo database.py está,
 # e que será o CWD quando rodarmos via run_backend.py).
 # Então, importamos diretamente de 'core.config'.
-from core.config import settings #
+from Backend.core.config import settings #
 
 engine = create_engine(settings.DATABASE_URL)
 

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -7,27 +7,27 @@ from pathlib import Path
 from typing import List, Optional, Any
 import json
 import traceback
-from core.logging_config import get_logger
+from Backend.core.logging_config import get_logger
 
-import models
-import schemas
-import crud_users
-import crud_product_types
-from auth import router as auth_router_direct
-from database import SessionLocal, engine, get_db
-from core.config import settings
+from Backend import models
+from Backend import schemas
+from Backend import crud_users
+from Backend import crud_product_types
+from Backend.auth import router as auth_router_direct
+from Backend.database import SessionLocal, engine, get_db
+from Backend.core.config import settings
 
 # Importa os routers da subpasta 'routers'
-from routers.produtos import router as produtos_router
-from routers.fornecedores import router as fornecedores_router
-from routers.generation import router as generation_router
-from routers.web_enrichment import router as web_enrichment_router
-from routers.uploads import router as uploads_router
-from routers.product_types import router as product_types_router
-from routers.uso_ia import router as uso_ia_router
-from routers.password_recovery import router as password_recovery_router
-from routers.admin_analytics import router as admin_analytics_router
-from routers.social_auth import router as social_auth_router
+from Backend.routers.produtos import router as produtos_router
+from Backend.routers.fornecedores import router as fornecedores_router
+from Backend.routers.generation import router as generation_router
+from Backend.routers.web_enrichment import router as web_enrichment_router
+from Backend.routers.uploads import router as uploads_router
+from Backend.routers.product_types import router as product_types_router
+from Backend.routers.uso_ia import router as uso_ia_router
+from Backend.routers.password_recovery import router as password_recovery_router
+from Backend.routers.admin_analytics import router as admin_analytics_router
+from Backend.routers.social_auth import router as social_auth_router
 
 logger = get_logger(__name__)
 
@@ -37,7 +37,7 @@ try:
 except Exception as e:
     logger.error(f"Erro ao criar tabelas: {e}")
 
-from core.config import logger
+from Backend.core.config import logger
 
 
 try:

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -4,7 +4,7 @@ from sqlalchemy import (Column, Integer, String, Boolean, DateTime, ForeignKey, 
                         Float, Enum as SQLAlchemyEnum, JSON, Index, UniqueConstraint, func)
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.ext.mutable import MutableDict, MutableList # Para tipos JSON mutáveis
-from database import Base # Assume que database.py define Base = declarative_base()
+from Backend.database import Base # Assume que database.py define Base = declarative_base()
 from datetime import datetime, timezone # Corrigido para importar timezone
 import enum
 

--- a/Backend/routers/admin_analytics.py
+++ b/Backend/routers/admin_analytics.py
@@ -3,15 +3,15 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from sqlalchemy import func, cast, String # Importar cast e String
-from core.config import logger
+from Backend.core.config import logger
 from datetime import datetime, timedelta, timezone 
 
-import crud 
-import models 
-import schemas 
-from database import get_db 
-from auth import get_current_active_user # Importa a dependência correta
-from core.logging_config import get_logger
+from Backend import crud
+from Backend import models
+from Backend import schemas
+from Backend.database import get_db
+from Backend.auth import get_current_active_user  # Importa a dependência correta
+from Backend.core.logging_config import get_logger
 
 router = APIRouter()
 

--- a/Backend/routers/auth_utils.py
+++ b/Backend/routers/auth_utils.py
@@ -9,12 +9,12 @@ from jose import JWTError, jwt # JWTError pode ser útil para tratamento especí
 # from passlib.context import CryptContext # Removido, agora em core.security
 from sqlalchemy.orm import Session
 
-import crud_users
-import models
-import schemas
-from core import config # Mantido para settings que não são de segurança direta
-from core import security # <<< ADICIONADO: Importa o novo módulo de segurança
-from database import get_db
+from Backend import crud_users
+from Backend import models
+from Backend import schemas
+from Backend.core import config  # Mantido para settings que não são de segurança direta
+from Backend.core import security  # <<< ADICIONADO: Importa o novo módulo de segurança
+from Backend.database import get_db
 
 # Configuração básica de logging
 logger = logging.getLogger(__name__)

--- a/Backend/routers/fornecedores.py
+++ b/Backend/routers/fornecedores.py
@@ -6,10 +6,10 @@ from sqlalchemy.orm import Session
 import logging
 
 
-import crud_fornecedores
-import models
-import schemas # schemas é importado
-import database
+from Backend import crud_fornecedores
+from Backend import models
+from Backend import schemas  # schemas é importado
+from Backend import database
 from . import auth_utils # Para obter o usuário 
 
 logger = logging.getLogger(__name__)

--- a/Backend/routers/generation.py
+++ b/Backend/routers/generation.py
@@ -7,12 +7,12 @@ from datetime import datetime
 import logging # <-- ADICIONADO
 
 from . import auth_utils
-import crud_users
-import crud_produtos
-import models
-import schemas
-from database import get_db, SessionLocal
-from services import ia_generation_service, limit_service
+from Backend import crud_users
+from Backend import crud_produtos
+from Backend import models
+from Backend import schemas
+from Backend.database import get_db, SessionLocal
+from Backend.services import ia_generation_service, limit_service
 from .auth_utils import get_current_active_user
 
 # Configuração do logger para este módulo

--- a/Backend/routers/password_recovery.py
+++ b/Backend/routers/password_recovery.py
@@ -4,16 +4,16 @@ from datetime import datetime, timedelta, timezone  # Adicionado timezone
 from fastapi import APIRouter, Depends, HTTPException, Request, status, Body # Adicionado Body
 from sqlalchemy.orm import Session
 
-import crud_users
-import schemas # schemas é importado
-import models # models é importado
-from database import get_db # Corrigido para get_db
-from core.config import settings # Para FRONTEND_URL
-from core.email_utils import send_password_reset_email  # Importa a função de envio de email
-from core import security
-from core.logging_config import get_logger
-from core.config import settings, logger  # Para FRONTEND_URL e logging
-from auth import create_password_reset_token, hash_password_reset_token
+from Backend import crud_users
+from Backend import schemas  # schemas é importado
+from Backend import models  # models é importado
+from Backend.database import get_db  # Corrigido para get_db
+from Backend.core.config import settings  # Para FRONTEND_URL
+from Backend.core.email_utils import send_password_reset_email  # Importa a função de envio de email
+from Backend.core import security
+from Backend.core.logging_config import get_logger
+from Backend.core.config import settings, logger  # Para FRONTEND_URL e logging
+from Backend.auth import create_password_reset_token, hash_password_reset_token
 
 router = APIRouter(
     prefix="/api/v1/auth", # Mantendo o prefixo como no arquivo original, se for este

--- a/Backend/routers/product_types.py
+++ b/Backend/routers/product_types.py
@@ -4,16 +4,16 @@ from fastapi import APIRouter, Depends, HTTPException, status, Path as FastAPIPa
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-import crud_product_types
-import models
-import schemas
-import database
+from Backend import crud_product_types
+from Backend import models
+from Backend import schemas
+from Backend import database
 from . import auth_utils
-from core.logging_config import get_logger
+from Backend.core.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-from core.config import logger
+from Backend.core.config import logger
 
 router = APIRouter(
     prefix="/product-types", 

--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -17,14 +17,14 @@ from fastapi import (
 from sqlalchemy.orm import Session
 from sqlalchemy import func, or_
 
-import crud_produtos
-import crud_fornecedores
-import crud_product_types
-import models 
-import schemas # schemas é importado
-import database
+from Backend import crud_produtos
+from Backend import crud_fornecedores
+from Backend import crud_product_types
+from Backend import models
+from Backend import schemas  # schemas é importado
+from Backend import database
 from . import auth_utils # Para obter o usuário logado
-from core import config # Pode ser necessário para settings, se usado diretamente
+from Backend.core import config # Pode ser necessário para settings, se usado diretamente
 
 router = APIRouter(
     prefix="/produtos",

--- a/Backend/routers/social_auth.py
+++ b/Backend/routers/social_auth.py
@@ -5,7 +5,7 @@
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.orm import Session
-from auth import (
+from Backend.auth import (
     oauth,
     OAuthError,
     process_google_login,
@@ -13,10 +13,10 @@ from auth import (
     create_access_token,
     create_refresh_token,
 )
-from database import get_db
-from core.config import settings
-from core.logging_config import get_logger
-import schemas
+from Backend.database import get_db
+from Backend.core.config import settings
+from Backend.core.logging_config import get_logger
+from Backend import schemas
 
 router = APIRouter()
 logger = get_logger(__name__)
@@ -85,9 +85,9 @@ async def facebook_callback(request: Request, db: Session = Depends(get_db)):
     access_token = create_access_token({"sub": user.email, "user_id": user.id})
     refresh_token = create_refresh_token({"sub": user.email, "user_id": user.id})
     return {"access_token": access_token, "refresh_token": refresh_token, "token_type": "bearer"}
-from core.config import settings
-from database import get_db
-import schemas
+from Backend.core.config import settings
+from Backend.database import get_db
+from Backend import schemas
 
 router = APIRouter()
 

--- a/Backend/routers/uploads.py
+++ b/Backend/routers/uploads.py
@@ -3,19 +3,19 @@ from fastapi.responses import JSONResponse
 from typing import List, Optional
 import shutil
 import os
-from core.config import logger
+from Backend.core.config import logger
 from pathlib import Path
 import imghdr # Para detectar o tipo MIME de imagem
 import magic # Para detectar o tipo MIME de forma mais robusta (requer python-magic)
 
 # --- IMPORTS ALTERADOS ---
-from database import get_db
-from auth import get_current_active_user
-from models import User
-from schemas import FileProcessResponse
+from Backend.database import get_db
+from Backend.auth import get_current_active_user
+from Backend.models import User
+from Backend.schemas import FileProcessResponse
 from sqlalchemy.orm import Session
 # --- FIM DOS IMPORTS ALTERADOS ---
-from core.logging_config import get_logger
+from Backend.core.logging_config import get_logger
 
 router = APIRouter()
 

--- a/Backend/routers/uso_ia.py
+++ b/Backend/routers/uso_ia.py
@@ -3,15 +3,15 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from datetime import datetime # Necessário para filtros de data
-from core.config import logger
+from Backend.core.config import logger
 
-import crud
-import crud_produtos
-import models
-import schemas # schemas é importado
-import database
+from Backend import crud
+from Backend import crud_produtos
+from Backend import models
+from Backend import schemas  # schemas é importado
+from Backend import database
 from . import auth_utils # Para obter o usuário logado
-from core.logging_config import get_logger
+from Backend.core.logging_config import get_logger
 
 router = APIRouter(
     prefix="/uso-ia", # FIX: Removido o '/api/v1' daqui

--- a/Backend/routers/web_enrichment.py
+++ b/Backend/routers/web_enrichment.py
@@ -6,18 +6,18 @@ from typing import List, Dict, Any, Optional
 import asyncio
 import json
 
-import crud_users
-import crud_produtos
-import crud
-import models
-import schemas
-from database import get_db, SessionLocal
+from Backend import crud_users
+from Backend import crud_produtos
+from Backend import crud
+from Backend import models
+from Backend import schemas
+from Backend.database import get_db, SessionLocal
 
 from .auth_utils import get_current_active_user
 
-from services import web_data_extractor_service as web_extractor
-from core.config import settings
-from core.logging_config import get_logger
+from Backend.services import web_data_extractor_service as web_extractor
+from Backend.core.config import settings
+from Backend.core.logging_config import get_logger
 
 router = APIRouter(
     prefix="/enriquecimento-web",

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -10,7 +10,7 @@ import json # Para validação de JSON string
 # a importação direta pode funcionar. Caso contrário, pode ser necessário um ajuste
 # relativo ou absoluto dependendo de como o projeto é executado.
 # Assumindo que 'models.py' está no mesmo diretório (Backend) e é acessível:
-from models import StatusEnriquecimentoEnum, StatusGeracaoIAEnum, TipoAcaoIAEnum, AttributeFieldTypeEnum
+from Backend.models import StatusEnriquecimentoEnum, StatusGeracaoIAEnum, TipoAcaoIAEnum, AttributeFieldTypeEnum
 
 # Schemas de Autenticação e Usuário
 class Token(BaseModel):

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -4,7 +4,7 @@ import pdfplumber
 import csv
 import io # Para ler o conteúdo do arquivo em memória
 from typing import List, Dict, Any, Union, Optional
-from core.logging_config import get_logger
+from Backend.core.logging_config import get_logger
 
 logger = get_logger(__name__)
 

--- a/Backend/services/ia_generation_service.py
+++ b/Backend/services/ia_generation_service.py
@@ -9,11 +9,11 @@ import logging # Adicionado para logging
 from jose import JWTError, jwt
 from fastapi import HTTPException, status, Depends
 
-import crud
-import crud_produtos
-import models # models completo para acesso a TipoAcaoIAEnum
-import schemas
-from core.config import settings
+from Backend import crud
+from Backend import crud_produtos
+from Backend import models  # models completo para acesso a TipoAcaoIAEnum
+from Backend import schemas
+from Backend.core.config import settings
 from . import limit_service # Para verificar e consumir limites/créditos
 
 # Configuração do logger

--- a/Backend/services/limit_service.py
+++ b/Backend/services/limit_service.py
@@ -5,11 +5,11 @@ from sqlalchemy.orm import Session
 # CORREÇÕES DOS IMPORTS:
 # Como 'run_backend.py' coloca 'Backend/' no sys.path e define como CWD,
 # 'crud' e 'models' (que estão em Backend/) são importados diretamente.
-import crud
-import crud_users #
-import models #
+from Backend import crud
+from Backend import crud_users #
+from Backend import models #
 # Se 'database.py' fosse necessário, seria: from database import get_db
-from core.logging_config import get_logger
+from Backend.core.logging_config import get_logger
 # Se 'database.py' fosse necessário, seria: from database import get_db
 
 def verificar_limite_uso(

--- a/Backend/services/web_data_extractor_service.py
+++ b/Backend/services/web_data_extractor_service.py
@@ -10,7 +10,7 @@ from typing import List, Dict, Optional, Any
 from urllib.parse import urlparse
 from sqlalchemy.orm import Session # Importar Session para type hinting, se necessário
 from datetime import datetime, timezone
-from core.logging_config import get_logger
+from Backend.core.logging_config import get_logger
 
 logger = get_logger(__name__)
 
@@ -26,9 +26,9 @@ except ImportError:
 
 # Ajustando as importações para serem absolutas a partir da raiz do projeto (Backend)
 # Assumindo que 'Backend' está no sys.path ou é o diretório de trabalho.
-from core.config import settings 
-import models 
-from services import ia_generation_service # Importação absoluta para o módulo irmão
+from Backend.core.config import settings
+from Backend import models
+from Backend.services import ia_generation_service  # Importação absoluta para o módulo irmão
 
 # --- Google Search Service ---
 async def buscar_urls_google(query: str, num_results: int = 3) -> List[str]:

--- a/run_backend.py
+++ b/run_backend.py
@@ -8,20 +8,12 @@ if __name__ == "__main__":
     project_root = os.path.dirname(os.path.abspath(__file__))
     backend_dir = os.path.join(project_root, "Backend")
 
-    # Adiciona o diretório raiz do projeto ao sys.path para que o pacote
-    # "Backend" seja importável usando a sintaxe de pacote completa
+    # Assegura que o pacote ``Backend`` seja importável acrescentando o
+    # diretório raiz do projeto ao ``sys.path``. Ao utilizar importações com o
+    # prefixo ``Backend`` (por exemplo, ``from Backend.core.config import
+    # settings``) não é necessário incluir ``backend_dir`` no ``sys.path``.
     if project_root not in sys.path:
         sys.path.insert(0, project_root)
-
-    # Alguns módulos dentro de "Backend" usam imports sem o prefixo do pacote
-    # (por exemplo, ``from core.logging_config import get_logger``). Esses
-    # imports funcionam apenas se o diretório ``Backend`` também estiver
-    # presente em ``sys.path``. Ao incluir explicitamente ``backend_dir``,
-    # garantimos que esses módulos possam ser resolvidos corretamente, mesmo
-    # quando ``run_backend.py`` é executado a partir do diretório raiz do
-    # projeto.
-    if backend_dir not in sys.path:
-        sys.path.insert(0, backend_dir)
 
     # Não alteramos o diretório de trabalho para evitar que módulos dentro do
     # pacote sejam carregados como scripts de nível superior. Isso garante que


### PR DESCRIPTION
## Summary
- ensure Backend package is referenced explicitly in imports
- update run_backend helper path comment
- adjust all modules to use `Backend.` prefix for internal modules

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684611ed4c34832fbd675fee5dca7738