### PR TITLE
Fix missing import in auth module

### DIFF
--- a/Backend/auth.py
+++ b/Backend/auth.py
@@ -21,6 +21,7 @@ from Backend.core.config import settings, pwd_context, logger
 from Backend import schemas
 from Backend import models
 from Backend import crud
+from Backend import crud_users
 from Backend.database import get_db  # Para Depends(get_db)
 
 # Constante para expiração do token de reset de senha


### PR DESCRIPTION
## Summary
- import `crud_users` in `auth.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6846157944c4832f81840bd2b5409110