### PR TITLE
Implement password recovery flow

### DIFF
--- a/Frontend/app/src/App.jsx
+++ b/Frontend/app/src/App.jsx
@@ -15,6 +15,8 @@ import EnriquecimentoPage from './pages/EnriquecimentoPage';
 import HistoricoPage from './pages/HistoricoPage';
 import PlanoPage from './pages/PlanoPage';
 import ConfiguracoesPage from './pages/ConfiguracoesPage';
+import RecuperarSenhaPage from './pages/RecuperarSenhaPage';
+import ResetSenhaPage from './pages/ResetSenhaPage';
 import ProtectedRoute from './components/ProtectedRoute';
 // Importe outras páginas e componentes necessários
 
@@ -43,6 +45,8 @@ function AppContent() {
   return (
     <Routes>
       <Route path="/login" element={<LoginPage />} />
+      <Route path="/recuperar-senha" element={<RecuperarSenhaPage />} />
+      <Route path="/resetar-senha" element={<ResetSenhaPage />} />
       
       {/* Rotas Protegidas */}
       <Route 

--- a/Frontend/app/src/pages/RecuperarSenhaPage.jsx
+++ b/Frontend/app/src/pages/RecuperarSenhaPage.jsx
@@ -1,0 +1,53 @@
+import React, { useState } from 'react';
+import { Link } from 'react-router-dom';
+import authService from '../services/authService';
+import { showSuccessToast, showErrorToast } from '../utils/notifications';
+import './LoginPage.css';
+
+const RecuperarSenhaPage = () => {
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await authService.requestPasswordRecovery(email);
+      showSuccessToast('Se o email existir, enviaremos instruções para redefinição.');
+    } catch (error) {
+      const msg = error?.detail || error.message || 'Falha ao solicitar recuperação de senha.';
+      showErrorToast(msg);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="login-page-wrapper">
+      <div className="login-form-card">
+        <h2>Recuperar Senha</h2>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="email">Email cadastrado</label>
+            <input
+              type="email"
+              id="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              disabled={isSubmitting}
+            />
+          </div>
+          <button type="submit" className="login-button" disabled={isSubmitting}>
+            {isSubmitting ? 'Enviando...' : 'Enviar link'}
+          </button>
+          <div className="login-links">
+            <Link to="/login">Voltar para login</Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default RecuperarSenhaPage;

--- a/Frontend/app/src/pages/ResetSenhaPage.jsx
+++ b/Frontend/app/src/pages/ResetSenhaPage.jsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { useSearchParams, Link } from 'react-router-dom';
+import authService from '../services/authService';
+import { showSuccessToast, showErrorToast } from '../utils/notifications';
+import './LoginPage.css';
+
+const ResetSenhaPage = () => {
+  const [searchParams] = useSearchParams();
+  const token = searchParams.get('token');
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (password !== confirmPassword) {
+      showErrorToast('A senha e a confirmação não coincidem.');
+      return;
+    }
+    if (!token) {
+      showErrorToast('Token inválido.');
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await authService.resetPassword(token, password);
+      showSuccessToast('Senha alterada com sucesso. Faça login.');
+    } catch (error) {
+      const msg = error?.detail || error.message || 'Falha ao redefinir senha.';
+      showErrorToast(msg);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="login-page-wrapper">
+      <div className="login-form-card">
+        <h2>Definir Nova Senha</h2>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label htmlFor="new_password">Nova senha (mín. 8 caracteres)</label>
+            <input
+              type="password"
+              id="new_password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+            />
+          </div>
+          <div className="form-group">
+            <label htmlFor="confirm_password">Confirmar nova senha</label>
+            <input
+              type="password"
+              id="confirm_password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              minLength={8}
+            />
+          </div>
+          <button type="submit" className="login-button" disabled={isSubmitting}>
+            {isSubmitting ? 'Salvando...' : 'Alterar Senha'}
+          </button>
+          <div className="login-links">
+            <Link to="/login">Voltar para login</Link>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default ResetSenhaPage;

--- a/Frontend/app/src/services/authService.js
+++ b/Frontend/app/src/services/authService.js
@@ -80,6 +80,33 @@ const authService = {
     }
   },
 
+  async requestPasswordRecovery(email) {
+    try {
+      const response = await apiClient.post(`/auth/password-recovery/${encodeURIComponent(email)}`);
+      showSuccessToast('Se o email existir, um link de redefinição será enviado.');
+      return response.data;
+    } catch (error) {
+      console.error('Error requesting password recovery (authService):', error.response?.data || error.message);
+      showErrorToast(error.response?.data?.detail || 'Falha ao solicitar recuperação de senha.');
+      throw error.response?.data || new Error('Falha ao solicitar recuperação de senha.');
+    }
+  },
+
+  async resetPassword(token, newPassword) {
+    try {
+      const response = await apiClient.post('/auth/reset-password/', {
+        token,
+        new_password: newPassword,
+      });
+      showSuccessToast('Senha redefinida com sucesso!');
+      return response.data;
+    } catch (error) {
+      console.error('Error resetting password (authService):', error.response?.data || error.message);
+      showErrorToast(error.response?.data?.detail || 'Falha ao redefinir senha.');
+      throw error.response?.data || new Error('Falha ao redefinir senha.');
+    }
+  },
+
   // Adicione outras funções de autenticação/usuário conforme necessário
   // Ex: forgotPassword, resetPassword, etc.
 };


### PR DESCRIPTION
## Summary
- add API helpers for password reset
- create pages for requesting and resetting password
- register new routes in the React app

## Testing
- `npm --prefix Frontend/app test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68461a20b158832f844ec77dca77c42e