### PR TITLE
Fix Meu Plano page data mapping

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -74,7 +74,7 @@ class UserResponse(UserBase): # O que é retornado pela API
     limite_geracao_ia: Optional[int] = None
     data_expiracao_plano: Optional[datetime] = None
     # Adicionar informações do plano e role se desejado na resposta
-    # plano: Optional[PlanoResponse] = None # Evitar dependência circular aqui, resolver no router
+    plano: Optional['PlanoResponse'] = None  # type: ignore  # Evitar dependência circular
     # role: Optional[RoleResponse] = None  # Evitar dependência circular
 
     class Config:

--- a/Frontend/app/src/pages/PlanoPage.jsx
+++ b/Frontend/app/src/pages/PlanoPage.jsx
@@ -81,15 +81,15 @@ function PlanoPage() {
         <div className="plano-details-grid">
           <div className="plano-card current-plan-card">
             <div className="current-plan-header">
-              <span className={`plan-badge ${plano.name?.toLowerCase()}`}>{plano.name || "N/D"}</span>
+              <span className={`plan-badge ${plano.nome?.toLowerCase()}`}>{plano.nome || "N/D"}</span>
               <span className="current-plan-label">Plano Atual</span>
             </div>
             <ul className="plan-features">
-              <li><strong>{formatLimit(plano.max_titulos_mes)}</strong> títulos/mês</li>
-              <li><strong>{formatLimit(plano.max_descricoes_mes)}</strong> descrições/mês</li>
-              {/* Adicionar mais características do plano conforme necessário */}
+              <li><strong>{formatLimit(plano.limite_produtos)}</strong> produtos</li>
+              <li><strong>{formatLimit(plano.limite_enriquecimento_web)}</strong> enriquecimentos/mês</li>
+              <li><strong>{formatLimit(plano.limite_geracao_ia)}</strong> gerações IA/mês</li>
               <li>Suporte via Email</li>
-              {plano.name?.toLowerCase() !== 'gratuito' && <li>Suporte Prioritário</li>}
+              {plano.nome?.toLowerCase() !== 'gratuito' && <li>Suporte Prioritário</li>}
             </ul>
             <div className="plan-renewal">
               {/* Data de renovação não está no modelo User/Plano ainda */}


### PR DESCRIPTION
## Summary
- expose plano data in user response
- align PlanoPage with backend field names

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68461dc217bc832fa418cdd77b38653f