### PR TITLE
Implement admin analytics endpoints

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -384,6 +384,19 @@ class UserActivity(BaseModel):
     class Config:
         from_attributes = True
 
+class ProductStatusCount(BaseModel):
+    status: StatusEnriquecimentoEnum
+    total: int
+
+class RecentActivity(BaseModel):
+    id: int
+    user_id: int
+    user_email: Optional[EmailStr] = None
+    tipo_acao: TipoAcaoIAEnum
+    created_at: datetime
+    class Config:
+        from_attributes = True
+
 # ----- NOVOS SCHEMAS PARA SUGESTÃO DE ATRIBUTOS GEMINI -----
 class SugestaoAtributoItem(BaseModel):
     chave_atributo: str = Field(..., description="A chave do atributo para o qual o valor é sugerido (ex: 'cor', 'material').")

--- a/Frontend/app/src/services/adminService.js
+++ b/Frontend/app/src/services/adminService.js
@@ -14,6 +14,26 @@ const adminService = {
     }
   },
 
+  async getProductStatusCounts() {
+    try {
+      const response = await apiClient.get('/admin/analytics/product-status-counts');
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching product status counts:', error.response?.data || error.message);
+      throw error.response?.data || new Error('Falha ao buscar contagem de status dos produtos.');
+    }
+  },
+
+  async getRecentActivities() {
+    try {
+      const response = await apiClient.get('/admin/analytics/recent-activities');
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching recent activities:', error.response?.data || error.message);
+      throw error.response?.data || new Error('Falha ao buscar atividades recentes.');
+    }
+  },
+
   // Você pode adicionar outras funções de admin aqui no futuro, como:
   // async getUsoIaPorPlano() { ... }
   // async getUserActivity() { ... }

--- a/tests/test_admin_analytics.py
+++ b/tests/test_admin_analytics.py
@@ -1,0 +1,54 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from Backend.main import app
+from Backend.database import Base, get_db
+from Backend import crud, crud_users, crud_produtos, schemas, models
+from Backend.core.config import settings
+
+# disable heavy startup events
+app.router.on_startup.clear()
+
+engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(bind=engine)
+Base.metadata.create_all(bind=engine)
+
+# override dependency
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+# setup initial data
+with TestingSessionLocal() as db:
+    crud.create_initial_data(db)
+    admin = crud_users.get_user_by_email(db, settings.FIRST_SUPERUSER_EMAIL)
+    crud_produtos.create_produto(db, schemas.ProdutoCreate(nome_base="Teste"), user_id=admin.id)
+    crud.create_registro_uso_ia(db, schemas.RegistroUsoIACreate(user_id=admin.id, tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO))
+
+def get_auth_headers():
+    resp = client.post("/api/v1/auth/token", data={"username": settings.FIRST_SUPERUSER_EMAIL, "password": settings.FIRST_SUPERUSER_PASSWORD})
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_product_status_counts_endpoint():
+    headers = get_auth_headers()
+    resp = client.get("/api/v1/admin/analytics/product-status-counts", headers=headers)
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+def test_recent_activities_endpoint():
+    headers = get_auth_headers()
+    resp = client.get("/api/v1/admin/analytics/recent-activities", headers=headers)
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)


### PR DESCRIPTION
## Summary
- add product status counts and recent activity endpoints for admins
- expose new analytics fetchers in adminService
- load dashboard charts and feed from the backend
- test admin analytics endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68461ec0be38832fa6c8d3f476b9ae92