### PR TITLE
Fix hydration warning in FornecedorTable

### DIFF
--- a/Frontend/app/src/components/fornecedores/FornecedorTable.jsx
+++ b/Frontend/app/src/components/fornecedores/FornecedorTable.jsx
@@ -6,7 +6,7 @@ function FornecedorTable({ fornecedores, onRowClick, onSelectRow, selectedIds, o
     return <p>Carregando tabela de fornecedores...</p>;
   }
   return (
-    <table style={{ width: '100%' }} id="forn-table"> {/* Adicionado ID para consistência se necessário */}
+    <table style={{ width: '100%' }} id="forn-table">
       <thead>
         <tr>
           <th className="select">


### PR DESCRIPTION
## Summary
- remove inline comment after `<table>` tag to avoid whitespace node

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6846205cdfc8832fb662a294b4c4d249