### PR TITLE
Create default example product

### DIFF
--- a/Backend/crud.py
+++ b/Backend/crud.py
@@ -654,5 +654,16 @@ def create_initial_data(db: Session):
         else:
             logger.info(f"Tipo de Produto Global '{pt_create_schema.friendly_name}' já existe.")
 
+    # Criar um produto de exemplo para o administrador na primeira execução
+    if db.query(Produto).count() == 0:
+        admin_user = get_user_by_email(db, admin_email)
+        if admin_user:
+            exemplo = schemas.ProdutoCreate(
+                nome_base="Produto de Exemplo",
+                descricao_original="Item criado automaticamente na inicialização"
+            )
+            create_produto(db, exemplo, user_id=admin_user.id)
+            logger.info("Produto de exemplo criado para o administrador.")
+
     logger.info("Criação/verificação de dados iniciais concluída.")
 

--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ cd ..
 python run_backend.py       # Inicia o backend (http://localhost:8000)
 ```
 
+Após a primeira execução, o backend cria automaticamente um usuário administrador
+e um **produto de exemplo**. Utilize as credenciais definidas em `.env` para
+acessar a plataforma e visualizar esse item inicial.
+
 ---
 
 ### 4. **Configuração do Frontend**


### PR DESCRIPTION
## Summary
- generate a sample product in `create_initial_data`
- document the auto-created example product in the quickstart guide

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68462329f458832f998420c56bf8cecc