### PR TITLE
Fix search service logout issue

### DIFF
--- a/Frontend/app/src/services/searchService.js
+++ b/Frontend/app/src/services/searchService.js
@@ -3,7 +3,8 @@ import apiClient from './apiClient';
 const searchService = {
   async searchAll(term) {
     const params = term ? { q: term } : {};
-    const response = await apiClient.get('/search', { params });
+    // Include trailing slash to avoid redirect that might drop auth headers
+    const response = await apiClient.get('/search/', { params });
     return response.data;
   }
 };


### PR DESCRIPTION
## Summary
- keep auth header on search requests by using trailing slash

## Testing
- `pytest -k test_search_endpoint_returns_results -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68462b73378c832fa7d7dd52a330a8b3