### PR TITLE
Fix empty search on dashboard

### DIFF
--- a/Frontend/app/src/pages/DashboardPage.jsx
+++ b/Frontend/app/src/pages/DashboardPage.jsx
@@ -209,16 +209,26 @@ function DashboardPage() {
                   </tr>
                 </thead>
                 <tbody>
-                  {searchResults.map(item => (
-                    <tr key={item.id}>
-                      <td>{item.type}</td>
-                      <td style={{ fontWeight: 600 }}>{item.name}</td>
-                      <td>-</td>
-                      <td style={{ textAlign: 'right' }}>
-                        <button className="btn-detalhe">Ver Detalhes</button>
-                      </td>
-                    </tr>
-                  ))}
+                  {searchResults.length > 0 ? (
+                    searchResults.map(item => (
+                      <tr key={item.id}>
+                        <td>{item.type}</td>
+                        <td style={{ fontWeight: 600 }}>{item.name}</td>
+                        <td>-</td>
+                        <td style={{ textAlign: 'right' }}>
+                          <button className="btn-detalhe">Ver Detalhes</button>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    searchTerm.trim() !== '' && (
+                      <tr>
+                        <td colSpan="4" style={{ textAlign: 'center', padding: '20px' }}>
+                          Nenhum resultado encontrado.
+                        </td>
+                      </tr>
+                    )
+                  )}
                 </tbody>
               </table>
             </div>


### PR DESCRIPTION
## Summary
- show a message when the dashboard search yields no matches

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68462dc76b74832f8a10323a03c6237b