### PR TITLE
Improve dashboard search clearing

### DIFF
--- a/Frontend/app/src/pages/DashboardPage.jsx
+++ b/Frontend/app/src/pages/DashboardPage.jsx
@@ -57,8 +57,11 @@ function DashboardPage() {
 
   useEffect(() => {
     const doSearch = async () => {
+      // Clear previous results immediately so old data isn't shown
+      setSearchResults([]);
       try {
-        const data = await searchService.searchAll(searchTerm);
+        const trimmed = searchTerm.trim();
+        const data = await searchService.searchAll(trimmed);
         setSearchResults(Array.isArray(data.results) ? data.results : []);
       } catch (err) {
         console.error('Erro ao buscar:', err);

--- a/Frontend/app/src/services/searchService.js
+++ b/Frontend/app/src/services/searchService.js
@@ -2,7 +2,8 @@ import apiClient from './apiClient';
 
 const searchService = {
   async searchAll(term) {
-    const params = term ? { q: term } : {};
+    const trimmed = term ? term.trim() : '';
+    const params = trimmed ? { q: trimmed } : {};
     // Include trailing slash to avoid redirect that might drop auth headers
     const response = await apiClient.get('/search/', { params });
     return response.data;


### PR DESCRIPTION
## Summary
- reset search results when typing new query
- ignore whitespace-only searches in API call

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68462f039014832f841f539a590bf2fc