### PR TITLE
Disable edit tabs without product type

### DIFF
--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -471,10 +471,10 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
                 <div className="tab-navigation">
                     <button type="button" className={activeTab === 'info' ? 'active' : ''} onClick={() => setActiveTab('info')}>Info Principais</button>
                     <button type="button" className={activeTab === 'atributos' ? 'active' : ''} onClick={() => setActiveTab('atributos')} disabled={!formData.product_type_id}>Atributos</button>
-                    <button type="button" className={activeTab === 'midia' ? 'active' : ''} onClick={() => setActiveTab('midia')}>Mídia</button>
-                    <button type="button" className={activeTab === 'conteudo-ia' ? 'active' : ''} onClick={() => setActiveTab('conteudo-ia')}>Conteúdo IA</button>
-                    <button type="button" className={activeTab === 'sugestoes-ia' ? 'active' : ''} onClick={() => setActiveTab('sugestoes-ia')}>Sugestões IA</button> 
-                    <button type="button" className={activeTab === 'log' ? 'active' : ''} onClick={() => setActiveTab('log')}>Log</button>
+                    <button type="button" className={activeTab === 'midia' ? 'active' : ''} onClick={() => setActiveTab('midia')} disabled={!formData.product_type_id}>Mídia</button>
+                    <button type="button" className={activeTab === 'conteudo-ia' ? 'active' : ''} onClick={() => setActiveTab('conteudo-ia')} disabled={!formData.product_type_id}>Conteúdo IA</button>
+                    <button type="button" className={activeTab === 'sugestoes-ia' ? 'active' : ''} onClick={() => setActiveTab('sugestoes-ia')} disabled={!formData.product_type_id}>Sugestões IA</button>
+                    <button type="button" className={activeTab === 'log' ? 'active' : ''} onClick={() => setActiveTab('log')} disabled={!formData.product_type_id}>Log</button>
                 </div>
 
                 <div className="tab-content">
@@ -489,15 +489,19 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
                                     ))}
                                 </select>
                             </label>
-                            <label> Nome Base: <input type="text" name="nome_base" value={formData.nome_base} onChange={handleChange} required /> </label>
-                            <label> Marca: <input type="text" name="marca" value={formData.marca} onChange={handleChange} /> </label>
-                            <label> SKU: <input type="text" name="sku" value={formData.sku} onChange={handleChange} /> </label>
-                             <label> Fornecedor:
-                                <select name="fornecedor_id" value={formData.fornecedor_id} onChange={handleChange}>
-                                    <option value="">Selecione um fornecedor</option>
-                                    {fornecedores.map(f => (<option key={f.id} value={f.id}>{f.nome}</option>))}
-                                </select>
-                            </label>
+                            {formData.product_type_id && (
+                                <>
+                                    <label> Nome Base: <input type="text" name="nome_base" value={formData.nome_base} onChange={handleChange} required /> </label>
+                                    <label> Marca: <input type="text" name="marca" value={formData.marca} onChange={handleChange} /> </label>
+                                    <label> SKU: <input type="text" name="sku" value={formData.sku} onChange={handleChange} /> </label>
+                                    <label> Fornecedor:
+                                        <select name="fornecedor_id" value={formData.fornecedor_id} onChange={handleChange}>
+                                            <option value="">Selecione um fornecedor</option>
+                                            {fornecedores.map(f => (<option key={f.id} value={f.id}>{f.nome}</option>))}
+                                        </select>
+                                    </label>
+                                </>
+                            )}
                         </div>
                     )}
                     {activeTab === 'atributos' && (

--- a/Frontend/app/src/components/common/Modal.css
+++ b/Frontend/app/src/components/common/Modal.css
@@ -92,6 +92,11 @@
     font-weight: bold;
 }
 
+.tab-navigation button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
 .form-section {
     margin-bottom: 20px;
     padding: 15px;


### PR DESCRIPTION
## Summary
- only show info fields after product type is selected in product modal
- disable all other tabs until a product type is chosen
- style disabled tab buttons

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68463212ed7c832f9cd174d7afa79d9f