### PR TITLE
Adjust product edit layout

### DIFF
--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -452,7 +452,7 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
         <Modal isOpen={isOpen} onClose={onClose} title={isNewProduct ? "Criar Novo Produto" : `Editar Produto: ${formData.nome_base || 'ID ' + product?.id}`}>
             {stage === 'selectType' ? (
                 <div className="form-section" style={{padding:'1rem'}}>
-                    <label>
+                    <label className="full-width">
                         Tipo de Produto:
                         <select name="product_type_id" value={formData.product_type_id} onChange={handleChange} required>
                             <option value="">Selecione um tipo</option>
@@ -480,7 +480,7 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
                 <div className="tab-content">
                     {activeTab === 'info' && (
                         <div className="form-section form-grid">
-                            <label>
+                            <label className="full-width">
                                 Tipo de Produto:
                                 <select name="product_type_id" value={formData.product_type_id} onChange={handleChange} required>
                                     <option value="">Selecione um tipo</option>

--- a/Frontend/app/src/components/common/Modal.css
+++ b/Frontend/app/src/components/common/Modal.css
@@ -69,26 +69,23 @@
 }
 
 .tab-navigation button {
-    background-color: #f0f0f0;
-    border: 1px solid #ddd;
-    border-bottom: none;
+    background-color: transparent;
+    border: none;
+    border-bottom: 3px solid transparent;
     padding: 10px 15px;
     cursor: pointer;
     font-size: 0.9em;
-    border-top-left-radius: 5px;
-    border-top-right-radius: 5px;
     margin-right: 5px;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    transition: border-color 0.2s ease, color 0.2s ease;
 }
 
 .tab-navigation button:hover:not(.active) {
-    background-color: #e0e0e0;
+    color: #007bff;
 }
 
 .tab-navigation button.active {
-    background-color: #007bff;
-    color: white;
-    border-color: #007bff;
+    border-bottom-color: #007bff;
+    color: #007bff;
     font-weight: bold;
 }
 
@@ -288,4 +285,12 @@
 .form-grid label {
     display: flex;
     flex-direction: column;
+}
+
+.form-grid label.full-width {
+    grid-column: 1 / -1;
+}
+
+.form-grid label.full-width select {
+    width: 100%;
 }


### PR DESCRIPTION
## Summary
- adjust tab buttons to look like tabs
- allow the product type select to span full width

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm run lint --silent` *(fails: ESLint deps not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6846337a3f64832fb777add774cac32f