### PR TITLE
Add supplier catalog import functionality

### DIFF
--- a/Backend/crud_produtos.py
+++ b/Backend/crud_produtos.py
@@ -45,6 +45,19 @@ def create_produto(db: Session, produto: schemas.ProdutoCreate, user_id: int) ->
     return db_produto
 
 
+def create_produtos_bulk(db: Session, produtos: List[schemas.ProdutoCreate], user_id: int) -> List[Produto]:
+    """Cria múltiplos produtos em uma única transação."""
+    db_produtos: List[Produto] = []
+    for produto_schema in produtos:
+        db_produto = Produto(**produto_schema.model_dump(exclude_unset=True), user_id=user_id)
+        db.add(db_produto)
+        db_produtos.append(db_produto)
+    db.commit()
+    for p in db_produtos:
+        db.refresh(p)
+    return db_produtos
+
+
 def get_produto(db: Session, produto_id: int) -> Optional[Produto]:
     # Usar selectinload para carregar relacionamentos de forma eficiente se sempre forem acessados
     return db.query(Produto).options(

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -85,10 +85,29 @@ export const deleteFornecedor = async (fornecedorId) => {
   }
 };
 
+export const importCatalogo = async (fornecedorId, file) => {
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response = await apiClient.post(`/produtos/importar-catalogo/${fornecedorId}/`, formData);
+    return response.data;
+  } catch (error) {
+    console.error(`Erro ao importar catálogo para fornecedor ${fornecedorId}:`, JSON.stringify(error.response?.data || error.message || error));
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    } else if (error.request) {
+      throw new Error('Nenhuma resposta do servidor ao tentar importar catálogo.');
+    } else {
+      throw new Error(error.message || 'Erro ao configurar requisição de importação de catálogo.');
+    }
+  }
+};
+
 export default {
   getFornecedores,
   getFornecedorById,
   createFornecedor,
   updateFornecedor,
   deleteFornecedor,
+  importCatalogo,
 };


### PR DESCRIPTION
## Summary
- add bulk create helper for products
- allow importing product catalog for a supplier via new API endpoint
- expose importCatalogo on fornecedor service
- extend EditFornecedorModal with an Importar Catálogo tab

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846341da23c832fb2dfacf3aed5c08f