### PR TITLE
Show supplier field alongside product type selection

### DIFF
--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -479,6 +479,15 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
             ) : stage === 'selectType' ? (
                 <div className="form-section" style={{padding:'1rem'}}>
                     <label className="full-width">
+                        Fornecedor:
+                        <select name="fornecedor_id" value={formData.fornecedor_id} onChange={handleChange} required>
+                            <option value="">Selecione um fornecedor</option>
+                            {fornecedores.map(f => (
+                                <option key={f.id} value={f.id}>{f.nome}</option>
+                            ))}
+                        </select>
+                    </label>
+                    <label className="full-width">
                         Tipo de Produto:
                         <select name="product_type_id" value={formData.product_type_id} onChange={handleChange} required>
                             <option value="">Selecione um tipo</option>


### PR DESCRIPTION
## Summary
- keep supplier dropdown visible while selecting product type in ProductEditModal

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684636439708832f93f5ee56a0ade5b9