### PR TITLE
Adjust height for product type panels

### DIFF
--- a/Frontend/app/src/pages/TiposProdutoPage.css
+++ b/Frontend/app/src/pages/TiposProdutoPage.css
@@ -4,6 +4,9 @@
   padding: 20px;
   background-color: var(--main-bg);
   min-height: calc(100vh - 60px);
+  display: flex;
+  flex-direction: column;
+  height: 100%;
 }
 
 .tipos-produto-header {
@@ -45,7 +48,8 @@
   display: flex;
   gap: 1.5rem;
   align-items: stretch; /* Painéis ocupam toda a altura disponível */
-  min-height: calc(100vh - 160px); /* Altura aproximada da viewport sem a topbar e cabeçalho */
+  flex: 1;
+  overflow: hidden; /* Evita que painéis extravasem */
 }
 
 .type-list-panel {
@@ -73,7 +77,7 @@
 .type-list-panel ul {
   list-style-type: none;
   padding: 0;
-  max-height: 65vh;
+  flex: 1;
   overflow-y: auto;
 }
 
@@ -134,6 +138,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 }
 
 .panel-header {


### PR DESCRIPTION
## Summary
- stretch product type management panels to fill the viewport
- allow scrolling when lists exceed available space

## Testing
- `npm test --prefix Frontend/app` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684637393120832fa2e4fe94719f4f8e