### PR TITLE
Adjust height for product type panels

### DIFF
--- a/Frontend/app/src/index.css
+++ b/Frontend/app/src/index.css
@@ -513,7 +513,8 @@ tr:hover {
   border: 1px solid #ccc; border-radius: var(--radius); font-size: 1rem;
 }
 .modal-content textarea { resize: vertical; min-height: 100px; }
-.modal-content button[type="submit"], .modal-content button:not(.modal-close) { 
+.modal-content button[type="submit"],
+.modal-content button:not(.modal-close):not(.modal-close-button) {
   display: block; width: 100%; margin-top: 0.5rem;
   padding: 0.75rem; font-size: 1.05rem;
 }

--- a/Frontend/app/src/pages/TiposProdutoPage.css
+++ b/Frontend/app/src/pages/TiposProdutoPage.css
@@ -3,7 +3,10 @@
 .tipos-produto-container {
   padding: 20px;
   background-color: var(--main-bg);
-  min-height: calc(100vh - 60px);
+  height: calc(100vh - 60px); /* ocupa a altura da tela sem exceder */
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box; /* padding incluído na altura */
 }
 
 .tipos-produto-header {
@@ -45,7 +48,8 @@
   display: flex;
   gap: 1.5rem;
   align-items: stretch; /* Painéis ocupam toda a altura disponível */
-  min-height: calc(100vh - 160px); /* Altura aproximada da viewport sem a topbar e cabeçalho */
+  flex: 1;
+  overflow: hidden; /* Evita que painéis extravasem */
 }
 
 .type-list-panel {
@@ -73,7 +77,7 @@
 .type-list-panel ul {
   list-style-type: none;
   padding: 0;
-  max-height: 65vh;
+  flex: 1;
   overflow-y: auto;
 }
 
@@ -134,6 +138,7 @@
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow-y: auto;
 }
 
 .panel-header {


### PR DESCRIPTION
## Summary
- limit product type management container to viewport height
- keep panels stretched with scrolling for long lists
- fix modal close button width so it doesn't span the whole header

## Testing
- `npm test --prefix Frontend/app` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684637393120832fa2e4fe94719f4f8e