### PR TITLE
Fix React syntax error in ProductEditModal

### DIFF
--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -221,6 +221,7 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
                     showErrorToast('Erro ao carregar dados completos do produto.');
                     populateFormData(product);
                 }
+                }
             } else {
                 setFormData(initialFormData);
                 setIaAttributeSuggestions({});


### PR DESCRIPTION
## Summary
- fix missing closing brace in `ProductEditModal.jsx`

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68463c505000832fabc42642d915aeaf