### PR TITLE
Allow trailing slash for produto endpoint

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -80,6 +80,16 @@ def read_produto( # Nome da função mantido como no arquivo do usuário
         raise HTTPException(status_code=403, detail="Não autorizado a visualizar este produto")
     return db_produto
 
+# Também expõe a rota com barra ao final para evitar redirecionamentos que podem
+# levar à perda do cabeçalho Authorization em alguns clientes HTTP.
+router.add_api_route(
+    "/{produto_id}/",
+    read_produto,
+    methods=["GET"],
+    response_model=schemas.ProdutoResponse,
+    include_in_schema=False,
+)
+
 
 @router.get("/", response_model=schemas.ProdutoPage) # Este já estava correto
 def read_produtos( # Nome da função mantido como no arquivo do usuário


### PR DESCRIPTION
## Summary
- handle trailing slash on `/produtos/{produto_id}/` to avoid redirects that drop auth headers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68463da50cec832f967837174c20de89