### PR TITLE
Remove duplicate return from limit service

### DIFF
--- a/Backend/services/limit_service.py
+++ b/Backend/services/limit_service.py
@@ -80,8 +80,6 @@ def verificar_limite_uso(
     )
     return True
 
-    print(f"INFO: Verificação de limite para usuário {user.id} ({tipo_geracao_principal}): {usos_no_mes}/{limite_mensal} usos.")
-    return True
 
 
 async def verificar_creditos_disponiveis_geracao_ia(


### PR DESCRIPTION
## Summary
- clean up limit service function by removing stray print and return

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68473b9e1ae8832fa51a294cbbd4fee3