### PR TITLE
Fix logger usage in config

### DIFF
--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -11,7 +11,6 @@ from .logging_config import get_logger
 logger = get_logger(__name__)
 
 logging.basicConfig(level=logging.INFO)
-logger = logging.getLogger("tdai")
 
 dotenv_path = Path(__file__).resolve().parent.parent.parent / ".env"
 if dotenv_path.exists():


### PR DESCRIPTION
## Summary
- stop overwriting the logger instance in `Backend/core/config.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68473ba3757c832f9c23c557cedd0c01