### PR TITLE
Fix module logging in uso_ia router

### DIFF
--- a/Backend/routers/uso_ia.py
+++ b/Backend/routers/uso_ia.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from datetime import datetime # Necessário para filtros de data
-from Backend.core.config import logger
 
 from Backend import crud
 from Backend import crud_produtos


### PR DESCRIPTION
## Summary
- remove unused logger import from config
- keep per-module logger via `get_logger(__name__)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68473baa3970832fb6106b24f629d742