### PR TITLE
Fix SQLite check_same_thread

### DIFF
--- a/Backend/database.py
+++ b/Backend/database.py
@@ -8,7 +8,11 @@ from sqlalchemy.orm import sessionmaker
 # Então, importamos diretamente de 'core.config'.
 from Backend.core.config import settings #
 
-engine = create_engine(settings.DATABASE_URL)
+engine_args = {}
+if settings.DATABASE_URL.startswith("sqlite"):
+    engine_args["connect_args"] = {"check_same_thread": False}
+
+engine = create_engine(settings.DATABASE_URL, **engine_args)
 
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 


### PR DESCRIPTION
## Summary
- configure SQLAlchemy engine to handle SQLite threading

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68473bae8198832f92a599ab68098957