### PR TITLE
Fix duplicate password recovery logging

### DIFF
--- a/Backend/routers/password_recovery.py
+++ b/Backend/routers/password_recovery.py
@@ -36,7 +36,6 @@ async def recover_password(email: str, request: Request, db: Session = Depends(g
         # detail="O email fornecido não foi encontrado em nosso sistema.",
         # )
         # No entanto, para evitar enumeração de usuários, retornamos sucesso mesmo se não encontrado.
-        logger.info("Solicitação de recuperação de senha para email não registrado: %s", email)
         logger.info(
             "Solicitação de recuperação de senha para email não registrado: %s",
             email,


### PR DESCRIPTION
## Summary
- fix password recovery log spam by removing duplicate logger call

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68473f988e4c832f996188332df49101