### PR TITLE
Disable social login buttons until OAuth configured

### DIFF
--- a/Backend/routers/social_auth.py
+++ b/Backend/routers/social_auth.py
@@ -18,6 +18,15 @@ router = APIRouter()
 logger = get_logger(__name__)
 
 
+@router.get("/social/config", response_model=schemas.SocialLoginConfig)
+async def social_login_config():
+    """Retorna se Google/Facebook OAuth estão configurados."""
+    return schemas.SocialLoginConfig(
+        google_enabled="google" in oauth._clients,
+        facebook_enabled="facebook" in oauth._clients,
+    )
+
+
 @router.get("/google/login")
 async def google_login(request: Request):
     """Redirects the user to Google's OAuth consent page."""

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -429,6 +429,12 @@ class FileProcessResponse(BaseModel):
     size_bytes: Optional[int] = None
 
 
+class SocialLoginConfig(BaseModel):
+    """Indica quais provedores de login social estão configurados."""
+    google_enabled: bool
+    facebook_enabled: bool
+
+
 # --- Rebuilds Finais ---
 UserResponse.model_rebuild()
 PlanoResponse.model_rebuild()
@@ -439,4 +445,5 @@ ProductTypeResponse.model_rebuild()
 ProdutoResponse.model_rebuild()
 RegistroUsoIAResponse.model_rebuild()
 UserActivity.model_rebuild()
+SocialLoginConfig.model_rebuild()
 

--- a/Frontend/app/src/pages/LoginPage.css
+++ b/Frontend/app/src/pages/LoginPage.css
@@ -122,3 +122,9 @@
 .social-login-button:hover {
   filter: brightness(90%);
 }
+
+.social-login-button.disabled {
+  background-color: #9ca3af;
+  cursor: not-allowed;
+  pointer-events: none;
+}

--- a/Frontend/app/src/pages/LoginPage.jsx
+++ b/Frontend/app/src/pages/LoginPage.jsx
@@ -5,12 +5,14 @@ import { toast } from 'react-toastify';
 import './LoginPage.css';
 import { FaGoogle, FaFacebookF } from 'react-icons/fa';
 import logger from '../utils/logger';
+import configService from '../services/configService';
 
 const LoginPage = () => {
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
     const [error, setError] = useState('');
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [socialConfig, setSocialConfig] = useState({ google_enabled: false, facebook_enabled: false });
     const { login, isAuthenticated, isLoading: authIsLoading, user } = useAuth();
     const navigate = useNavigate();
     const location = useLocation();
@@ -23,6 +25,18 @@ const LoginPage = () => {
             navigate(from, { replace: true });
         }
     }, [isAuthenticated, authIsLoading, navigate, location.state]);
+
+    useEffect(() => {
+        async function fetchSocialConfig() {
+            try {
+                const cfg = await configService.getSocialLoginConfig();
+                setSocialConfig(cfg);
+            } catch (err) {
+                console.error('LoginPage: Erro ao obter config de social login', err);
+            }
+        }
+        fetchSocialConfig();
+    }, []);
 
     const handleSubmit = async (e) => {
         e.preventDefault();
@@ -87,10 +101,20 @@ const LoginPage = () => {
                         {isSubmitting ? 'Entrando...' : 'Entrar'}
                     </button>
                     <div className="social-login-buttons">
-                        <a href="/api/v1/auth/google/login" className="social-login-button google-btn" title="Entrar com Google">
+                        <a
+                            href={socialConfig.google_enabled ? "/api/v1/auth/google/login" : undefined}
+                            className={`social-login-button google-btn ${socialConfig.google_enabled ? '' : 'disabled'}`}
+                            title={socialConfig.google_enabled ? "Entrar com Google" : "Login Google indisponível"}
+                            onClick={(e) => { if (!socialConfig.google_enabled) e.preventDefault(); }}
+                        >
                             <FaGoogle /> Entrar com Google
                         </a>
-                        <a href="/api/v1/auth/facebook/login" className="social-login-button facebook-btn" title="Entrar com Facebook">
+                        <a
+                            href={socialConfig.facebook_enabled ? "/api/v1/auth/facebook/login" : undefined}
+                            className={`social-login-button facebook-btn ${socialConfig.facebook_enabled ? '' : 'disabled'}`}
+                            title={socialConfig.facebook_enabled ? "Entrar com Facebook" : "Login Facebook indisponível"}
+                            onClick={(e) => { if (!socialConfig.facebook_enabled) e.preventDefault(); }}
+                        >
                             <FaFacebookF /> Entrar com Facebook
                         </a>
                     </div>

--- a/Frontend/app/src/services/configService.js
+++ b/Frontend/app/src/services/configService.js
@@ -1,0 +1,17 @@
+import apiClient from './apiClient';
+import logger from '../utils/logger';
+
+const configService = {
+  async getSocialLoginConfig() {
+    try {
+      const response = await apiClient.get('/auth/social/config');
+      logger.log('configService: social login config', response.data);
+      return response.data;
+    } catch (error) {
+      console.error('configService: error fetching social login config', error.response?.data || error.message);
+      return { google_enabled: false, facebook_enabled: false };
+    }
+  }
+};
+
+export default configService;


### PR DESCRIPTION
## Summary
- expose backend endpoint to report OAuth status
- add SocialLoginConfig schema
- disable Google/Facebook buttons on login page when providers aren't configured
- style disabled social login buttons
- add front-end service to fetch social login config

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68473a722d38832fbdf6f351b2d32437