### PR TITLE
Fix duplicate magic import

### DIFF
--- a/Backend/routers/uploads.py
+++ b/Backend/routers/uploads.py
@@ -5,8 +5,7 @@ import shutil
 import os
 from Backend.core.config import logger
 from pathlib import Path
-import imghdr # Para detectar o tipo MIME de imagem
-import magic # Para detectar o tipo MIME de forma mais robusta (requer python-magic)
+import imghdr  # Para detectar o tipo MIME de imagem
 
 # --- IMPORTS ALTERADOS ---
 from Backend.database import get_db


### PR DESCRIPTION
## Summary
- avoid unconditional `import magic` in uploads router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684740d91b44832fa09b277d2b14d229