### PR TITLE
Remove extra logging line

### DIFF
--- a/Backend/routers/password_recovery.py
+++ b/Backend/routers/password_recovery.py
@@ -36,10 +36,6 @@ async def recover_password(email: str, request: Request, db: Session = Depends(g
         # detail="O email fornecido não foi encontrado em nosso sistema.",
         # )
         # No entanto, para evitar enumeração de usuários, retornamos sucesso mesmo se não encontrado.
-        logger.info(
-            "Solicitação de recuperação de senha para email não registrado: %s",
-            email,
-        )
         return {"msg": "Se um usuário com este email existir, um link de recuperação foi enviado."}
 
 


### PR DESCRIPTION
## Summary
- clean up duplicate logging message in `recover_password`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684740d30f88832fab06a5ebcb313713