### PR TITLE
Clean up logger imports

### DIFF
--- a/Backend/auth.py
+++ b/Backend/auth.py
@@ -16,7 +16,6 @@ from Backend.core.config import settings, pwd_context
 from Backend.core.logging_config import get_logger
 
 logger = get_logger(__name__)
-from Backend.core.config import settings, pwd_context, logger
 
 from Backend import schemas
 from Backend import models

--- a/Backend/core/email_utils.py
+++ b/Backend/core/email_utils.py
@@ -5,7 +5,6 @@ from typing import List, Dict, Any, Optional # Adicionado Optional
 from pathlib import Path
 from .config import settings # Importa as configurações (settings)
 from .logging_config import get_logger
-from .config import settings, logger  # Importa as configurações (settings) e logger
 
 # Removido import desnecessário de auth que estava no arquivo do usuário
 # import auth # Cuidado com import circular se auth importar email_utils

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -41,7 +41,6 @@ try:
 except Exception as e:
     logger.error(f"Erro ao criar tabelas: {e}")
 
-from Backend.core.config import logger
 
 
 try:

--- a/Backend/routers/admin_analytics.py
+++ b/Backend/routers/admin_analytics.py
@@ -3,7 +3,6 @@ from typing import List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, status
 from sqlalchemy.orm import Session
 from sqlalchemy import func, cast, String # Importar cast e String
-from Backend.core.config import logger
 from datetime import datetime, timedelta, timezone 
 
 from Backend import crud

--- a/Backend/routers/product_types.py
+++ b/Backend/routers/product_types.py
@@ -10,7 +10,6 @@ from Backend import schemas
 from Backend import database
 from . import auth_utils
 from Backend.core.logging_config import get_logger
-from Backend.core.config import logger
 
 router = APIRouter(
     prefix="/product-types",

--- a/Backend/routers/uploads.py
+++ b/Backend/routers/uploads.py
@@ -3,7 +3,6 @@ from fastapi.responses import JSONResponse
 from typing import List, Optional
 import shutil
 import os
-from Backend.core.config import logger
 from pathlib import Path
 import imghdr # Para detectar o tipo MIME de imagem
 import magic # Para detectar o tipo MIME de forma mais robusta (requer python-magic)


### PR DESCRIPTION
## Summary
- drop deprecated `logger` import from config
- ensure modules use local `get_logger(__name__)`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68473f948598832fbfaf7e2b5fd2dce8