### PR TITLE
Implement RegistroUsoIA CRUD and fix usage

### DIFF
--- a/Backend/crud.py
+++ b/Backend/crud.py
@@ -2,4 +2,5 @@ from .crud_users import *
 from .crud_fornecedores import *
 from .crud_produtos import *
 from .crud_product_types import *
+from .crud_registros_uso_ia import *
 from .initial_data import create_initial_data

--- a/Backend/crud_registros_uso_ia.py
+++ b/Backend/crud_registros_uso_ia.py
@@ -1,0 +1,107 @@
+from datetime import datetime
+from typing import List, Optional
+
+from sqlalchemy import func
+from sqlalchemy.orm import Session
+
+from Backend import models, schemas
+
+
+def create_registro_uso_ia(db: Session, registro_uso: schemas.RegistroUsoIACreate) -> models.RegistroUsoIA:
+    db_obj = models.RegistroUsoIA(**registro_uso.model_dump(exclude_unset=True))
+    db.add(db_obj)
+    db.commit()
+    db.refresh(db_obj)
+    return db_obj
+
+
+def get_registros_uso_ia(
+    db: Session,
+    user_id: int,
+    skip: int = 0,
+    limit: int = 100,
+    tipo_acao: Optional[str] = None,
+    data_inicio: Optional[datetime] = None,
+    data_fim: Optional[datetime] = None,
+) -> List[models.RegistroUsoIA]:
+    query = db.query(models.RegistroUsoIA).filter(models.RegistroUsoIA.user_id == user_id)
+    if tipo_acao:
+        query = query.filter(models.RegistroUsoIA.tipo_acao == tipo_acao)
+    if data_inicio:
+        query = query.filter(models.RegistroUsoIA.created_at >= data_inicio)
+    if data_fim:
+        query = query.filter(models.RegistroUsoIA.created_at <= data_fim)
+    return (
+        query.order_by(models.RegistroUsoIA.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+def count_registros_uso_ia(
+    db: Session,
+    user_id: int,
+    tipo_acao: Optional[str] = None,
+    data_inicio: Optional[datetime] = None,
+    data_fim: Optional[datetime] = None,
+) -> int:
+    query = db.query(func.count(models.RegistroUsoIA.id)).filter(models.RegistroUsoIA.user_id == user_id)
+    if tipo_acao:
+        query = query.filter(models.RegistroUsoIA.tipo_acao == tipo_acao)
+    if data_inicio:
+        query = query.filter(models.RegistroUsoIA.created_at >= data_inicio)
+    if data_fim:
+        query = query.filter(models.RegistroUsoIA.created_at <= data_fim)
+    return query.scalar() or 0
+
+
+def get_usos_ia_by_produto(
+    db: Session,
+    produto_id: int,
+    user_id: int,
+    skip: int = 0,
+    limit: int = 100,
+) -> List[models.RegistroUsoIA]:
+    return (
+        db.query(models.RegistroUsoIA)
+        .filter(
+            models.RegistroUsoIA.produto_id == produto_id,
+            models.RegistroUsoIA.user_id == user_id,
+        )
+        .order_by(models.RegistroUsoIA.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+
+
+def count_usos_ia_by_user_and_type_no_mes_corrente(
+    db: Session,
+    user_id: int,
+    tipo_geracao_prefix: str,
+) -> int:
+    inicio_mes = datetime.utcnow().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    return (
+        db.query(func.count(models.RegistroUsoIA.id))
+        .filter(
+            models.RegistroUsoIA.user_id == user_id,
+            models.RegistroUsoIA.created_at >= inicio_mes,
+            models.RegistroUsoIA.tipo_acao.ilike(f"{tipo_geracao_prefix}%"),
+        )
+        .scalar()
+        or 0
+    )
+
+
+def get_geracoes_ia_count_no_mes_corrente(db: Session, user_id: int) -> int:
+    inicio_mes = datetime.utcnow().replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    return (
+        db.query(func.count(models.RegistroUsoIA.id))
+        .filter(
+            models.RegistroUsoIA.user_id == user_id,
+            models.RegistroUsoIA.created_at >= inicio_mes,
+        )
+        .scalar()
+        or 0
+    )

--- a/Backend/services/limit_service.py
+++ b/Backend/services/limit_service.py
@@ -34,11 +34,11 @@ def verificar_limite_uso(
     limite_mensal = 0
 
     if tipo_geracao_principal == "descricao":
-        limite_mensal = user.plano.max_descricoes_mes
+        limite_mensal = getattr(user.plano, "max_descricoes_mes", user.plano.limite_geracao_ia)
         tipo_geracao_prefix_db = "descricao"
-        
+
     elif tipo_geracao_principal == "titulo":
-        limite_mensal = user.plano.max_titulos_mes
+        limite_mensal = getattr(user.plano, "max_titulos_mes", user.plano.limite_geracao_ia)
         tipo_geracao_prefix_db = "titulo"
     else:
         logger.warning(

--- a/Backend/services/web_data_extractor_service.py
+++ b/Backend/services/web_data_extractor_service.py
@@ -244,13 +244,19 @@ async def extrair_dados_produto_com_llm(
 
     try:
         # A função call_openai_api está em ia_generation_service
+        prompt_messages = [
+            {
+                "role": "system",
+                "content": "Sua tarefa é extrair informações de um texto e retorná-las em formato JSON conforme o schema solicitado. Seja preciso e não adicione campos extras.",
+            },
+            {"role": "user", "content": prompt},
+        ]
         json_str_resposta = await ia_generation_service.call_openai_api(
-            prompt=prompt,
+            prompt_messages=prompt_messages,
             api_key=api_key_para_usar,
             model="gpt-3.5-turbo-0125", # Exemplo de modelo, pode ser configurável
             max_tokens=2048, # Ajustar conforme necessidade
             temperature=0.0, # Baixa temperatura para extração factual
-            system_message="Sua tarefa é extrair informações de um texto e retorná-las em formato JSON conforme o schema solicitado. Seja preciso e não adicione campos extras."
         )
         
         # Tentativa de limpar a resposta da LLM para pegar apenas o JSON


### PR DESCRIPTION
## Summary
- add CRUD helpers for RegistroUsoIA
- expose new helpers from `crud` package
- fix limit service to handle missing plan fields
- correct OpenAI call in web data extractor

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684742976430832f8205520ee398f30b