### PR TITLE
Fix import for admin analytics

### DIFF
--- a/Backend/routers/admin_analytics.py
+++ b/Backend/routers/admin_analytics.py
@@ -6,6 +6,7 @@ from sqlalchemy import func, cast, String  # Importar cast e String
 from datetime import datetime, timedelta, timezone
 
 from Backend import crud
+from Backend import crud_users
 from Backend import models
 from Backend import schemas
 from Backend.database import get_db


### PR DESCRIPTION
## Summary
- add missing `crud_users` import to `admin_analytics`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68474cdf4cac832fba9730afc171d3c2