### PR TITLE
Fix refresh token key usage

### DIFF
--- a/Backend/auth.py
+++ b/Backend/auth.py
@@ -106,7 +106,7 @@ def create_refresh_token(data: dict, expires_delta: Optional[timedelta] = None) 
     else:
         expire = datetime.now(timezone.utc) + timedelta(days=settings.REFRESH_TOKEN_EXPIRE_DAYS)
     to_encode.update({"exp": expire, "iat": datetime.now(timezone.utc)})
-    encoded_jwt = jwt.encode(to_encode, settings.SECRET_KEY, algorithm=settings.ALGORITHM)
+    encoded_jwt = jwt.encode(to_encode, settings.REFRESH_SECRET_KEY, algorithm=settings.ALGORITHM)
     return encoded_jwt
 
 def create_password_reset_token() -> str:
@@ -202,7 +202,7 @@ async def refresh_access_token(
             headers={"WWW-Authenticate": "Bearer"},
         )
     try:
-        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.ALGORITHM])
+        payload = jwt.decode(token, settings.REFRESH_SECRET_KEY, algorithms=[settings.ALGORITHM])
         email: Optional[str] = payload.get("sub")
         user_id: Optional[int] = payload.get("user_id")
         if email is None or user_id is None:


### PR DESCRIPTION
## Summary
- use REFRESH_SECRET_KEY when encoding refresh tokens
- decode refresh tokens with REFRESH_SECRET_KEY in refresh access endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68474ce33dec832f8d87bdb7ceda354a