### PR TITLE
Fix README env example

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,10 +277,6 @@ DATABASE_URL="postgresql://usuario:senha@localhost:5432/tdai_db"
 # Segurança
 SECRET_KEY="sua_chave_forte"
 
- codex/add-configuration-variables-to-config.py
-REFRESH_SECRET_KEY="sua_chave_refresh"
-
-REFRESH_SECRET_KEY="change-me"
 REFRESH_SECRET_KEY="sua_chave_refresh_forte"
 
 ALGORITHM="HS256"
@@ -319,7 +315,7 @@ ADMIN_EMAIL="admin@email.com"
 ADMIN_PASSWORD="adminpassword"
 FIRST_SUPERUSER_EMAIL="admin@example.com"
 FIRST_SUPERUSER_PASSWORD="adminpassword"
-```Dev
+```
 
 > ⚠️ **Nunca suba arquivos `.env` com dados sensíveis para o git!**
 


### PR DESCRIPTION
## Summary
- clean up `.env` example section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68474eeac194832f86c1b03ff4d9b6d3