### PR TITLE
Fix query.get deprecation in admin analytics

### DIFF
--- a/Backend/routers/admin_analytics.py
+++ b/Backend/routers/admin_analytics.py
@@ -151,7 +151,7 @@ async def get_recent_activities(db: Session = Depends(get_db), limit: int = Quer
     registros = db.query(models.RegistroUsoIA).order_by(models.RegistroUsoIA.created_at.desc()).limit(limit).all()
     activities = []
     for reg in registros:
-        user = db.query(models.User).get(reg.user_id)
+        user = db.get(models.User, reg.user_id)
         activities.append(
             schemas.RecentActivity(
                 id=reg.id,


### PR DESCRIPTION
## Summary
- avoid deprecated `query.get` usage when fetching user inside admin analytics

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68474eed1148832f8f1411562a8be49b