### PR TITLE
Allow admin to fetch IA usage of any product

### DIFF
--- a/Backend/routers/uso_ia.py
+++ b/Backend/routers/uso_ia.py
@@ -123,5 +123,12 @@ def read_usos_ia_por_produto(
         raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Não autorizado a ver usos de IA para este produto")
         
     # A função no CRUD foi nomeada como get_usos_ia_by_produto
-    usos = crud.get_usos_ia_by_produto(db, produto_id=produto_id, user_id=current_user.id, skip=skip, limit=limit)
+    query_user_id = produto.user_id if current_user.is_superuser else current_user.id
+    usos = crud.get_usos_ia_by_produto(
+        db,
+        produto_id=produto_id,
+        user_id=query_user_id,
+        skip=skip,
+        limit=limit,
+    )
     return usos

--- a/tests/test_uso_ia.py
+++ b/tests/test_uso_ia.py
@@ -1,0 +1,71 @@
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from Backend.main import app
+from Backend.database import Base, get_db
+from Backend import crud, crud_users, crud_produtos, schemas, models
+from Backend.main import create_new_user
+from Backend.core.config import settings
+
+# disable heavy startup events
+app.router.on_startup.clear()
+
+engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(bind=engine)
+Base.metadata.create_all(bind=engine)
+
+# override dependency
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+# setup initial data
+with TestingSessionLocal() as db:
+    crud.create_initial_data(db)
+    user_in = schemas.UserCreate(
+        email="user@example.com",
+        password="secret",
+        nome_completo="Normal User",
+    )
+    normal_user = create_new_user(user_in=user_in, db=db)
+    produto = crud_produtos.create_produto(db, schemas.ProdutoCreate(nome_base="TesteProd"), user_id=normal_user.id)
+    crud.create_registro_uso_ia(
+        db,
+        schemas.RegistroUsoIACreate(
+            user_id=normal_user.id,
+            produto_id=produto.id,
+            tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO,
+        ),
+    )
+
+
+def get_admin_headers():
+    resp = client.post(
+        "/api/v1/auth/token",
+        data={"username": settings.FIRST_SUPERUSER_EMAIL, "password": settings.FIRST_SUPERUSER_PASSWORD},
+    )
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_admin_can_view_usos_ia_of_other_user_product():
+    headers = get_admin_headers()
+    # get product id created earlier
+    with TestingSessionLocal() as db:
+        produto = db.query(models.Produto).filter(models.Produto.nome_base == "TesteProd").first()
+    resp = client.get(f"/api/v1/uso-ia/por-produto/{produto.id}", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 1
+    assert data[0]["produto_id"] == produto.id


### PR DESCRIPTION
## Summary
- fix IA usage router for admin users
- test admin usage retrieval for other user's product

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68475305ee78832f80a1603ed3ed86b6