### PR TITLE
Add userId to change password flow

### DIFF
--- a/Frontend/app/src/components/user/ChangePasswordModal.jsx
+++ b/Frontend/app/src/components/user/ChangePasswordModal.jsx
@@ -2,8 +2,12 @@
 import React, { useState } from 'react';
 import authService from '../../services/authService'; // Ajuste o caminho se o seu authService estiver noutro local
 import { showSuccessToast, showErrorToast } from '../../utils/notifications'; // Ajuste o caminho se necessário
+import { useAuth } from '../../contexts/AuthContext';
 
-function ChangePasswordModal({ isOpen, onClose }) {
+function ChangePasswordModal({ isOpen, onClose, userId: propUserId }) {
+  const { user } = useAuth();
+  const userId = propUserId || user?.id;
+
   const [passwordData, setPasswordData] = useState({
     current_password: '',
     new_password: '',
@@ -22,6 +26,10 @@ function ChangePasswordModal({ isOpen, onClose }) {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (!userId) {
+      showErrorToast('Usuário não identificado.');
+      return;
+    }
     if (passwordData.new_password !== passwordData.confirm_new_password) {
       showErrorToast('A nova senha e a confirmação não coincidem.');
       return;
@@ -38,7 +46,7 @@ function ChangePasswordModal({ isOpen, onClose }) {
         current_password: passwordData.current_password,
         new_password: passwordData.new_password
       };
-      const response = await authService.changePassword(payload);
+      const response = await authService.changePassword(userId, payload);
       showSuccessToast(response.message || 'Senha alterada com sucesso!');
       clearForm();
       onClose(); // Fecha o modal após o sucesso

--- a/Frontend/app/src/pages/ConfiguracoesPage.jsx
+++ b/Frontend/app/src/pages/ConfiguracoesPage.jsx
@@ -3,8 +3,10 @@ import React, { useState, useEffect } from 'react';
 import authService from '../services/authService';
 import { showSuccessToast, showErrorToast } from '../utils/notifications';
 import ChangePasswordModal from '../components/user/ChangePasswordModal'; // Importar o novo modal
+import { useAuth } from '../contexts/AuthContext';
 
 function ConfiguracoesPage() {
+  const { user } = useAuth();
   const [profileData, setProfileData] = useState({
     nome: '',
     email: '',
@@ -150,9 +152,10 @@ function ConfiguracoesPage() {
         </button>
       </div>
 
-      <ChangePasswordModal 
+      <ChangePasswordModal
         isOpen={isChangePasswordModalOpen}
         onClose={handleCloseChangePasswordModal}
+        userId={user?.id}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- get user id from context or prop in `ChangePasswordModal`
- pass userId from `ConfiguracoesPage` to the modal
- use the userId when calling authService.changePassword

## Testing
- `npm run lint` *(fails: cannot find @eslint/js)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684755d34364832f8bde37d67c8376bb