### PR TITLE
Fix attribute template router calls and update test

### DIFF
--- a/Backend/routers/product_types.py
+++ b/Backend/routers/product_types.py
@@ -303,7 +303,11 @@ def add_attribute_to_product_type_endpoint(
             detail=f"Um atributo com a chave '{attribute_in.attribute_key}' já existe para este tipo de produto."
         )
     
-    new_attribute = crud_product_types.create_attribute_template(db=db, attribute_template_data=attribute_in, product_type_id=type_id, user_id=current_user.id)
+    new_attribute = crud_product_types.create_attribute_template(
+        db=db,
+        attr_template_create=attribute_in,
+        product_type_id=type_id,
+    )
     logger.info(
         "ROUTER (add_attribute): Atributo '%s' adicionado ao tipo ID %s.",
         new_attribute.label,
@@ -350,7 +354,11 @@ def update_attribute_for_product_type_endpoint(
                 detail=f"Um atributo com a nova chave '{attribute_in.attribute_key}' já existe para este tipo de produto."
             )
 
-    updated_attribute = crud_product_types.update_attribute_template(db=db, attribute_template_id=attribute_id, attribute_template_data=attribute_in, user_id=current_user.id)
+    updated_attribute = crud_product_types.update_attribute_template(
+        db=db,
+        db_attr_template=db_attribute_to_check,
+        attr_template_update=attribute_in,
+    )
     if not updated_attribute:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Falha ao atualizar o atributo.")
 
@@ -387,7 +395,10 @@ def remove_attribute_from_product_type_endpoint(
     if not db_attribute_to_check or db_attribute_to_check.product_type_id != type_id:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Atributo não encontrado ou não pertence ao tipo de produto especificado para deleção.")
 
-    deleted_attribute = crud_product_types.delete_attribute_template(db=db, attribute_template_id=attribute_id, user_id=current_user.id)
+    deleted_attribute = crud_product_types.delete_attribute_template(
+        db=db,
+        db_attr_template=db_attribute_to_check,
+    )
     if not deleted_attribute: 
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Falha ao deletar o atributo.")
 

--- a/Backend/tests/test_health.py
+++ b/Backend/tests/test_health.py
@@ -1,5 +1,5 @@
 from fastapi.testclient import TestClient
-from main import app
+from Backend.main import app
 
 client = TestClient(app)
 


### PR DESCRIPTION
## Summary
- update router attribute CRUD calls to use correct parameters
- update health test import path

## Testing
- `pytest -q Backend/tests/test_health.py` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684756dd9670832fa00fe5fdf6803e83