### PR TITLE
Fix AttributeField import path

### DIFF
--- a/Frontend/app/src/components/ProductModal.jsx
+++ b/Frontend/app/src/components/ProductModal.jsx
@@ -7,7 +7,7 @@ import { showSuccessToast, showErrorToast, showInfoToast, showWarningToast } fro
 import productService from '../../services/productService';
 import fornecedorService from '../../services/fornecedorService';
 // Ajuste do caminho para o componente de atributo
-import AttributeField from './produtos/shared/AttributeField';
+import AttributeField from '../components/produtos/shared/AttributeField';
 import { useProductTypes } from '../../contexts/ProductTypeContext';
 import '../ProductEditModal.css';
 


### PR DESCRIPTION
## Summary
- correct AttributeField import path in ProductModal.jsx

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684757cee33c832fbf11b1f62089e3d3