### PR TITLE
Fix password recovery router prefix

### DIFF
--- a/Backend/routers/password_recovery.py
+++ b/Backend/routers/password_recovery.py
@@ -15,7 +15,7 @@ from Backend.core.logging_config import get_logger
 from Backend.auth import create_password_reset_token, hash_password_reset_token
 
 router = APIRouter(
-    prefix="/api/v1/auth", # Mantendo o prefixo como no arquivo original, se for este
+    prefix="/auth",  # Prefixo reduzido; '/api/v1' será adicionado em main.py
     tags=["password-recovery"],
 )
 


### PR DESCRIPTION
## Summary
- correct the router prefix for password recovery so `/api/v1` isn't duplicated

## Testing
- `pip install -r requirements-backend.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684757fc441c832fb7fc5b50fed56ad6