### PR TITLE
Use absolute import in backend health test

### DIFF
--- a/Backend/tests/test_health.py
+++ b/Backend/tests/test_health.py
@@ -1,4 +1,5 @@
 from fastapi.testclient import TestClient
+# Use absolute import so tests run correctly regardless of working directory
 from Backend.main import app
 
 client = TestClient(app)


### PR DESCRIPTION
## Summary
- ensure health test uses absolute import from Backend.main

## Testing
- `pytest Backend/tests/test_health.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_684757fa47e4832f95d9ac0ee683d8e5