### PR TITLE
Update ChangePasswordModal to use userId from context

### DIFF
--- a/Frontend/app/src/components/user/ChangePasswordModal.jsx
+++ b/Frontend/app/src/components/user/ChangePasswordModal.jsx
@@ -6,7 +6,7 @@ import { useAuth } from '../../contexts/AuthContext';
 
 function ChangePasswordModal({ isOpen, onClose, userId: propUserId }) {
   const { user } = useAuth();
-  const userId = propUserId || user?.id;
+  const userId = propUserId ?? user?.id;
 
   const [passwordData, setPasswordData] = useState({
     current_password: '',


### PR DESCRIPTION
## Summary
- refine userId retrieval in ChangePasswordModal

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684757ceb5e4832fbcb1eedbe6fcf2b3