### PR TITLE
Use updateUser with authenticated ID

### DIFF
--- a/Frontend/app/src/pages/ConfiguracoesPage.jsx
+++ b/Frontend/app/src/pages/ConfiguracoesPage.jsx
@@ -13,7 +13,6 @@ function ConfiguracoesPage() {
     idioma_preferido: 'pt',
     chave_openai_pessoal: ''
   });
-  const [userId, setUserId] = useState(null);
   const [loadingProfile, setLoadingProfile] = useState(false);
   const [initialUserDataLoaded, setInitialUserDataLoaded] = useState(false);
   const [isChangePasswordModalOpen, setIsChangePasswordModalOpen] = useState(false);
@@ -25,7 +24,6 @@ function ConfiguracoesPage() {
       try {
         const user = await authService.getCurrentUser();
         if (user) {
-          setUserId(user.id);
           setProfileData({
             nome: user.nome || '',
             email: user.email || '',
@@ -59,7 +57,7 @@ function ConfiguracoesPage() {
         chave_openai_pessoal: profileData.chave_openai_pessoal
       };
       
-      const updatedUser = await authService.updateUser(userId, updatePayload);
+      const updatedUser = await authService.updateUser(user.id, updatePayload);
       showSuccessToast('Perfil atualizado com sucesso!');
       if (updatedUser) {
           setProfileData(prev => ({


### PR DESCRIPTION
## Summary
- update profile function to call `authService.updateUser` with `user.id`
- drop unused `userId` state

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` within frontend *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684757ce3b2c832fb93dfb7b504d6c40