### PR TITLE
Ensure /auth prefix for password recovery routes

### DIFF
--- a/Backend/routers/password_recovery.py
+++ b/Backend/routers/password_recovery.py
@@ -15,7 +15,7 @@ from Backend.core.logging_config import get_logger
 from Backend.auth import create_password_reset_token, hash_password_reset_token
 
 router = APIRouter(
-    prefix="/auth",  # Prefixo reduzido; '/api/v1' será adicionado em main.py
+    prefix="/auth",
     tags=["password-recovery"],
 )
 


### PR DESCRIPTION
## Summary
- ensure `password_recovery` router uses `/auth` prefix

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847598b2ad0832f87af6be8fcbbdb7c