### PR TITLE
Fix AttributeField import

### DIFF
--- a/Frontend/app/src/components/ProductModal.jsx
+++ b/Frontend/app/src/components/ProductModal.jsx
@@ -7,7 +7,7 @@ import { showSuccessToast, showErrorToast, showInfoToast, showWarningToast } fro
 import productService from '../../services/productService';
 import fornecedorService from '../../services/fornecedorService';
 // Ajuste do caminho para o componente de atributo
-import AttributeField from '../components/produtos/shared/AttributeField';
+import AttributeField from './produtos/shared/AttributeField';
 import { useProductTypes } from '../../contexts/ProductTypeContext';
 import '../ProductEditModal.css';
 


### PR DESCRIPTION
## Summary
- fix import path for `AttributeField` in `ProductModal.jsx`

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68475b7ea104832f9ee60063344d7c92