### PR TITLE
Normalize field_type comparisons

### DIFF
--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -265,7 +265,7 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
             selectedType.attribute_templates
                 .filter(tpl => !BASE_PRODUCT_FIELDS.has(tpl.attribute_key))
                 .forEach(template => {
-                    const typeLower = template.field_type ? String(template.field_type).toLowerCase() : '';
+                    const typeLower = template.field_type ? template.field_type.toLowerCase() : '';
                     if (template.default_value !== null && template.default_value !== undefined) {
                         initialAttrs[template.attribute_key] = typeLower === 'boolean'
                             ? (String(template.default_value).toLowerCase() === 'true' || template.default_value === '1')

--- a/Frontend/app/src/components/produtos/NewProductModal.jsx
+++ b/Frontend/app/src/components/produtos/NewProductModal.jsx
@@ -73,7 +73,7 @@ function NewProductModal({
       const initializeAttributes = (templates) => {
         const initialAttrs = {};
         templates.forEach(template => {
-          const typeLower = template.field_type ? String(template.field_type).toLowerCase() : '';
+          const typeLower = template.field_type ? template.field_type.toLowerCase() : '';
           if (template.default_value !== null && template.default_value !== undefined) {
             initialAttrs[template.attribute_key] = typeLower === 'boolean'
               ? (String(template.default_value).toLowerCase() === 'true' || template.default_value === '1')

--- a/Frontend/app/src/components/produtos/shared/AttributeField.jsx
+++ b/Frontend/app/src/components/produtos/shared/AttributeField.jsx
@@ -25,7 +25,7 @@ function AttributeField({ attributeTemplate, value, onChange, disabled = false }
     default_value // default_value vem do template
   } = attributeTemplate;
 
-  const fieldType = field_type ? String(field_type).toLowerCase() : '';
+  const fieldType = field_type ? field_type.toLowerCase() : '';
 
   const fieldId = `attr-${attribute_key}`;
 


### PR DESCRIPTION
## Summary
- normalize `field_type` by converting to lowercase before comparing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68475df08458832fa9d0edf2b91f6542