### PR TITLE
Fix duplicate model rebuild

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -140,7 +140,6 @@ class PlanoResponse(PlanoBase):
 
 
 # Adicionar UserResponse ao final para resolver dependência circular se PlanoResponse referenciar UserResponse
-UserResponse.model_rebuild()
 
 
 # Schemas para Fornecedor


### PR DESCRIPTION
## Summary
- remove early call to `UserResponse.model_rebuild`
- keep rebuilds in final section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684760ec9654832f8bba03ebdb38e0af