### PR TITLE
Remove unused auth header logging

### DIFF
--- a/Backend/routers/auth_utils.py
+++ b/Backend/routers/auth_utils.py
@@ -42,13 +42,6 @@ async def get_current_user(
     # logger.debug(f"--- DEBUG: auth_utils.get_current_user ---")
     # logger.debug(f"Path da Requisição: {request.url.path}")
     # logger.debug(f"Headers Recebidos (raw): {dict(request.headers)}")
-    auth_header = request.headers.get('authorization')
-    if auth_header:
-        # logger.debug(f"Cabeçalho 'authorization' encontrado: {auth_header[:30]}...") # Log apenas uma parte do token
-        pass
-    else:
-        # logger.debug("Cabeçalho 'authorization' NÃO encontrado.")
-        pass
     # logger.debug(f"--- FIM DEBUG: auth_utils.get_current_user ---")
 
 


### PR DESCRIPTION
## Summary
- simplify `get_current_user` by removing unused authorization header retrieval

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684760edf5a8832fae1e3e898b5c3078