### PR TITLE
Fix partial index definition for ProductType

### DIFF
--- a/Backend/alembic/versions/ab0264b3dd00_update_product_type_index_clause.py
+++ b/Backend/alembic/versions/ab0264b3dd00_update_product_type_index_clause.py
@@ -1,0 +1,38 @@
+"""replace lambda with clause in product type index
+
+Revision ID: ab0264b3dd00
+Revises: e82d95b0cae0
+Create Date: 2025-06-10 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = 'ab0264b3dd00'
+down_revision: Union[str, None] = 'e82d95b0cae0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_index('ix_product_types_global_key_name_unique', table_name='product_types')
+    op.create_index(
+        'ix_product_types_global_key_name_unique',
+        'product_types',
+        ['key_name'],
+        unique=True,
+        postgresql_where=sa.text('user_id IS NULL')
+    )
+
+
+def downgrade() -> None:
+    op.drop_index('ix_product_types_global_key_name_unique', table_name='product_types')
+    op.create_index(
+        'ix_product_types_global_key_name_unique',
+        'product_types',
+        ['key_name'],
+        unique=True,
+        postgresql_where=sa.text('user_id IS NULL')
+    )

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -180,14 +180,17 @@ class ProductType(Base):
 
     __table_args__ = (
         UniqueConstraint('user_id', 'key_name', name='_user_key_name_uc'),
-        Index(
-            'ix_product_types_global_key_name_unique',
-            'key_name',
-            unique=True,
-            postgresql_where=lambda: ProductType.user_id.is_(None)
-        ),
         Index('ix_product_types_user_id_key_name', 'user_id', 'key_name'),
     )
+
+
+# Índice parcial para garantir key_name único quando user_id é NULL
+Index(
+    'ix_product_types_global_key_name_unique',
+    ProductType.key_name,
+    unique=True,
+    postgresql_where=(ProductType.user_id.is_(None))
+)
 
 
 # Modelo de Template de Atributo (AttributeTemplate)


### PR DESCRIPTION
## Summary
- fix index definition in ProductType model
- add Alembic migration for updated clause

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847dd67c074832fbb6be50c4ea5c49a