### PR TITLE
Fix password reset cleanup

### DIFF
--- a/Backend/routers/password_recovery.py
+++ b/Backend/routers/password_recovery.py
@@ -94,7 +94,6 @@ def reset_password(
 
     # Atualizar a senha do usuário
     hashed_password = security.get_password_hash(reset_data.new_password)
-    user_update_data = schemas.UserUpdate(password=reset_data.new_password) # Criar um schema de update
     
     # Para atualizar apenas a senha e limpar o token:
     db_user = crud_users.get_user(db, user_id=user.id) # Busca o usuário novamente para garantir que temos o objeto da sessão


### PR DESCRIPTION
## Summary
- remove unused `user_update_data` variable in password reset route

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847dd6814ec832fab01acd37192a0fd