### PR TITLE
Standardize fornecedores pagination

### DIFF
--- a/Backend/routers/fornecedores.py
+++ b/Backend/routers/fornecedores.py
@@ -72,7 +72,8 @@ def read_user_fornecedores(
         items_paginados = crud_fornecedores.get_fornecedores_by_user(db, user_id=current_user.id, skip=skip, limit=limit, search=termo_busca)
         total_items = crud_fornecedores.count_fornecedores_by_user(db=db, user_id=current_user.id, search=termo_busca)
     
-    return {"items": items_paginados, "total_items": total_items, "page": skip // limit, "limit": limit}
+    page_number = skip // limit + 1
+    return {"items": items_paginados, "total_items": total_items, "page": page_number, "limit": limit}
 
 # Endpoint para obter um fornecedor específico
 @router.get("/{fornecedor_id}", response_model=schemas.FornecedorResponse) # CORRIGIDO AQUI

--- a/README Backend.md
+++ b/README Backend.md
@@ -188,7 +188,7 @@
 ## Backend/routers/fornecedores.py
 
 * `create_supplier(fornecedor: FornecedorCreate, db: Session)`: Cria novo fornecedor.
-* `list_suppliers(skip: int = 0, limit: int = 100, db: Session)`: Lista fornecedores com paginação.
+* `list_suppliers(skip: int = 0, limit: int = 100, db: Session)`: Lista fornecedores com paginação (campo `page` inicia em 1).
 * `get_supplier(supplier_id: int, db: Session)`: Busca fornecedor pelo ID.
 * `update_supplier(supplier_id: int, update: FornecedorUpdate, db: Session)`: Atualiza fornecedor.
 * `delete_supplier(supplier_id: int, db: Session)`: Remove fornecedor.

--- a/tests/test_fornecedores.py
+++ b/tests/test_fornecedores.py
@@ -1,0 +1,57 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from Backend.main import app
+from Backend.database import Base, get_db
+from Backend import crud, crud_fornecedores, schemas
+from Backend.core.config import settings
+
+# disable heavy startup events
+app.router.on_startup.clear()
+
+engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+# setup initial data
+with TestingSessionLocal() as db:
+    crud.create_initial_data(db)
+    admin = crud.get_user_by_email(db, settings.FIRST_SUPERUSER_EMAIL)
+    # create extra suppliers for pagination
+    for i in range(15):
+        crud_fornecedores.create_fornecedor(db, schemas.FornecedorCreate(nome=f"F{i}"), user_id=admin.id)
+
+
+def get_admin_headers():
+    resp = client.post(
+        "/api/v1/auth/token",
+        data={"username": settings.FIRST_SUPERUSER_EMAIL, "password": settings.FIRST_SUPERUSER_PASSWORD},
+    )
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_pagination_returns_1_based_page():
+    headers = get_admin_headers()
+    resp = client.get("/api/v1/fornecedores", params={"skip": 0, "limit": 10}, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 1
+
+    resp = client.get("/api/v1/fornecedores", params={"skip": 10, "limit": 10}, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 2


### PR DESCRIPTION
## Summary
- move fornecedores pagination to a 1-based page number
- document page numbering in README
- add regression test for pagination value

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847dd68fb88832fa227b3432980f3fe