### PR TITLE
Add items-per-page selector to PaginationControls

### DIFF
--- a/Frontend/app/src/components/common/PaginationControls.jsx
+++ b/Frontend/app/src/components/common/PaginationControls.jsx
@@ -1,9 +1,18 @@
 // Frontend/app/src/components/common/PaginationControls.jsx
 import React from 'react';
 
-function PaginationControls({ currentPage, totalPages, onPageChange, isLoading }) {
-  if (totalPages <= 1) {
-    return null; // Não mostra controlos se houver apenas uma página ou nenhuma
+function PaginationControls({
+  currentPage,
+  totalPages,
+  onPageChange,
+  isLoading,
+  itemsPerPage,
+  onItemsPerPageChange,
+  totalItems,
+}) {
+  if (totalPages <= 1 && !itemsPerPage) {
+    // Mantém comportamento antigo se o seletor de itens não for usado
+    return null;
   }
 
   const handlePrevious = () => {
@@ -19,9 +28,21 @@ function PaginationControls({ currentPage, totalPages, onPageChange, isLoading }
   };
 
   return (
-    <div className="pagination-controls" style={{ marginTop: '1.5rem', marginBottom: '0.5rem', textAlign: 'center', display: 'flex', justifyContent: 'center', alignItems: 'center', gap: '10px' }}>
-      <button 
-        onClick={handlePrevious} 
+    <div
+      className="pagination-controls"
+      style={{
+        marginTop: '1.5rem',
+        marginBottom: '0.5rem',
+        textAlign: 'center',
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        gap: '10px',
+        flexWrap: 'wrap',
+      }}
+    >
+      <button
+        onClick={handlePrevious}
         disabled={currentPage === 0 || isLoading}
         style={{ padding: '0.5em 1em' }}
       >
@@ -29,14 +50,30 @@ function PaginationControls({ currentPage, totalPages, onPageChange, isLoading }
       </button>
       <span style={{ margin: '0 10px', fontSize: '0.9em', color: '#555' }}>
         Página {currentPage + 1} de {totalPages}
+        {typeof totalItems === 'number' && (
+          <span style={{ marginLeft: '0.5rem' }}>({totalItems} itens)</span>
+        )}
       </span>
-      <button 
-        onClick={handleNext} 
+      <button
+        onClick={handleNext}
         disabled={currentPage === totalPages - 1 || isLoading}
         style={{ padding: '0.5em 1em' }}
       >
         Próxima
       </button>
+      {typeof itemsPerPage === 'number' && onItemsPerPageChange && (
+        <select
+          style={{ marginLeft: '0.5rem' }}
+          value={itemsPerPage}
+          onChange={(e) => onItemsPerPageChange(e.target.value)}
+        >
+          {[5, 10, 25, 50, 100].map((num) => (
+            <option key={num} value={num}>
+              {num}/página
+            </option>
+          ))}
+        </select>
+      )}
     </div>
   );
 }

--- a/Frontend/app/src/components/common/__tests__/PaginationControls.test.jsx
+++ b/Frontend/app/src/components/common/__tests__/PaginationControls.test.jsx
@@ -5,3 +5,19 @@ test('shows current page information', () => {
   render(<PaginationControls currentPage={0} totalPages={3} onPageChange={() => {}} isLoading={false} />);
   expect(screen.getByText(/Página 1 de 3/)).toBeInTheDocument();
 });
+
+test('renders items per page selector and total items when props provided', () => {
+  render(
+    <PaginationControls
+      currentPage={0}
+      totalPages={1}
+      onPageChange={() => {}}
+      isLoading={false}
+      itemsPerPage={10}
+      onItemsPerPageChange={() => {}}
+      totalItems={25}
+    />
+  );
+  expect(screen.getByText(/25 itens/)).toBeInTheDocument();
+  expect(screen.getByDisplayValue('10/página')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- extend `PaginationControls` with optional props
- show total item count and items-per-page selector
- update unit tests

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: httpx/sqlalchemy)*

------
https://chatgpt.com/codex/tasks/task_e_6847dd7c5390832fbbd594db01b1c8a7