### PR TITLE
Fix attribute suggestion naming

### DIFF
--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -365,7 +365,7 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
         showInfoToast("Buscando sugestões de atributos com a IA (Gemini)... Isso pode levar um momento.");
 
         try {
-            const suggestionsData = await productService.getAtributoSugestions(product.id);
+            const suggestionsData = await productService.getAtributoSuggestions(product.id);
             if (suggestionsData && suggestionsData.sugestoes_atributos && suggestionsData.sugestoes_atributos.length > 0) {
                 const newSuggestions = suggestionsData.sugestoes_atributos.reduce((acc, item) => {
                     acc[item.chave_atributo] = item.valor_sugerido;

--- a/Frontend/app/src/services/productService.js
+++ b/Frontend/app/src/services/productService.js
@@ -129,7 +129,7 @@ export const batchDeleteProdutos = async (produtoIds) => {
 };
 
 // --- FUNÇÃO ADICIONADA ---
-export const getAtributoSugestions = async (produtoId) => {
+export const getAtributoSuggestions = async (produtoId) => {
   try {
     // O endpoint no backend é: POST /api/v1/geracao/sugerir-atributos-gemini/{produto_id}
     const response = await apiClient.post(`/geracao/sugerir-atributos-gemini/${produtoId}`);
@@ -143,7 +143,7 @@ export const getAtributoSugestions = async (produtoId) => {
 // --- FIM DA FUNÇÃO ADICIONADA ---
 
 // Alias para o modal que usa este nome
-export const sugerirAtributosGemini = getAtributoSugestions;
+export const sugerirAtributosGemini = getAtributoSuggestions;
 
 
 export default {
@@ -158,6 +158,6 @@ export default {
   gerarDescricaoGemini,
   iniciarEnriquecimentoWebProduto,
   batchDeleteProdutos,
-  getAtributoSugestions,
+  getAtributoSuggestions,
   sugerirAtributosGemini,
 };


### PR DESCRIPTION
## Summary
- rename `getAtributoSugestions` -> `getAtributoSuggestions`
- update `sugerirAtributosGemini` alias and export object
- use the new method in `ProductEditModal`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847e4284fb4832fb070ad62b57970fe