### PR TITLE
Fix plano update removal logic

### DIFF
--- a/Backend/crud_users.py
+++ b/Backend/crud_users.py
@@ -87,8 +87,7 @@ def update_user(db: Session, db_user: User, user_update: Union[schemas.UserUpdat
                 logger.warning(
                     f"Plano com ID {new_plano_id} não encontrado ao atualizar usuário {db_user.email}. Plano não alterado."
                 )
-        if "plano_id" in update_data:
-            del update_data["plano_id"]
+        update_data.pop("plano_id", None)
 
     for field, value in update_data.items():
         if hasattr(db_user, field):


### PR DESCRIPTION
## Summary
- simplify plano_id cleanup in `update_user`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847e43f79dc832fabb0727920a1cacb