### PR TITLE
Fix product detail loading in edit modal

### DIFF
--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -202,17 +202,6 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
         const loadDetails = async () => {
             if (!isOpen) return;
             if (product && product.id) {
-                const token = localStorage.getItem('accessToken');
-                if (token && isAuthenticated) {
-                    try {
-                        const fullProduct = await productService.getProdutoById(product.id);
-                        populateFormData(fullProduct);
-                    } catch (err) {
-                        console.error('Erro ao carregar produto:', err);
-                        showErrorToast('Erro ao carregar dados completos do produto.');
-                        populateFormData(product);
-                    }
-                } else {
                 try {
                     const fullProduct = await productService.getProdutoById(product.id);
                     populateFormData(fullProduct);
@@ -220,7 +209,6 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
                     console.error('Erro ao carregar produto:', err);
                     showErrorToast('Erro ao carregar dados completos do produto.');
                     populateFormData(product);
-                }
                 }
             } else {
                 setFormData(initialFormData);


### PR DESCRIPTION
## Summary
- simplify `loadDetails` in ProductEditModal by removing token check

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ea90e630832fbcf5ddfe81b329f0