### PR TITLE
Implement sidebar toggle in main layout

### DIFF
--- a/Frontend/app/src/components/MainLayout.jsx
+++ b/Frontend/app/src/components/MainLayout.jsx
@@ -6,6 +6,7 @@ import Topbar from './Topbar';   // Certifique-se que o caminho está correto
 
 function MainLayout() {
   const [viewTitle, setViewTitle] = useState('Dashboard');
+  const [sidebarOpen, setSidebarOpen] = useState(true);
   const location = useLocation();
 
   useEffect(() => {
@@ -38,11 +39,11 @@ function MainLayout() {
   // As classes .main e .content no JSX abaixo irão buscar os seus estilos do index.css.
   return (
     <div style={{ display: 'flex', height: '100%', width: '100%', fontFamily: 'var(--font)' }}>
-      <Sidebar /> {/* A Sidebar terá largura fixa e altura 100% via CSS */}
+      <Sidebar isOpen={sidebarOpen} toggleSidebar={() => setSidebarOpen(o => !o)} /> {/* A Sidebar terá largura fixa e altura 100% via CSS */}
       
       {/* A classe "main" agora será um item flex que ocupa o espaço restante */}
       <div className="main"> 
-        <Topbar viewTitle={viewTitle} />
+        <Topbar viewTitle={viewTitle} toggleSidebar={() => setSidebarOpen(o => !o)} />
         {/* A classe "content" é o container interno que terá overflow-y: auto */}
         <main className="content"> 
           <Outlet />

--- a/Frontend/app/src/components/Topbar.jsx
+++ b/Frontend/app/src/components/Topbar.jsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
+import { LuMenu } from 'react-icons/lu';
 // Se você criar um AuthContext, importe-o:
 // import { AuthContext } from '../contexts/AuthContext';
 
@@ -16,7 +17,7 @@ const getInitials = (name) => {
   return initials;
 };
 
-function Topbar({ viewTitle }) {
+function Topbar({ viewTitle, toggleSidebar }) {
   const navigate = useNavigate();
   const [userMenuOpen, setUserMenuOpen] = useState(false);
   const { user, logout, isLoading: loadingUser } = useAuth();
@@ -27,6 +28,9 @@ function Topbar({ viewTitle }) {
 
   return (
     <header className="topbar">
+      <button onClick={toggleSidebar} className="sidebar-toggle-btn" aria-label="Alternar menu">
+        <LuMenu />
+      </button>
       <h1>{viewTitle || "Dashboard"}</h1>
       <div 
         className="user-area"

--- a/Frontend/app/src/index.css
+++ b/Frontend/app/src/index.css
@@ -158,12 +158,23 @@ button[disabled], button:disabled {
   justify-content: space-between;
   min-height: 60px; /* Altura mínima da topbar */
   flex-shrink: 0; /* Topbar não encolhe */
-  z-index: 50; 
+  z-index: 50;
 }
-.topbar h1 { 
-  font-size: 1.65rem; 
-  color: #333; 
-  margin-bottom: 0; 
+.sidebar-toggle-btn {
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  margin-right: 1rem;
+  cursor: pointer;
+  color: var(--primary);
+}
+.sidebar-toggle-btn:hover {
+  filter: brightness(90%);
+}
+.topbar h1 {
+  font-size: 1.65rem;
+  color: #333;
+  margin-bottom: 0;
 }
 
 .user-area {


### PR DESCRIPTION
## Summary
- allow toggling the sidebar from `MainLayout` using new state
- expose toggle button in `Topbar`
- style sidebar toggle button

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847ea8f751c832fa643100b7ce5d3e1