### PR TITLE
Fix docs backend requirements path

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,12 +207,12 @@ cd <PASTA_DO_PROJETO>
 
 ### 3. **Configuração do Backend**
 
-As dependências Python necessárias estão listadas em `Backend/requirements.txt`.
+As dependências Python necessárias estão listadas em `requirements-backend.txt`.
 
 ```sh
 python -m venv venv
 source venv/bin/activate    # Ou .\venv\Scripts\activate no Windows
-pip install -r Backend/requirements.txt   # dependências fixas do backend
+pip install -r requirements-backend.txt   # dependências fixas do backend
 cd Backend
 alembic upgrade head        # Cria as tabelas do banco
 cd ..

--- a/README.txt
+++ b/README.txt
@@ -118,18 +118,20 @@ source venv/bin/activate  # Linux/macOS
 
 
 Todas as bibliotecas necessárias para o backend já estão listadas em
-`Backend/requirements.txt`. Execute na raiz do projeto:
+`requirements-backend.txt`. Execute na raiz do projeto:
 
 ```bash
-pip install -r Backend/requirements.txt
+pip install -r requirements-backend.txt
 ```
 
-Já existe um arquivo Backend/requirements.txt com as principais bibliotecas.
+Bash
+
+Já existe um arquivo requirements-backend.txt com as principais bibliotecas.
 Execute na raiz do projeto:
 
 Bash
 
-pip install -r Backend/requirements.txt
+pip install -r requirements-backend.txt
 playwright install
 
 


### PR DESCRIPTION
## Summary
- clarify `requirements-backend.txt` as the main file for backend dependencies
- update quickstart steps in README files

## Testing
- `pip install -r requirements-backend.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847ead9dbb0832f8e58483870fb738b