### PR TITLE
Fix BACKEND_CORS_ORIGINS env parsing

### DIFF
--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -37,8 +37,12 @@ class Settings(BaseSettings):
     ACCESS_TOKEN_EXPIRE_MINUTES: int = int(os.getenv("ACCESS_TOKEN_EXPIRE_MINUTES", 60 * 24 * 1)) # Default 1 dia
     REFRESH_TOKEN_EXPIRE_DAYS: int = int(os.getenv("REFRESH_TOKEN_EXPIRE_DAYS", 7))
 
-    _cors_origins_str: Optional[str] = os.getenv("BACKEND_CORS_ORIGINS")
-    BACKEND_CORS_ORIGINS: List[AnyHttpUrl] = []
+    # ``_cors_origins_str`` captura o valor cru da variável de ambiente
+    # ``BACKEND_CORS_ORIGINS``. ``BACKEND_CORS_ORIGINS`` em si utiliza um alias
+    # inexistente para evitar que o ``BaseSettings`` tente processá-la
+    # automaticamente (o que falharia quando o valor não está em formato JSON).
+    _cors_origins_str: Optional[str] = Field(default=None, alias="BACKEND_CORS_ORIGINS")
+    BACKEND_CORS_ORIGINS: List[AnyHttpUrl] = Field(default_factory=list, alias="BACKEND_CORS_ORIGINS_PARSED")
 
     ADMIN_EMAIL: str = os.getenv("ADMIN_EMAIL", "<ADMIN_EMAIL>")
     ADMIN_PASSWORD: str = os.getenv("ADMIN_PASSWORD", "<ADMIN_PASSWORD>")


### PR DESCRIPTION
## Summary
- avoid pydantic from parsing BACKEND_CORS_ORIGINS directly
- store raw string then parse manually

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847efdde694832f81f67a4156bb71ad