### PR TITLE
Clarify SQLite fallback in env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,8 @@
 
 # Database configuration
 DATABASE_URL="postgresql://postgres:password@localhost:5432/tdai_db"
+# If you do not have PostgreSQL available, remove or comment the line above.
+# The backend will automatically use SQLite at the path defined below.
 SQLITE_DB_FILE="tdai_app.db"
 
 # Security settings

--- a/README.md
+++ b/README.md
@@ -274,6 +274,7 @@ npm test
 ```
 # Banco de Dados
 DATABASE_URL="postgresql://usuario:senha@localhost:5432/tdai_db"
+SQLITE_DB_FILE="tdai_app.db"  # usado automaticamente se DATABASE_URL estiver ausente
 
 # Segurança
 SECRET_KEY="sua_chave_forte"
@@ -317,6 +318,11 @@ ADMIN_PASSWORD="<ADMIN_PASSWORD>"
 FIRST_SUPERUSER_EMAIL="<FIRST_SUPERUSER_EMAIL>"
 FIRST_SUPERUSER_PASSWORD="<FIRST_SUPERUSER_PASSWORD>"
 ```
+
+Se `DATABASE_URL` não estiver definido, o backend utilizará automaticamente
+SQLite, criando o arquivo no caminho especificado por `SQLITE_DB_FILE`. Caso
+você não tenha PostgreSQL disponível, remova ou comente a variável
+`DATABASE_URL` ou ajuste o caminho do arquivo SQLite conforme necessário.
 
 > ⚠️ **Nunca suba arquivos `.env` com dados sensíveis para o git!**
 > Configure senhas e chaves reais via variáveis de ambiente ou um gerenciador de segredos seguro.

--- a/README.txt
+++ b/README.txt
@@ -149,6 +149,7 @@ Snippet de código
 
 # Backend/core/config.py espera estas variáveis
 DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DB_NAME" # Ex: postgresql://postgres:password@localhost:5432/tdai_db
+SQLITE_DB_FILE="tdai_app.db"  # usado se DATABASE_URL não estiver presente
 SECRET_KEY="sua_chave_secreta_super_forte_aqui" # Importante para JWT
 
 REFRESH_SECRET_KEY="change-me"
@@ -193,6 +194,11 @@ FRONTEND_URL="http://localhost:5173" # Ou a porta do seu frontend Vite/React
 ADMIN_EMAIL="<ADMIN_EMAIL>"
 ADMIN_PASSWORD="<ADMIN_PASSWORD>"
 Preencha os valores corretos para cada variável. O arquivo Backend/core/config.py define como essas variáveis são lidas.
+
+Se `DATABASE_URL` não for informado, o backend irá utilizar automaticamente
+SQLite no caminho definido por `SQLITE_DB_FILE`. Remova ou comente a variável
+`DATABASE_URL` caso não disponha de um servidor PostgreSQL ou ajuste o caminho
+do arquivo SQLite conforme necessário.
 
 6. Migrações do Banco de Dados:
 


### PR DESCRIPTION
## Summary
- document SQLITE_DB_FILE and fallback behavior when `DATABASE_URL` is not set
- advise developers without PostgreSQL to remove/comment `DATABASE_URL`

## Testing
- `pip install -r requirements-backend.txt` *(fails: Tunnel connection failed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847f374c84c832fa7adb75ff34b583b