### PR TITLE
Fix positioning of modal close button

### DIFF
--- a/Frontend/app/src/components/common/Modal.css
+++ b/Frontend/app/src/components/common/Modal.css
@@ -32,6 +32,7 @@
     border-bottom: 1px solid #eee;
     padding-bottom: 10px;
     margin-bottom: 20px;
+    position: relative; /* Para posicionar o botão de fechar */
 }
 
 .modal-header h2 {
@@ -46,8 +47,14 @@
     font-size: 1.2em;
     cursor: pointer;
     color: #888;
+    width: 24px;
+    height: 24px;
     padding: 0;
+    margin: 0;
     line-height: 1;
+    position: absolute;
+    top: 0;
+    right: 0;
 }
 
 .modal-close-button:hover {


### PR DESCRIPTION
## Summary
- improve modal header positioning
- set size and absolute positioning for the modal close button

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847f7206f50832f876b2477dc4b9ba7