### PR TITLE
Add product deep-link from dashboard search

### DIFF
--- a/Frontend/app/src/pages/DashboardPage.jsx
+++ b/Frontend/app/src/pages/DashboardPage.jsx
@@ -1,5 +1,6 @@
 // Frontend/app/src/pages/DashboardPage.jsx
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import authService from '../services/authService'; // Mantido para getCurrentUser
 import adminService from '../services/adminService'; // NOVO: Importar o adminService
 import { showErrorToast } from '../utils/notifications';
@@ -14,6 +15,7 @@ const mockDashboardData = {
 };
 
 function DashboardPage() {
+  const navigate = useNavigate();
   const [currentUser, setCurrentUser] = useState(null);
   const [adminStats, setAdminStats] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -219,7 +221,12 @@ function DashboardPage() {
                         <td style={{ fontWeight: 600 }}>{item.name}</td>
                         <td>-</td>
                         <td style={{ textAlign: 'right' }}>
-                          <button className="btn-detalhe">Ver Detalhes</button>
+                          <button
+                            className="btn-detalhe"
+                            onClick={() => navigate(`/produtos?id=${item.id}`)}
+                          >
+                            Ver Detalhes
+                          </button>
                         </td>
                       </tr>
                     ))

--- a/Frontend/app/src/pages/ProdutosPage.jsx
+++ b/Frontend/app/src/pages/ProdutosPage.jsx
@@ -1,5 +1,6 @@
 // Frontend/app/src/pages/ProdutosPage.jsx
 import React, { useState, useEffect, useCallback } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import ProductTable from '../components/produtos/ProductTable';
 // REMOVIDO: import NewProductModal from '../components/produtos/NewProductModal';
 // REMOVIDO: import ProductEditModal from '../components/ProductEditModal';
@@ -13,6 +14,8 @@ import './ProdutosPage.css';
 import { useProductTypes } from '../contexts/ProductTypeContext';
 
 function ProdutosPage() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
   const [produtos, setProdutos] = useState([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
@@ -99,6 +102,24 @@ function ProdutosPage() {
     setIsModalOpen(false);
     setProdutoParaEditar(null);
   };
+
+  // Abra o modal automaticamente se um ID de produto for fornecido na URL
+  useEffect(() => {
+    const productId = searchParams.get('id');
+    if (productId) {
+      const openById = async () => {
+        try {
+          const prod = await productService.getProdutoById(productId);
+          handleOpenModal(prod);
+          navigate('/produtos', { replace: true });
+        } catch (err) {
+          const msg = err.response?.data?.detail || err.message || 'Falha ao carregar produto.';
+          showErrorToast(msg);
+        }
+      };
+      openById();
+    }
+  }, [searchParams]);
 
   // REMOVIDO: Handlers antigos dos modais separados
   // const handleOpenNewProductModal = () => setIsNewProductModalOpen(true);


### PR DESCRIPTION
## Summary
- enable navigation to `/produtos` from dashboard search table
- auto-open `ProductEditModal` when `id` query param is present on produtos page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6847f72282f0832fb5676a56ccca2343