### PR TITLE
Show warning when product detail fetch fails

### DIFF
--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -209,6 +209,7 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
                     console.error('Erro ao carregar produto:', err);
                     showErrorToast('Erro ao carregar dados completos do produto.');
                     populateFormData(product);
+                    showWarningToast('Dados carregados parcialmente.');
                 }
             } else {
                 setFormData(initialFormData);


### PR DESCRIPTION
## Summary
- display error toast when fetching full product details fails
- warn user that only partial data has been loaded

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847f724aa74832fb91122d71a1438e3