### PR TITLE
Fix product edit modal close button

### DIFF
--- a/Frontend/app/src/components/common/Modal.css
+++ b/Frontend/app/src/components/common/Modal.css
@@ -44,17 +44,17 @@
 .modal-close-button {
     background: none;
     border: none;
-    font-size: 1.2em;
+    font-size: 1.2rem;
     cursor: pointer;
-    color: #888;
+    color: #777;
     width: 24px;
     height: 24px;
     padding: 0;
     margin: 0;
     line-height: 1;
     position: absolute;
-    top: 0;
-    right: 0;
+    top: 10px;
+    right: 10px;
 }
 
 .modal-close-button:hover {

--- a/Frontend/app/src/components/common/Modal.jsx
+++ b/Frontend/app/src/components/common/Modal.jsx
@@ -12,7 +12,11 @@ const Modal = ({ isOpen, onClose, title, children }) => {
             <div className="modal-content">
                 <div className="modal-header">
                     <h2>{title}</h2>
-                    <button className="modal-close-button" onClick={onClose}>
+                    <button
+                        type="button"
+                        className="modal-close-button"
+                        onClick={onClose}
+                    >
                         &times;
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- style the modal close button so it sits at the top-right corner
- add `type="button"` to prevent accidental form submission

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --prefix Frontend/app` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847fdf3f76c832fa1304d1b6dfb0102