### PR TITLE
Update modal close buttons

### DIFF
--- a/Frontend/app/src/components/fornecedores/EditFornecedorModal.jsx
+++ b/Frontend/app/src/components/fornecedores/EditFornecedorModal.jsx
@@ -87,7 +87,15 @@ function EditFornecedorModal({ isOpen, onClose, fornecedorData, onSave, isLoadin
   return (
     <div className="modal active" id="edit-forn-modal">
       <div className="modal-content">
-        <button className="modal-close" onClick={onClose} disabled={isLoading || importLoading}>×</button>
+        <button
+          type="button"
+          className="modal-close-button"
+          aria-label="Fechar"
+          onClick={onClose}
+          disabled={isLoading || importLoading}
+        >
+          ×
+        </button>
         <h3>Editar Fornecedor: {fornecedorData.nome}</h3>
         <div className="tab-navigation">
           <button type="button" className={activeTab === 'info' ? 'active' : ''} onClick={() => setActiveTab('info')}>Info</button>

--- a/Frontend/app/src/components/fornecedores/NewFornecedorModal.jsx
+++ b/Frontend/app/src/components/fornecedores/NewFornecedorModal.jsx
@@ -57,7 +57,15 @@ function NewFornecedorModal({ isOpen, onClose, onSave, isLoading }) {
   return (
     <div className="modal active" id="new-forn-modal">
       <div className="modal-content">
-        <button className="modal-close" onClick={onClose} disabled={isLoading}>×</button>
+        <button
+          type="button"
+          className="modal-close-button"
+          aria-label="Fechar"
+          onClick={onClose}
+          disabled={isLoading}
+        >
+          ×
+        </button>
         <h3>Novo Fornecedor</h3>
         <div>
             <label htmlFor="new-forn-nome">Nome*</label>

--- a/Frontend/app/src/components/product_types/AttributeTemplateModal.jsx
+++ b/Frontend/app/src/components/product_types/AttributeTemplateModal.jsx
@@ -86,6 +86,8 @@ const AttributeTemplateModal = ({ isOpen, onClose, attribute, onSave, isSubmitti
         <div style={styles.modalHeader}>
           <h3 style={styles.modalTitle}>{isEditing ? 'Editar Atributo' : 'Novo Atributo'}</h3>
           <button
+            type="button"
+            aria-label="Fechar"
             onClick={onClose}
             className="modal-close-button"
             style={styles.closeButton}

--- a/Frontend/app/src/index.css
+++ b/Frontend/app/src/index.css
@@ -511,12 +511,21 @@ tr:hover {
 }
 .modal-close {
   position: absolute; top: 0.75rem; right: 0.75rem;
-  background: none; border: none; font-size: 1.5rem; 
+  background: none; border: none; font-size: 1.5rem;
   line-height: 1; width: 2rem; height: 2rem;
   display: flex; align-items: center; justify-content: center;
   cursor: pointer; color: #777; transition: color 0.2s;
 }
 .modal-close:hover { color: #333; }
+
+.modal-close-button {
+  position: absolute; top: 0.75rem; right: 0.75rem;
+  background: none; border: none; font-size: 1.5rem;
+  line-height: 1; width: 2rem; height: 2rem;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; color: #777; transition: color 0.2s;
+}
+.modal-close-button:hover { color: #333; }
 .modal-content h3 { margin-bottom: 1.5rem; font-size: 1.4rem; color: #333; }
 .modal-content label { 
   display: block; font-weight: 500; margin-bottom: 0.5rem; color: #444;


### PR DESCRIPTION
## Summary
- replace `.modal-close` with `.modal-close-button` for supplier modals
- add `type` and `aria-label` to modal close buttons
- support new class in global CSS

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848024aa260832f9b37e9e61362ff94