### PR TITLE
Fix modal close button width

### DIFF
--- a/Frontend/app/src/index.css
+++ b/Frontend/app/src/index.css
@@ -526,6 +526,24 @@ tr:hover {
   cursor: pointer; color: #777; transition: color 0.2s;
 }
 .modal-close-button:hover { color: #333; }
+.tipos-produto-modal-close-button {
+  position: absolute;
+  top: 0.75rem;
+  right: 0.75rem;
+  background: none;
+  border: none;
+  font-size: 1.5rem;
+  line-height: 1;
+  width: 2rem;
+  height: 2rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  color: #777;
+  transition: color 0.2s;
+}
+.tipos-produto-modal-close-button:hover { color: #333; }
 .modal-content h3 { margin-bottom: 1.5rem; font-size: 1.4rem; color: #333; }
 .modal-content label { 
   display: block; font-weight: 500; margin-bottom: 0.5rem; color: #444;
@@ -536,7 +554,7 @@ tr:hover {
 }
 .modal-content textarea { resize: vertical; min-height: 100px; }
 .modal-content button[type="submit"],
-.modal-content button:not(.modal-close):not(.modal-close-button) {
+.modal-content button:not(.modal-close):not(.modal-close-button):not(.tipos-produto-modal-close-button) {
   display: block; width: 100%; margin-top: 0.5rem;
   padding: 0.75rem; font-size: 1.05rem;
 }

--- a/Frontend/app/src/pages/ProdutosPage.css
+++ b/Frontend/app/src/pages/ProdutosPage.css
@@ -221,7 +221,7 @@
   font-size: 0.95rem;
 }
 
-.modal-content button:not(.modal-close) { /* Botão de salvar no modal */
+.modal-content button:not(.modal-close):not(.modal-close-button):not(.tipos-produto-modal-close-button) { /* Botão de salvar no modal */
   display: block;
   width: 100%;
   padding: 12px;
@@ -233,7 +233,7 @@
   cursor: pointer;
   margin-top: 20px;
 }
-.modal-content button:not(.modal-close):hover {
+.modal-content button:not(.modal-close):not(.modal-close-button):not(.tipos-produto-modal-close-button):hover {
   background-color: var(--success-dark); /* Definir essa variável */
 }
 .modal-content button:disabled {

--- a/Frontend/app/src/pages/TiposProdutoPage.css
+++ b/Frontend/app/src/pages/TiposProdutoPage.css
@@ -294,15 +294,6 @@
     font-size: 1.5rem;
     color: var(--sidebar-bg);
 }
-.tipos-produto-modal-close-button {
-    background: none;
-    border: none;
-    font-size: 1.8rem;
-    font-weight: 300;
-    color: #6b7280;
-    cursor: pointer;
-    line-height: 1;
-}
 .tipos-produto-modal-actions {
     margin-top: 20px;
     display: flex;


### PR DESCRIPTION
## Summary
- prevent modal close buttons from expanding to full width across modals
- simplify unused type-product modal close button styles

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684803a08f18832faa5415b7458ab578