### PR TITLE
Fix update endpoint with trailing slash

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -90,6 +90,23 @@ router.add_api_route(
     include_in_schema=False,
 )
 
+# Expondo rotas com barra final para operações de atualização e deleção.
+router.add_api_route(
+    "/{produto_id}/",
+    update_produto,
+    methods=["PUT"],
+    response_model=schemas.ProdutoResponse,
+    include_in_schema=False,
+)
+
+router.add_api_route(
+    "/{produto_id}/",
+    delete_produto,
+    methods=["DELETE"],
+    response_model=schemas.ProdutoResponse,
+    include_in_schema=False,
+)
+
 
 @router.get("/", response_model=schemas.ProdutoPage) # Este já estava correto
 def read_produtos( # Nome da função mantido como no arquivo do usuário


### PR DESCRIPTION
## Summary
- ensure PUT and DELETE /produtos/{id}/ routes exist

## Testing
- `pip install -r requirements-full.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68482762fdb4832f9896f7d0bf0bf422