### PR TITLE
Refactor user menu component

### DIFF
--- a/Frontend/app/src/components/Sidebar.jsx
+++ b/Frontend/app/src/components/Sidebar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext'; // Se precisar do logout ou dados do usuário
 import './Sidebar.css'; // Certifique-se de que este arquivo CSS existe e está correto
+import UserMenu from './UserMenu.jsx';
 
 // Ícones (exemplo, substitua pelos seus ou remova se não usar)
 import {
@@ -62,9 +63,9 @@ const Sidebar = ({ isOpen, toggleSidebar }) => {
         </ul>
       </nav>
       <div className="sidebar-footer">
-        {user && isOpen && (
+        {user && (
           <div className="user-info">
-            {/* <p>Bem-vindo, {user.nome_completo || user.email}!</p> */}
+            <UserMenu onLogout={handleLogout} showDropdown={isOpen} />
           </div>
         )}
         <button onClick={handleLogout} className="logout-button" title="Sair">

--- a/Frontend/app/src/components/Topbar.jsx
+++ b/Frontend/app/src/components/Topbar.jsx
@@ -1,30 +1,16 @@
 // Frontend/app/src/components/Topbar.jsx
-import React, { useState } from 'react';
+import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import { LuMenu } from 'react-icons/lu';
+import UserMenu from './UserMenu.jsx';
 // Se você criar um AuthContext, importe-o:
 // import { AuthContext } from '../contexts/AuthContext';
 
 
-const getInitials = (name) => {
-  if (!name || typeof name !== 'string') return '??';
-  const names = name.split(' ');
-  let initials = names[0].substring(0, 1).toUpperCase();
-  if (names.length > 1) {
-    initials += names[names.length - 1].substring(0, 1).toUpperCase();
-  }
-  return initials;
-};
-
 function Topbar({ viewTitle, toggleSidebar }) {
   const navigate = useNavigate();
-  const [userMenuOpen, setUserMenuOpen] = useState(false);
-  const { user, logout, isLoading: loadingUser } = useAuth();
-
-
-  const userNameDisplay = loadingUser ? "Carregando..." : (user?.nome_completo || user?.email || "Usuário");
-  const userInitials = loadingUser ? "..." : getInitials(user?.nome_completo || user?.email);
+  const { logout } = useAuth();
 
   return (
     <header className="topbar">
@@ -32,33 +18,7 @@ function Topbar({ viewTitle, toggleSidebar }) {
         <LuMenu />
       </button>
       <h1>{viewTitle || "Dashboard"}</h1>
-      <div 
-        className="user-area"
-        tabIndex="0" 
-        onMouseEnter={() => setUserMenuOpen(true)}
-        onMouseLeave={() => setUserMenuOpen(false)}
-        onClick={() => setUserMenuOpen(prev => !prev)}
-        onFocus={() => setUserMenuOpen(true)} // Para acessibilidade com teclado
-        onBlur={() => setTimeout(() => setUserMenuOpen(false), 150)} // Pequeno delay para permitir clique no menu
-      >
-        <div className="user-avatar">
-          {userInitials}
-        </div>
-        <span className="user-name">{userNameDisplay}</span>
-        
-        {userMenuOpen && (
-          <div className="user-menu" style={{ display: 'flex' }}> {/* Mantido flex para layout interno dos botões */}
-            <button onClick={() => { setUserMenuOpen(false); navigate('/configuracoes'); }}> 
-              <span style={{color:"#7c3aed",verticalAlign:"middle", marginRight:"5px"}}>&#9881;&#65039;</span> 
-              Configurações
-            </button>
-            <button onClick={() => { setUserMenuOpen(false); logout(); }}>
-              <span style={{color:"var(--danger)",verticalAlign:"middle", marginRight:"5px"}}>➔</span>
-              Sair
-            </button>
-          </div>
-        )}
-      </div>
+      <UserMenu onLogout={logout} onNavigate={path => navigate(path)} />
     </header>
   );
 }

--- a/Frontend/app/src/components/UserMenu.jsx
+++ b/Frontend/app/src/components/UserMenu.jsx
@@ -1,0 +1,72 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../contexts/AuthContext';
+
+const getInitials = (name) => {
+  if (!name || typeof name !== 'string') return '??';
+  const names = name.split(' ');
+  let initials = names[0].substring(0, 1).toUpperCase();
+  if (names.length > 1) {
+    initials += names[names.length - 1].substring(0, 1).toUpperCase();
+  }
+  return initials;
+};
+
+function UserMenu({ onLogout, onNavigate, showDropdown = true }) {
+  const navigate = useNavigate();
+  const { user, logout, isLoading } = useAuth();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  const userNameDisplay = isLoading ? 'Carregando...' : (user?.nome_completo || user?.email || 'Usuário');
+  const userInitials = isLoading ? '...' : getInitials(user?.nome_completo || user?.email);
+
+  const handleNavigate = (path) => {
+    setMenuOpen(false);
+    if (onNavigate) {
+      onNavigate(path);
+    } else {
+      navigate(path);
+    }
+  };
+
+  const handleLogout = () => {
+    setMenuOpen(false);
+    if (onLogout) {
+      onLogout();
+    } else {
+      logout();
+    }
+  };
+
+  const enableMenu = showDropdown;
+
+  return (
+    <div
+      className="user-area"
+      tabIndex={enableMenu ? '0' : undefined}
+      onMouseEnter={() => enableMenu && setMenuOpen(true)}
+      onMouseLeave={() => enableMenu && setMenuOpen(false)}
+      onClick={() => enableMenu && setMenuOpen(prev => !prev)}
+      onFocus={() => enableMenu && setMenuOpen(true)}
+      onBlur={() => enableMenu && setTimeout(() => setMenuOpen(false), 150)}
+    >
+      <div className="user-avatar">{userInitials}</div>
+      <span className="user-name">{userNameDisplay}</span>
+
+      {enableMenu && menuOpen && (
+        <div className="user-menu" style={{ display: 'flex' }}>
+          <button onClick={() => handleNavigate('/configuracoes')}>
+            <span style={{color:'#7c3aed',verticalAlign:'middle',marginRight:'5px'}}>&#9881;&#65039;</span>
+            Configurações
+          </button>
+          <button onClick={handleLogout}>
+            <span style={{color:'var(--danger)',verticalAlign:'middle',marginRight:'5px'}}>➔</span>
+            Sair
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default UserMenu;

--- a/Frontend/app/src/index.css
+++ b/Frontend/app/src/index.css
@@ -233,8 +233,23 @@ button[disabled], button:disabled {
 .user-menu button:hover { 
   background: var(--main-bg); 
 }
-.user-menu button > span { 
+.user-menu button > span {
   opacity: 0.7;
+}
+
+/* Ajustes para o UserMenu dentro da sidebar */
+.sidebar .user-area {
+  justify-content: center;
+}
+.sidebar .user-menu {
+  left: 0;
+  right: auto;
+}
+.sidebar.closed .user-menu {
+  display: none;
+}
+.sidebar.closed .user-name {
+  display: none;
 }
 
 .content {


### PR DESCRIPTION
## Summary
- share avatar + dropdown logic in new `UserMenu` component
- embed `UserMenu` in `Topbar` and `Sidebar`
- tweak sidebar CSS so the menu works in both contexts

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68482e5c5480832fbfec147c7e977edd