### PR TITLE
Remove sidebar user menu, improve dropdown

### DIFF
--- a/Frontend/app/src/components/Sidebar.jsx
+++ b/Frontend/app/src/components/Sidebar.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext'; // Se precisar do logout ou dados do usuário
 import './Sidebar.css'; // Certifique-se de que este arquivo CSS existe e está correto
-import UserMenu from './UserMenu.jsx';
 
 // Ícones (exemplo, substitua pelos seus ou remova se não usar)
 import {
@@ -19,7 +18,7 @@ import {
 } from 'react-icons/lu'; // Exemplo com react-icons
 
 const Sidebar = ({ isOpen, toggleSidebar }) => {
-  const { user, logout } = useAuth(); // Obtenha o usuário e a função de logout do AuthContext
+  const { logout } = useAuth();
 
   const handleLogout = () => {
     logout();
@@ -63,11 +62,6 @@ const Sidebar = ({ isOpen, toggleSidebar }) => {
         </ul>
       </nav>
       <div className="sidebar-footer">
-        {user && (
-          <div className="user-info">
-            <UserMenu onLogout={handleLogout} showDropdown={isOpen} />
-          </div>
-        )}
         <button onClick={handleLogout} className="logout-button" title="Sair">
           <LuLogOut />
           {isOpen && <span className="nav-text">Sair</span>}

--- a/Frontend/app/src/components/UserMenu.jsx
+++ b/Frontend/app/src/components/UserMenu.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -16,6 +16,7 @@ function UserMenu({ onLogout, onNavigate, showDropdown = true }) {
   const navigate = useNavigate();
   const { user, logout, isLoading } = useAuth();
   const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef(null);
 
   const userNameDisplay = isLoading ? 'Carregando...' : (user?.nome_completo || user?.email || 'Usuário');
   const userInitials = isLoading ? '...' : getInitials(user?.nome_completo || user?.email);
@@ -40,18 +41,25 @@ function UserMenu({ onLogout, onNavigate, showDropdown = true }) {
 
   const enableMenu = showDropdown;
 
+  useEffect(() => {
+    if (!menuOpen) return;
+    function handleClickOutside(e) {
+      if (menuRef.current && !menuRef.current.contains(e.target)) {
+        setMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [menuOpen]);
+
+  const toggleMenu = () => {
+    if (enableMenu) setMenuOpen(prev => !prev);
+  };
+
   return (
-    <div
-      className="user-area"
-      tabIndex={enableMenu ? '0' : undefined}
-      onMouseEnter={() => enableMenu && setMenuOpen(true)}
-      onMouseLeave={() => enableMenu && setMenuOpen(false)}
-      onClick={() => enableMenu && setMenuOpen(prev => !prev)}
-      onFocus={() => enableMenu && setMenuOpen(true)}
-      onBlur={() => enableMenu && setTimeout(() => setMenuOpen(false), 150)}
-    >
-      <div className="user-avatar">{userInitials}</div>
-      <span className="user-name">{userNameDisplay}</span>
+    <div className="user-area" ref={menuRef} tabIndex={enableMenu ? '0' : undefined}>
+      <div className="user-avatar" onClick={toggleMenu}>{userInitials}</div>
+      <span className="user-name" onClick={toggleMenu}>{userNameDisplay}</span>
 
       {enableMenu && menuOpen && (
         <div className="user-menu" style={{ display: 'flex' }}>

--- a/Frontend/app/src/index.css
+++ b/Frontend/app/src/index.css
@@ -237,20 +237,6 @@ button[disabled], button:disabled {
   opacity: 0.7;
 }
 
-/* Ajustes para o UserMenu dentro da sidebar */
-.sidebar .user-area {
-  justify-content: center;
-}
-.sidebar .user-menu {
-  left: 0;
-  right: auto;
-}
-.sidebar.closed .user-menu {
-  display: none;
-}
-.sidebar.closed .user-name {
-  display: none;
-}
 
 .content {
   flex: 1; /* .content ocupa o espaço vertical restante no .main */


### PR DESCRIPTION
## Summary
- remove `UserMenu` from sidebar layout
- convert dropdown to click toggle with outside click handling
- clean up sidebar dropdown styles

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm test --silent` in `Frontend/app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684830af8974832fa038acf8a32f9a22