### PR TITLE
Add historico tipos endpoint and dynamic filter

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -28,6 +28,7 @@ from Backend.routers.web_enrichment import router as web_enrichment_router
 from Backend.routers.uploads import router as uploads_router
 from Backend.routers.product_types import router as product_types_router
 from Backend.routers.uso_ia import router as uso_ia_router
+from Backend.routers.historico import router as historico_router
 from Backend.routers.password_recovery import router as password_recovery_router
 from Backend.routers.admin_analytics import router as admin_analytics_router
 from Backend.routers.social_auth import router as social_auth_router
@@ -358,6 +359,7 @@ app.include_router(uploads_router, prefix=settings.API_V1_STR, tags=["Uploads de
 app.include_router(product_types_router, prefix=settings.API_V1_STR, tags=["Tipos de Produto e Templates"])
 app.include_router(search_router, prefix=settings.API_V1_STR, tags=["Busca"])
 app.include_router(uso_ia_router, prefix=settings.API_V1_STR, tags=["Registro de Uso de IA"])
+app.include_router(historico_router, prefix=settings.API_V1_STR, tags=["Registro de Uso de IA"])
 app.include_router(password_recovery_router, prefix=settings.API_V1_STR, tags=["Recuperação de Senha"])
 app.include_router(admin_analytics_router, prefix=settings.API_V1_STR + "/admin/analytics", tags=["Analytics (Admin)"])
 

--- a/Backend/routers/historico.py
+++ b/Backend/routers/historico.py
@@ -1,0 +1,18 @@
+from typing import List
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from Backend.database import get_db
+from Backend import models
+from . import auth_utils
+
+router = APIRouter(
+    prefix="/historico",
+    tags=["Histórico de IA"],
+    dependencies=[Depends(auth_utils.get_current_active_user)],
+)
+
+@router.get("/tipos", response_model=List[str])
+def get_tipos_acao(db: Session = Depends(get_db)):
+    """Retorna todos os valores possíveis de TipoAcaoIAEnum."""
+    return [enum_member.value for enum_member in models.TipoAcaoIAEnum]

--- a/Frontend/app/src/pages/HistoricoPage.jsx
+++ b/Frontend/app/src/pages/HistoricoPage.jsx
@@ -17,6 +17,7 @@ function HistoricoPage() {
   const [limitPerPage] = useState(10);
   const [totalHistoricoCount, setTotalHistoricoCount] = useState(0);
   const [filterTipoAcao, setFilterTipoAcao] = useState('');
+  const [tiposAcao, setTiposAcao] = useState([]);
 
   const totalPages = Math.ceil(totalHistoricoCount / limitPerPage);
 
@@ -76,6 +77,20 @@ function HistoricoPage() {
     fetchHistorico();
   }, [fetchHistorico]);
 
+  useEffect(() => {
+    const loadTipos = async () => {
+      try {
+        const data = await usoIAService.getTiposHistorico();
+        if (Array.isArray(data)) {
+          setTiposAcao(data);
+        }
+      } catch (err) {
+        console.error('Erro ao carregar tipos de histórico:', err);
+      }
+    };
+    loadTipos();
+  }, []);
+
   const handlePageChange = (newPage) => {
     setCurrentPage(newPage);
   };
@@ -101,11 +116,9 @@ function HistoricoPage() {
             disabled={loading}
           >
             <option value="">Todos</option>
-            <option value="geracao_titulo_produto">Geração Título Produto</option>
-            <option value="geracao_descricao_produto">Geração Descrição Produto</option>
-            <option value="enriquecimento_web_produto">Enriquecimento Web Produto</option>
-            <option value="criacao_produto">Criação de Produto</option>
-            {/* Adicione outras opções conforme as TipoAcaoIAEnum do seu backend */}
+            {tiposAcao.map((tipo) => (
+              <option key={tipo} value={tipo}>{tipo.replace(/_/g, ' ')}</option>
+            ))}
           </select>
         </div>
 

--- a/Frontend/app/src/services/usoIAService.js
+++ b/Frontend/app/src/services/usoIAService.js
@@ -2,6 +2,7 @@
 import apiClient from './apiClient';
 
 const USO_IA_RESOURCE_URL = '/uso-ia';
+const HISTORICO_RESOURCE_URL = '/historico';
 
 const usoIAService = {
   /**
@@ -34,6 +35,16 @@ const usoIAService = {
     } catch (error) {
       console.error('Error fetching my IA usage history:', error.response?.data || error.message);
       throw error.response?.data || new Error('Failed to fetch my IA usage history');
+    }
+  },
+
+  async getTiposHistorico() {
+    try {
+      const response = await apiClient.get(`${HISTORICO_RESOURCE_URL}/tipos`);
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching historico types:', error.response?.data || error.message);
+      throw error.response?.data || new Error('Failed to fetch historico types');
     }
   },
 };


### PR DESCRIPTION
## Summary
- add `/historico/tipos` route to expose available action types
- register new router in backend app
- fetch available types on Historico page and populate filter dropdown
- support new endpoint in `usoIAService`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684831c81128832f938ff9e7a451629a