### PR TITLE
Rename TipoAcao enum

### DIFF
--- a/Backend/alembic/versions/440d06ca18c5_rename_tipoacaoenum.py
+++ b/Backend/alembic/versions/440d06ca18c5_rename_tipoacaoenum.py
@@ -1,0 +1,22 @@
+"""rename TipoAcaoIAEnum to TipoAcaoEnum
+
+Revision ID: 440d06ca18c5
+Revises: ('de2f5f4cc0f6', 'ab0264b3dd00')
+Create Date: 2025-06-15 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '440d06ca18c5'
+down_revision: Union[str, Sequence[str], None] = ('de2f5f4cc0f6', 'ab0264b3dd00')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TYPE tipoacaoiaenum RENAME TO tipoacaoenum")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TYPE tipoacaoenum RENAME TO tipoacaoiaenum")

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -35,7 +35,7 @@ class StatusGeracaoIAEnum(str, enum.Enum):
     FALHA = "FALHA"
     NAO_APLICAVEL = "NAO_APLICAVEL" # Se IA não for usada para este campo/produto
 
-class TipoAcaoIAEnum(str, enum.Enum):
+class TipoAcaoEnum(str, enum.Enum):
     CRIACAO_TITULO_PRODUTO = "criacao_titulo_produto"
     CRIACAO_DESCRICAO_PRODUTO = "criacao_descricao_produto"
     ENRIQUECIMENTO_WEB_PRODUTO = "enriquecimento_web_produto" # Ação de buscar dados na web com ou sem IA
@@ -309,7 +309,7 @@ class RegistroUsoIA(Base):
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     produto_id = Column(Integer, ForeignKey("produtos.id", ondelete="SET NULL"), nullable=True) # Se o produto for deletado, manter o registro de uso
     
-    tipo_acao = Column(SQLAlchemyEnum(TipoAcaoIAEnum), nullable=False) # Usar o Enum Python
+    tipo_acao = Column(SQLAlchemyEnum(TipoAcaoEnum, name="tipoacaoenum"), nullable=False)  # Usar o Enum Python
     provedor_ia = Column(String, nullable=True) # ex: "openai", "gemini"
     modelo_ia = Column(String, nullable=True) # ex: "gpt-3.5-turbo", "gemini-1.5-flash-latest"
     

--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -65,7 +65,7 @@ def create_produto( # Nome da função mantido como no arquivo do usuário
         schemas.RegistroUsoIACreate(
             user_id=current_user.id,
             produto_id=db_produto.id,
-            tipo_acao=models.TipoAcaoIAEnum.CRIACAO_PRODUTO,
+            tipo_acao=models.TipoAcaoEnum.CRIACAO_PRODUTO,
             creditos_consumidos=0,
         ),
     )
@@ -337,7 +337,7 @@ async def importar_catalogo_fornecedor(
             schemas.RegistroUsoIACreate(
                 user_id=current_user.id,
                 produto_id=db_produto.id,
-                tipo_acao=models.TipoAcaoIAEnum.CRIACAO_PRODUTO,
+                tipo_acao=models.TipoAcaoEnum.CRIACAO_PRODUTO,
                 creditos_consumidos=0,
             ),
         )

--- a/Backend/routers/web_enrichment.py
+++ b/Backend/routers/web_enrichment.py
@@ -99,7 +99,7 @@ async def _tarefa_enriquecer_produto_web(
                 registro_uso=schemas.RegistroUsoIACreate(
                     user_id=user.id,
                     produto_id=produto_id,
-                    tipo_acao=models.TipoAcaoIAEnum.ENRIQUECIMENTO_WEB_PRODUTO,
+                    tipo_acao=models.TipoAcaoEnum.ENRIQUECIMENTO_WEB_PRODUTO,
                     modelo_ia="N/A",
                     provedor_ia=None,
                     prompt_utilizado="N/A",
@@ -122,7 +122,7 @@ async def _tarefa_enriquecer_produto_web(
                 registro_uso=schemas.RegistroUsoIACreate(
                     user_id=user.id,
                     produto_id=produto_id,
-                    tipo_acao=models.TipoAcaoIAEnum.ENRIQUECIMENTO_WEB_PRODUTO,
+                    tipo_acao=models.TipoAcaoEnum.ENRIQUECIMENTO_WEB_PRODUTO,
                     modelo_ia="N/A",
                     provedor_ia=None,
                     prompt_utilizado="N/A - Config OpenAI pendente para LLM",

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -10,7 +10,7 @@ import json # Para validação de JSON string
 # a importação direta pode funcionar. Caso contrário, pode ser necessário um ajuste
 # relativo ou absoluto dependendo de como o projeto é executado.
 # Assumindo que 'models.py' está no mesmo diretório (Backend) e é acessível:
-from Backend.models import StatusEnriquecimentoEnum, StatusGeracaoIAEnum, TipoAcaoIAEnum, AttributeFieldTypeEnum
+from Backend.models import StatusEnriquecimentoEnum, StatusGeracaoIAEnum, TipoAcaoEnum, AttributeFieldTypeEnum
 
 # Schemas de Autenticação e Usuário
 class Token(BaseModel):
@@ -324,7 +324,7 @@ class ProdutoPage(BaseModel):
 class RegistroUsoIABase(BaseModel):
     user_id: int
     produto_id: Optional[int] = None
-    tipo_acao: TipoAcaoIAEnum
+    tipo_acao: TipoAcaoEnum
     provedor_ia: Optional[str] = None
     modelo_ia: Optional[str] = None
     prompt_utilizado: Optional[str] = None
@@ -391,7 +391,7 @@ class RecentActivity(BaseModel):
     id: int
     user_id: int
     user_email: Optional[EmailStr] = None
-    tipo_acao: TipoAcaoIAEnum
+    tipo_acao: TipoAcaoEnum
     created_at: datetime
     class Config:
         from_attributes = True

--- a/Backend/services/ia_generation_service.py
+++ b/Backend/services/ia_generation_service.py
@@ -11,7 +11,7 @@ from fastapi import HTTPException, status, Depends
 
 from Backend import crud
 from Backend import crud_produtos
-from Backend import models  # models completo para acesso a TipoAcaoIAEnum
+from Backend import models  # models completo para acesso a TipoAcaoEnum
 from Backend import schemas
 from Backend.core.config import settings
 from . import limit_service # Para verificar e consumir limites/créditos
@@ -252,7 +252,7 @@ async def gerar_titulos_com_openai(db: Session, produto_id: int, user: models.Us
     titulos_list = [t.strip() for t in titulos_str.split('\n') if t.strip()]
 
     crud.create_registro_uso_ia(db, registro_uso=schemas.RegistroUsoIACreate(
-        user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO,
+        user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoEnum.CRIACAO_TITULO_PRODUTO,
         provedor_ia="openai", modelo_ia=OPENAI_DEFAULT_MODEL, creditos_consumidos=1 # Ajustar créditos
     ))
     return titulos_list[:num_titulos]
@@ -280,7 +280,7 @@ async def gerar_descricao_com_openai(db: Session, produto_id: int, user: models.
     descricao = await call_openai_api(prompt_messages, api_key, max_tokens=tamanho_palavras + 100) # Estimar tokens
 
     crud.create_registro_uso_ia(db, registro_uso=schemas.RegistroUsoIACreate(
-        user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoIAEnum.CRIACAO_DESCRICAO_PRODUTO,
+        user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoEnum.CRIACAO_DESCRICAO_PRODUTO,
         provedor_ia="openai", modelo_ia=OPENAI_DEFAULT_MODEL, creditos_consumidos=1 # Ajustar créditos
     ))
     return descricao
@@ -310,7 +310,7 @@ async def gerar_titulos_com_gemini(db: Session, produto_id: int, user: models.Us
     crud.create_registro_uso_ia(db, registro_uso=schemas.RegistroUsoIACreate(
         user_id=user.id,
         produto_id=produto_id,
-        tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO,
+        tipo_acao=models.TipoAcaoEnum.CRIACAO_TITULO_PRODUTO,
         provedor_ia="gemini",
         modelo_ia="gemini-1.5-flash-latest",
         creditos_consumidos=1,
@@ -342,7 +342,7 @@ async def gerar_descricao_com_gemini(db: Session, produto_id: int, user: models.
     crud.create_registro_uso_ia(db, registro_uso=schemas.RegistroUsoIACreate(
         user_id=user.id,
         produto_id=produto_id,
-        tipo_acao=models.TipoAcaoIAEnum.CRIACAO_DESCRICAO_PRODUTO,
+        tipo_acao=models.TipoAcaoEnum.CRIACAO_DESCRICAO_PRODUTO,
         provedor_ia="gemini",
         modelo_ia="gemini-1.5-flash-latest",
         creditos_consumidos=1,
@@ -385,7 +385,7 @@ async def sugerir_valores_atributos_com_gemini(
     if not chaves_para_sugerir:
         logger.info(f"Nenhum atributo definido no Tipo de Produto para produto ID {produto_id}. Retornando sugestões vazias.")
         crud.create_registro_uso_ia(db, registro_uso=schemas.RegistroUsoIACreate(
-            user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoIAEnum.SUGESTAO_ATRIBUTOS_GEMINI,
+            user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoEnum.SUGESTAO_ATRIBUTOS_GEMINI,
             provedor_ia="gemini", creditos_consumidos=0, status="INFO", # Não consumiu créditos se não houve chamada
             detalhes_erro="Nenhum atributo definido no Tipo de Produto para gerar sugestões."
         ))
@@ -475,7 +475,7 @@ async def sugerir_valores_atributos_com_gemini(
         
         # 7. Registrar Uso
         crud.create_registro_uso_ia(db, registro_uso=schemas.RegistroUsoIACreate(
-            user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoIAEnum.SUGESTAO_ATRIBUTOS_GEMINI,
+            user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoEnum.SUGESTAO_ATRIBUTOS_GEMINI,
             provedor_ia="gemini", modelo_ia=modelo_utilizado, creditos_consumidos=creditos_necessarios, status="SUCESSO",
             prompt_utilizado=prompt_final # Para auditoria
             # resposta_ia=json.dumps(sugestoes_dict) # Pode ser muito grande, opcional
@@ -489,7 +489,7 @@ async def sugerir_valores_atributos_com_gemini(
 
     except HTTPException as e: # Repassa HTTPExceptions de call_gemini_api_for_suggestions ou de verificações
         crud.create_registro_uso_ia(db, registro_uso=schemas.RegistroUsoIACreate(
-            user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoIAEnum.SUGESTAO_ATRIBUTOS_GEMINI,
+            user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoEnum.SUGESTAO_ATRIBUTOS_GEMINI,
             provedor_ia="gemini", modelo_ia=modelo_utilizado, creditos_consumidos=creditos_necessarios,
             status="FALHA", detalhes_erro=str(e.detail)
         ))
@@ -497,7 +497,7 @@ async def sugerir_valores_atributos_com_gemini(
     except Exception as e:
         logger.error(f"Erro geral no serviço de sugestão Gemini: {str(e)}", exc_info=True)
         crud.create_registro_uso_ia(db, registro_uso=schemas.RegistroUsoIACreate(
-            user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoIAEnum.SUGESTAO_ATRIBUTOS_GEMINI,
+            user_id=user.id, produto_id=produto_id, tipo_acao=models.TipoAcaoEnum.SUGESTAO_ATRIBUTOS_GEMINI,
             provedor_ia="gemini", modelo_ia=modelo_utilizado, creditos_consumidos=creditos_necessarios,
             status="FALHA", detalhes_erro=f"Erro inesperado no serviço de sugestão: {str(e)}"
         ))

--- a/tests/test_admin_analytics.py
+++ b/tests/test_admin_analytics.py
@@ -31,7 +31,7 @@ with TestingSessionLocal() as db:
     crud.create_initial_data(db)
     admin = crud_users.get_user_by_email(db, settings.FIRST_SUPERUSER_EMAIL)
     crud_produtos.create_produto(db, schemas.ProdutoCreate(nome_base="Teste"), user_id=admin.id)
-    crud.create_registro_uso_ia(db, schemas.RegistroUsoIACreate(user_id=admin.id, tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO))
+    crud.create_registro_uso_ia(db, schemas.RegistroUsoIACreate(user_id=admin.id, tipo_acao=models.TipoAcaoEnum.CRIACAO_TITULO_PRODUTO))
 
 def get_auth_headers():
     resp = client.post("/api/v1/auth/token", data={"username": settings.FIRST_SUPERUSER_EMAIL, "password": settings.FIRST_SUPERUSER_PASSWORD})

--- a/tests/test_limit_service.py
+++ b/tests/test_limit_service.py
@@ -19,12 +19,12 @@ async def test_verificar_e_consumir_creditos_geracao_ia():
     db.refresh(user)
 
     for _ in range(4):
-        db.add(models.RegistroUsoIA(user_id=user.id, tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO))
+        db.add(models.RegistroUsoIA(user_id=user.id, tipo_acao=models.TipoAcaoEnum.CRIACAO_TITULO_PRODUTO))
     db.commit()
 
     assert await limit_service.verificar_e_consumir_creditos_geracao_ia(db, user.id, 1)
 
-    db.add(models.RegistroUsoIA(user_id=user.id, tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO))
+    db.add(models.RegistroUsoIA(user_id=user.id, tipo_acao=models.TipoAcaoEnum.CRIACAO_TITULO_PRODUTO))
     db.commit()
 
     assert not await limit_service.verificar_e_consumir_creditos_geracao_ia(db, user.id, 1)

--- a/tests/test_uso_ia.py
+++ b/tests/test_uso_ia.py
@@ -43,7 +43,7 @@ with TestingSessionLocal() as db:
         schemas.RegistroUsoIACreate(
             user_id=normal_user.id,
             produto_id=produto.id,
-            tipo_acao=models.TipoAcaoIAEnum.CRIACAO_TITULO_PRODUTO,
+            tipo_acao=models.TipoAcaoEnum.CRIACAO_TITULO_PRODUTO,
         ),
     )
 
@@ -95,7 +95,7 @@ def test_product_creation_creates_uso_ia_record():
             db.query(models.RegistroUsoIA)
             .filter(
                 models.RegistroUsoIA.produto_id == produto_id,
-                models.RegistroUsoIA.tipo_acao == models.TipoAcaoIAEnum.CRIACAO_PRODUTO,
+                models.RegistroUsoIA.tipo_acao == models.TipoAcaoEnum.CRIACAO_PRODUTO,
             )
             .all()
         )


### PR DESCRIPTION
## Summary
- rename `TipoAcaoIAEnum` -> `TipoAcaoEnum`
- update code and tests to use new enum
- add Alembic migration to rename DB enum type

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684831c76d64832fbcf799e4d25e43e2