### PR TITLE
Update docs for RegistroHistorico

### DIFF
--- a/README Backend.md
+++ b/README Backend.md
@@ -51,6 +51,8 @@
 * `upgrade()`: Cria todas as tabelas e constraints necessárias.
 * `downgrade()`: Remove as tabelas criadas na migration.
 
+* Nova migration cria a tabela `registros_historico` para armazenar ações.
+
 ---
 
 ## Backend/auth.py
@@ -169,6 +171,11 @@
 
   * **Atributos**: id, user\_id, tipo, tokens, data.
   * `__repr__()`: Retorna representação textual do uso de IA.
+* `class RegistroHistorico(Base)`: Armazena ações realizadas e execuções de IA.
+
+  * **Atributos**: id, user_id, produto_id, tipo_acao, detalhes e timestamps.
+  * `__repr__()`: Retorna representação textual do registro.
+
 
 ---
 
@@ -234,6 +241,11 @@
 
 * `get_ia_usage(user_id: int, db: Session)`: Retorna uso de IA do usuário.
 * `get_ia_usage_admin(db: Session)`: Retorna relatório geral de uso IA.
+
+## Backend/routers/historico.py
+
+* `list_historico(...)`: Lista ações salvas no RegistroHistorico por usuário.
+* `get_tipos_acao()`: Retorna os valores do enum TipoAcaoIAEnum.
 
 ## Backend/routers/web\_enrichment.py
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ O **TDAI** é uma plataforma SaaS de automação e inteligência artificial para
 * Controle total de fornecedores, tipos e atributos
 * Administração de planos, permissões, créditos e limites
 * Painéis de analytics e controle de uso de IA
+* Registro histórico de ações realizadas e execuções de IA
 
 ---
 
@@ -214,7 +215,7 @@ python -m venv venv
 source venv/bin/activate    # Ou .\venv\Scripts\activate no Windows
 pip install -r requirements-backend.txt   # dependências fixas do backend
 cd Backend
-alembic upgrade head        # Cria as tabelas do banco
+alembic upgrade head        # Cria/atualiza tabelas, incluindo RegistroHistorico
 cd ..
 python run_backend.py       # Inicia o backend (http://localhost:8000)
 ```
@@ -351,7 +352,7 @@ que coincidam.
   `python run_backend.py`
 
 * **Rodar Migrations:**
-  `cd Backend && alembic upgrade head`
+  `cd Backend && alembic upgrade head`  # aplica migrações, inclusive a tabela RegistroHistorico
 
 * **Instalar navegadores Playwright:**
   `playwright install`
@@ -363,8 +364,19 @@ que coincidam.
 
 * **Explorar Endpoints API:**
 
-  * `/produtos/`, `/fornecedores/`, `/uploads/`, `/generation/`, `/web-enrichment/`, `/uso_ia/` etc.
+  * `/produtos/`, `/fornecedores/`, `/uploads/`, `/generation/`, `/web-enrichment/`, `/uso_ia/`, `/historico/` etc.
   * Veja todos em `/docs`
+  * Para listar os tipos de ações suportados, consulte `GET /historico/tipos`
+
+### Exemplo de uso no Frontend
+
+```javascript
+import usoIAService from './services/usoIAService';
+
+// Buscar histórico de IA do usuário logado
+const historico = await usoIAService.getMeuHistoricoUsoIA({ skip: 0, limit: 10 });
+console.log(historico.items);
+```
 
 ---
 


### PR DESCRIPTION
## Summary
- document RegistroHistorico and new /historico endpoints
- mention migrations for the new table
- show how to fetch action types and example frontend usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684831c93b60832f89af1366f9a0e906