### PR TITLE
Fix fornecedor service endpoints

### DIFF
--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -22,7 +22,7 @@ export const getFornecedores = async (params = {}) => { // params pode incluir s
 
 export const getFornecedorById = async (fornecedorId) => {
   try {
-    const response = await apiClient.get(`/fornecedores/${fornecedorId}/`);
+    const response = await apiClient.get(`/fornecedores/${fornecedorId}`);
     return response.data;
   } catch (error) {
     console.error(`Error fetching fornecedor ${fornecedorId} (SERVICE LEVEL):`, JSON.stringify(error.response?.data || error.message || error));
@@ -55,7 +55,7 @@ export const createFornecedor = async (fornecedorData) => {
 
 export const updateFornecedor = async (fornecedorId, fornecedorUpdateData) => {
   try {
-    const response = await apiClient.put(`/fornecedores/${fornecedorId}/`, fornecedorUpdateData);
+    const response = await apiClient.put(`/fornecedores/${fornecedorId}`, fornecedorUpdateData);
     return response.data;
   } catch (error) {
     console.error(`Error updating fornecedor ${fornecedorId} (SERVICE LEVEL):`, JSON.stringify(error.response?.data || error.message || error));
@@ -71,7 +71,7 @@ export const updateFornecedor = async (fornecedorId, fornecedorUpdateData) => {
 
 export const deleteFornecedor = async (fornecedorId) => {
   try {
-    const response = await apiClient.delete(`/fornecedores/${fornecedorId}/`);
+    const response = await apiClient.delete(`/fornecedores/${fornecedorId}`);
     return response.data;
   } catch (error) {
     console.error(`Error deleting fornecedor ${fornecedorId} (SERVICE LEVEL):`, JSON.stringify(error.response?.data || error.message || error));


### PR DESCRIPTION
## Summary
- fix supplier service endpoints to avoid logout

## Testing
- `npm run lint` *(fails: ESLint dependencies missing)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684832a9fe50832fa078f9660feadcf1