### PR TITLE
Add edit modal for product types

### DIFF
--- a/Frontend/app/src/components/product_types/EditProductTypeModal.jsx
+++ b/Frontend/app/src/components/product_types/EditProductTypeModal.jsx
@@ -1,0 +1,70 @@
+import React, { useState, useEffect } from 'react';
+import Modal from '../common/Modal';
+
+const EditProductTypeModal = ({ isOpen, onClose, type, onSave, isSubmitting }) => {
+  const [friendlyName, setFriendlyName] = useState('');
+  const [description, setDescription] = useState('');
+  const [keyName, setKeyName] = useState('');
+
+  useEffect(() => {
+    if (isOpen && type) {
+      setFriendlyName(type.friendly_name || '');
+      setDescription(type.description || '');
+      setKeyName(type.key_name || '');
+    }
+  }, [isOpen, type]);
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    onSave({ friendly_name: friendlyName, description, key_name: keyName });
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Editar Tipo de Produto">
+      <form onSubmit={handleSubmit}>
+        <div className="form-group">
+          <label htmlFor="edit-type-friendly-name">Nome Amigável*</label>
+          <input
+            id="edit-type-friendly-name"
+            type="text"
+            value={friendlyName}
+            onChange={(e) => setFriendlyName(e.target.value)}
+            className="form-control"
+            required
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="form-group">
+          <label htmlFor="edit-type-key-name">Chave</label>
+          <input
+            id="edit-type-key-name"
+            type="text"
+            value={keyName}
+            onChange={(e) => setKeyName(e.target.value)}
+            className="form-control"
+            disabled
+          />
+          <small>Este valor identifica o tipo e normalmente não deve ser alterado.</small>
+        </div>
+        <div className="form-group">
+          <label htmlFor="edit-type-description">Descrição</label>
+          <textarea
+            id="edit-type-description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            className="form-control"
+            disabled={isSubmitting}
+          />
+        </div>
+        <div className="modal-actions">
+          <button type="button" onClick={onClose} className="btn-secondary" disabled={isSubmitting}>Cancelar</button>
+          <button type="submit" className="btn-success" disabled={isSubmitting}>{isSubmitting ? 'Salvando...' : 'Salvar'}</button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default EditProductTypeModal;

--- a/Frontend/app/src/components/product_types/__tests__/EditProductTypeModal.test.jsx
+++ b/Frontend/app/src/components/product_types/__tests__/EditProductTypeModal.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import EditProductTypeModal from '../EditProductTypeModal.jsx';
+
+test('prefills form with product type data', () => {
+  const type = { friendly_name: 'Eletrônicos', key_name: 'eletronicos', description: 'Desc' };
+  render(
+    <EditProductTypeModal isOpen={true} onClose={() => {}} onSave={() => {}} type={type} isSubmitting={false} />
+  );
+  expect(screen.getByLabelText(/Nome Amigável/i)).toHaveValue('Eletrônicos');
+  expect(screen.getByLabelText(/Chave/i)).toHaveValue('eletronicos');
+  expect(screen.getByLabelText(/Descrição/i)).toHaveValue('Desc');
+});
+
+test('calls onSave with updated values', async () => {
+  const type = { friendly_name: 'Eletrônicos', key_name: 'eletronicos', description: 'Desc' };
+  const onSave = jest.fn();
+  render(
+    <EditProductTypeModal isOpen={true} onClose={() => {}} onSave={onSave} type={type} isSubmitting={false} />
+  );
+
+  await userEvent.clear(screen.getByLabelText(/Nome Amigável/i));
+  await userEvent.type(screen.getByLabelText(/Nome Amigável/i), 'Novo Nome');
+  await userEvent.clear(screen.getByLabelText(/Descrição/i));
+  await userEvent.type(screen.getByLabelText(/Descrição/i), 'Nova desc');
+  await userEvent.click(screen.getByText('Salvar'));
+
+  expect(onSave).toHaveBeenCalledWith({ friendly_name: 'Novo Nome', description: 'Nova desc', key_name: 'eletronicos' });
+});

--- a/Frontend/app/src/pages/TiposProdutoPage.css
+++ b/Frontend/app/src/pages/TiposProdutoPage.css
@@ -132,6 +132,11 @@
     color: white;
 }
 
+.type-list-panel .type-actions {
+    display: flex;
+    gap: 0.25rem;
+}
+
 .type-detail-panel {
   flex: 2.5; /* Painel de detalhes um pouco maior */
   background-color: var(--card-bg);


### PR DESCRIPTION
## Summary
- implement `EditProductTypeModal` with editable friendly name and description
- wire edit modal into `TiposProdutoPage` with new handlers
- add edit button to product type list and small CSS updates
- test modal behaviour with RTL

## Testing
- `npm run lint --prefix Frontend/app` *(fails: Cannot find package)*
- `npx jest --runInBand` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684833350a18832fa94a5e1685c66e3e