### PR TITLE
Fix enum name usage

### DIFF
--- a/Backend/routers/historico.py
+++ b/Backend/routers/historico.py
@@ -37,5 +37,5 @@ router = APIRouter(
 
 @router.get("/tipos", response_model=List[str])
 def get_tipos_acao(db: Session = Depends(get_db)):
-    """Retorna todos os valores possíveis de TipoAcaoIAEnum."""
-    return [enum_member.value for enum_member in models.TipoAcaoIAEnum]
+    """Retorna todos os valores possíveis de TipoAcaoEnum."""
+    return [enum_member.value for enum_member in models.TipoAcaoEnum]

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -13,11 +13,10 @@ import json # Para validação de JSON string
 from Backend.models import (
     StatusEnriquecimentoEnum,
     StatusGeracaoIAEnum,
-    TipoAcaoIAEnum,
+    TipoAcaoEnum,
     TipoAcaoSistemaEnum,
     AttributeFieldTypeEnum,
 )
-from Backend.models import StatusEnriquecimentoEnum, StatusGeracaoIAEnum, TipoAcaoEnum, AttributeFieldTypeEnum
 
 # Schemas de Autenticação e Usuário
 class Token(BaseModel):

--- a/README Backend.md
+++ b/README Backend.md
@@ -245,7 +245,7 @@
 ## Backend/routers/historico.py
 
 * `list_historico(...)`: Lista ações salvas no RegistroHistorico por usuário.
-* `get_tipos_acao()`: Retorna os valores do enum TipoAcaoIAEnum.
+* `get_tipos_acao()`: Retorna os valores do enum TipoAcaoEnum.
 
 ## Backend/routers/web\_enrichment.py
 


### PR DESCRIPTION
## Summary
- update schemas import to use `TipoAcaoEnum`
- use the new enum in `historico` router
- update documentation for the renamed enum

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848349543b8832fb6a26434b1f232a2