### PR TITLE
Fix enum migration case

### DIFF
--- a/Backend/alembic/versions/de2f5f4cc0f6_extend_tipoacaoiaenum_with_criacao_produto.py
+++ b/Backend/alembic/versions/de2f5f4cc0f6_extend_tipoacaoiaenum_with_criacao_produto.py
@@ -1,4 +1,4 @@
-"""extend TipoAcaoIAEnum with criacao_produto value
+"""extend TipoAcaoIAEnum with CRIACAO_PRODUTO value
 
 Revision ID: de2f5f4cc0f6
 Revises: e82d95b0cae0
@@ -15,7 +15,7 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.execute("ALTER TYPE tipoacaoiaenum ADD VALUE IF NOT EXISTS 'criacao_produto'")
+    op.execute("ALTER TYPE tipoacaoiaenum ADD VALUE IF NOT EXISTS 'CRIACAO_PRODUTO'")
 
 
 def downgrade() -> None:


### PR DESCRIPTION
## Summary
- fix case of CRIACAO_PRODUTO value in enum migration

## Testing
- `pytest -k uso_ia -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848366423c0832f890d295c4f6b0349