### PR TITLE
Add historico API test

### DIFF
--- a/tests/test_historico.py
+++ b/tests/test_historico.py
@@ -58,3 +58,8 @@ def test_historico_created_on_product_crud():
         assert models.TipoAcaoSistemaEnum.CRIACAO in actions
         assert models.TipoAcaoSistemaEnum.ATUALIZACAO in actions
         assert models.TipoAcaoSistemaEnum.DELECAO in actions
+
+    resp = client.get("/api/v1/historico/", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert len(data["items"]) >= 1


### PR DESCRIPTION
## Summary
- extend historico test to hit the /historico endpoint and verify entries are returned

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68483d1cb344832fb1118c6d456a2373