### PR TITLE
Remove duplicate historico router

### DIFF
--- a/Backend/main.py
+++ b/Backend/main.py
@@ -360,7 +360,6 @@ app.include_router(product_types_router, prefix=settings.API_V1_STR, tags=["Tipo
 app.include_router(search_router, prefix=settings.API_V1_STR, tags=["Busca"])
 app.include_router(uso_ia_router, prefix=settings.API_V1_STR, tags=["Registro de Uso de IA"])
 app.include_router(historico_router, prefix=settings.API_V1_STR, tags=["Historico"])
-app.include_router(historico_router, prefix=settings.API_V1_STR, tags=["Registro de Uso de IA"])
 app.include_router(password_recovery_router, prefix=settings.API_V1_STR, tags=["Recuperação de Senha"])
 app.include_router(admin_analytics_router, prefix=settings.API_V1_STR + "/admin/analytics", tags=["Analytics (Admin)"])
 


### PR DESCRIPTION
## Summary
- fix duplicate inclusion of historico router

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68483d1b816c832fb1ee881d0e9e80b4