### PR TITLE
Unify historico router

### DIFF
--- a/Backend/routers/historico.py
+++ b/Backend/routers/historico.py
@@ -1,11 +1,17 @@
+from typing import List
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
-from Backend import database, models, schemas
 from Backend import crud_historico
+from Backend import database, models, schemas
 from . import auth_utils
 
-router = APIRouter(prefix="/historico", tags=["historico"], dependencies=[Depends(auth_utils.get_current_active_user)])
+router = APIRouter(
+    prefix="/historico",
+    tags=["historico"],
+    dependencies=[Depends(auth_utils.get_current_active_user)],
+)
 
 
 @router.get("/", response_model=schemas.HistoricoPage)
@@ -16,26 +22,15 @@ def list_historico(
     current_user: models.User = Depends(auth_utils.get_current_active_user),
 ):
     user_id_filter = None if current_user.is_superuser else current_user.id
-    items = crud_historico.get_registros_historico(db, user_id=user_id_filter, skip=skip, limit=limit)
+    items = crud_historico.get_registros_historico(
+        db, user_id=user_id_filter, skip=skip, limit=limit
+    )
     total = crud_historico.count_registros_historico(db, user_id=user_id_filter)
     page = skip // limit + 1
     return {"items": items, "total_items": total, "page": page, "limit": limit}
 
-from typing import List
-from fastapi import APIRouter, Depends
-from sqlalchemy.orm import Session
-
-from Backend.database import get_db
-from Backend import models
-from . import auth_utils
-
-router = APIRouter(
-    prefix="/historico",
-    tags=["Histórico de IA"],
-    dependencies=[Depends(auth_utils.get_current_active_user)],
-)
 
 @router.get("/tipos", response_model=List[str])
-def get_tipos_acao(db: Session = Depends(get_db)):
+def get_tipos_acao(db: Session = Depends(database.get_db)):
     """Retorna todos os valores possíveis de TipoAcaoEnum."""
     return [enum_member.value for enum_member in models.TipoAcaoEnum]

--- a/tests/test_historico.py
+++ b/tests/test_historico.py
@@ -58,3 +58,31 @@ def test_historico_created_on_product_crud():
         assert models.TipoAcaoSistemaEnum.CRIACAO in actions
         assert models.TipoAcaoSistemaEnum.ATUALIZACAO in actions
         assert models.TipoAcaoSistemaEnum.DELECAO in actions
+
+
+def test_list_historico_endpoint():
+    headers = get_user_headers()
+    # cria um registro para garantir algum resultado
+    with TestingSessionLocal() as db:
+        crud.create_registro_historico(
+            db,
+            schemas.RegistroHistoricoCreate(
+                user_id=normal_user.id,
+                entidade="Teste",
+                acao=models.TipoAcaoSistemaEnum.CRIACAO,
+                entity_id=123,
+            ),
+        )
+
+    resp = client.get("/api/v1/historico/", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "items" in data
+
+
+def test_get_tipos_acao_endpoint():
+    headers = get_user_headers()
+    resp = client.get("/api/v1/historico/tipos", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)


### PR DESCRIPTION
## Summary
- simplify historico router creation
- add tests for historico endpoints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68483d1a23e0832fa25b348034dd03e1