### PR TITLE
Fix field_type casing

### DIFF
--- a/Frontend/app/src/components/product_types/AttributeTemplateModal.jsx
+++ b/Frontend/app/src/components/product_types/AttributeTemplateModal.jsx
@@ -57,8 +57,13 @@ const AttributeTemplateModal = ({ isOpen, onClose, attribute, onSave, isSubmitti
 
     const payload = { ...formData };
 
+    // Converte o tipo de campo para minúsculas, conforme esperado pelo backend
+    if (payload.field_type) {
+      payload.field_type = payload.field_type.toLowerCase();
+    }
+
     // Valida e formata o campo 'options' se for um tipo de seleção
-    if (payload.field_type === 'SELECT' || payload.field_type === 'MULTISELECT') {
+    if (payload.field_type === 'select' || payload.field_type === 'multiselect') {
       try {
         // Tenta parsear para garantir que é um JSON Array válido
         const parsedOptions = JSON.parse(payload.options);


### PR DESCRIPTION
## Summary
- ensure `field_type` sent from AttributeTemplateModal uses lowercase

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `npm run lint` *(fails: dependências do ESLint não encontradas)*

------
https://chatgpt.com/codex/tasks/task_e_68483f06c700832faf9d92f8f89830dc