### PR TITLE
Add recent historico endpoint with dashboard integration

### DIFF
--- a/Backend/routers/admin_analytics.py
+++ b/Backend/routers/admin_analytics.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 
 from Backend import crud
 from Backend import crud_users
+from Backend import crud_historico
 from Backend import models
 from Backend import schemas
 from Backend.database import get_db
@@ -162,3 +163,14 @@ async def get_recent_activities(db: Session = Depends(get_db), limit: int = Quer
             )
         )
     return activities
+
+
+@router.get("/recent-historico", response_model=List[schemas.RegistroHistoricoResponse],
+            dependencies=[Depends(get_current_active_admin_user)])
+async def get_recent_historico(
+    db: Session = Depends(get_db),
+    limit: int = Query(10, ge=1, le=50)
+):
+    """Retorna os registros históricos mais recentes."""
+    registros = crud_historico.get_registros_historico(db, skip=0, limit=limit)
+    return registros

--- a/Frontend/app/src/pages/DashboardPage.jsx
+++ b/Frontend/app/src/pages/DashboardPage.jsx
@@ -40,7 +40,7 @@ function DashboardPage() {
           try {
             const statusData = await adminService.getProductStatusCounts();
             setStatusCounts(statusData);
-            const activities = await adminService.getRecentActivities();
+            const activities = await adminService.getRecentHistorico(5);
             setRecentActivities(activities);
           } catch (innerErr) {
             console.error('Erro ao buscar dados adicionais do dashboard:', innerErr);
@@ -122,7 +122,7 @@ function DashboardPage() {
   const activityFeed = recentActivities.map(act => ({
     id: act.id,
     icon: '🔔',
-    message: `${act.tipo_acao} - ${act.user_email || act.user_id}`,
+    message: `${act.entidade} - ${act.acao} - ${act.user_id}`,
     date: new Date(act.created_at).toLocaleDateString()
   }));
 

--- a/Frontend/app/src/services/adminService.js
+++ b/Frontend/app/src/services/adminService.js
@@ -34,6 +34,16 @@ const adminService = {
     }
   },
 
+  async getRecentHistorico(limit = 5) {
+    try {
+      const response = await apiClient.get('/admin/analytics/recent-historico', { params: { limit } });
+      return response.data;
+    } catch (error) {
+      console.error('Error fetching recent historico:', error.response?.data || error.message);
+      throw error.response?.data || new Error('Falha ao buscar histórico recente.');
+    }
+  },
+
   // Você pode adicionar outras funções de admin aqui no futuro, como:
   // async getUsoIaPorPlano() { ... }
   // async getUserActivity() { ... }

--- a/tests/test_admin_analytics.py
+++ b/tests/test_admin_analytics.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker
 
 from Backend.main import app
 from Backend.database import Base, get_db
-from Backend import crud, crud_users, crud_produtos, schemas, models
+from Backend import crud, crud_users, crud_produtos, crud_historico, schemas, models
 from Backend.core.config import settings
 
 # disable heavy startup events
@@ -32,6 +32,16 @@ with TestingSessionLocal() as db:
     admin = crud_users.get_user_by_email(db, settings.FIRST_SUPERUSER_EMAIL)
     crud_produtos.create_produto(db, schemas.ProdutoCreate(nome_base="Teste"), user_id=admin.id)
     crud.create_registro_uso_ia(db, schemas.RegistroUsoIACreate(user_id=admin.id, tipo_acao=models.TipoAcaoEnum.CRIACAO_TITULO_PRODUTO))
+    for i in range(7):
+        crud_historico.create_registro_historico(
+            db,
+            schemas.RegistroHistoricoCreate(
+                user_id=admin.id,
+                entidade="Teste",
+                acao=models.TipoAcaoSistemaEnum.CRIACAO,
+                entity_id=i,
+            ),
+        )
 
 def get_auth_headers():
     resp = client.post("/api/v1/auth/token", data={"username": settings.FIRST_SUPERUSER_EMAIL, "password": settings.FIRST_SUPERUSER_PASSWORD})
@@ -52,3 +62,12 @@ def test_recent_activities_endpoint():
     resp = client.get("/api/v1/admin/analytics/recent-activities", headers=headers)
     assert resp.status_code == 200
     assert isinstance(resp.json(), list)
+
+
+def test_recent_historico_endpoint_limit():
+    headers = get_auth_headers()
+    resp = client.get("/api/v1/admin/analytics/recent-historico?limit=5", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+    assert len(data) == 5


### PR DESCRIPTION
## Summary
- add `/recent-historico` endpoint for admins
- expose `getRecentHistorico` on the admin service
- show recent historico entries in dashboard
- test admin analytics new endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848428d02e4832fa7f87474212f15b5