### PR TITLE
Rename TDAI branding to CatalogAI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,11 @@
-# Example environment variables for the TDAI backend
+# Example environment variables for the CatalogAI backend
 # Rename this file to .env and fill in the actual values before running the project
 
 # Database configuration
-DATABASE_URL="postgresql://postgres:password@localhost:5432/tdai_db"
+DATABASE_URL="postgresql://postgres:password@localhost:5432/catalogai_db"
 # If you do not have PostgreSQL available, remove or comment the line above.
 # The backend will automatically use SQLite at the path defined below.
-SQLITE_DB_FILE="tdai_app.db"
+SQLITE_DB_FILE="catalogai_app.db"
 
 # Security settings
 SECRET_KEY="change-me"
@@ -37,14 +37,14 @@ MAIL_PORT=587
 MAIL_SERVER="smtp.example.com"
 MAIL_STARTTLS=True
 MAIL_SSL_TLS=False
-MAIL_FROM_NAME="TDAI Platform"
+MAIL_FROM_NAME="CatalogAI Platform"
 
 # Additional SMTP configuration
 SMTP_SERVER="smtp.seuprovedor.com"
 SMTP_PORT=587
 SMTP_USER="your@email.com"
 SMTP_PASSWORD="senha"
-EMAIL_FROM="TDAI Platform <nao-responda@tdai.com>"
+EMAIL_FROM="CatalogAI Platform <nao-responda@catalogai.com>"
 
 # OAuth2 settings
 GOOGLE_CLIENT_ID=""

--- a/Backend/__init__.py
+++ b/Backend/__init__.py
@@ -1,4 +1,4 @@
-# tdai_project/app/__init__.py
+# catalogai_project/app/__init__.py
 # Este arquivo pode estar vazio.
 # Ele apenas marca o diretório 'app' como um pacote Python.
 

--- a/Backend/alembic.ini
+++ b/Backend/alembic.ini
@@ -60,7 +60,7 @@ version_path_separator = os  # Use os.pathsep. Default configuration used for ne
 # are written from script.py.mako
 # output_encoding = utf-8
 
-sqlalchemy.url = postgresql://postgres:5Dyxbf2o!jt7w@localhost:5432/tdai_db
+sqlalchemy.url = postgresql://postgres:5Dyxbf2o!jt7w@localhost:5432/catalogai_db
 
 
 [post_write_hooks]

--- a/Backend/core/__init__.py
+++ b/Backend/core/__init__.py
@@ -1,3 +1,3 @@
-# tdai_project/app/core/__init__.py
+# catalogai_project/app/core/__init__.py
 # Este arquivo pode estar vazio.
 # Ele marca o diretório 'core' como um subpacote de 'app'.

--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -24,11 +24,11 @@ def env_var_name_with_prefix(field_name: str) -> str:
     return field_name
 
 class Settings(BaseSettings):
-    PROJECT_NAME: str = "TDAI - Transformador de Dados Assistido por IA"
+    PROJECT_NAME: str = "CatalogAI - Transformador de Dados Assistido por IA"
     PROJECT_VERSION: str = "1.0.0"
     API_V1_STR: str = "/api/v1"
     DATABASE_URL: Optional[str] = os.getenv("DATABASE_URL")
-    SQLITE_DB_FILE: str = os.getenv("SQLITE_DB_FILE", "tdai_app.db")
+    SQLITE_DB_FILE: str = os.getenv("SQLITE_DB_FILE", "catalogai_app.db")
 
     SECRET_KEY: str = os.getenv("SECRET_KEY", "super-secret-key-deve-ser-alterada-imediatamente")
     REFRESH_SECRET_KEY: str = os.getenv("REFRESH_SECRET_KEY", "super-refresh-secret-change-me")
@@ -63,7 +63,7 @@ class Settings(BaseSettings):
     MAIL_SSL_TLS: bool = os.getenv("MAIL_SSL_TLS", "False").lower() in ("true", "1", "t")
     USE_CREDENTIALS: bool = bool(os.getenv("MAIL_USERNAME") and os.getenv("MAIL_PASSWORD"))
     VALIDATE_CERTS: bool = True
-    MAIL_FROM_NAME: Optional[str] = os.getenv("MAIL_FROM_NAME", "TDAI Platform")
+    MAIL_FROM_NAME: Optional[str] = os.getenv("MAIL_FROM_NAME", "CatalogAI Platform")
 
     GOOGLE_CLIENT_ID: Optional[str] = os.getenv("GOOGLE_CLIENT_ID")
     GOOGLE_CLIENT_SECRET: Optional[str] = os.getenv("GOOGLE_CLIENT_SECRET")

--- a/Backend/core/email_utils.py
+++ b/Backend/core/email_utils.py
@@ -113,7 +113,7 @@ async def send_password_reset_email(email_to: EmailStr, username: str, reset_lin
         # raise HTTPException(status_code=500, detail="Serviço de email não configurado.")
         return
 
-    subject = "Redefinição de Senha - TDAI"
+    subject = "Redefinição de Senha - CatalogAI"
     template_name = "password_reset_email.html" # Nome do arquivo de template em Backend/templates/
     
     template_body = {

--- a/Backend/database.py
+++ b/Backend/database.py
@@ -1,4 +1,4 @@
-# tdai_project/Backend/database.py
+# catalogai_project/Backend/database.py
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker

--- a/Backend/initial_data.py
+++ b/Backend/initial_data.py
@@ -58,7 +58,7 @@ def create_initial_data(db: Session):
         user_in = schemas.UserCreate(
             email=admin_email,
             password=admin_password,
-            nome_completo="Admin TDAI",
+            nome_completo="Admin CatalogAI",
             plano_id=admin_plano.id if admin_plano else None
         )
         db_admin_user = create_user(db, user_in)

--- a/Backend/main.py
+++ b/Backend/main.py
@@ -58,7 +58,7 @@ except Exception as e:
 app = FastAPI(
     title=settings.PROJECT_NAME,
     version=settings.PROJECT_VERSION,
-    description="API para o sistema TDAI - Ferramenta de Descrição Assistida por IA.",
+    description="API para o sistema CatalogAI - Ferramenta de Descrição Assistida por IA.",
 )
 
 # Configuração do CORS
@@ -190,7 +190,7 @@ async def startup_event_create_defaults():
                 user_in_data = {
                     "email": settings.ADMIN_EMAIL,
                     "password": settings.ADMIN_PASSWORD,
-                    "nome_completo": "Administrador TDAI",
+                    "nome_completo": "Administrador CatalogAI",
                     "plano_id": admin_plano_obj.id if admin_plano_obj else None,
                 }
                 if hasattr(settings, 'ADMIN_IDIOMA_PREFERIDO'):

--- a/Backend/routers/__init__.py
+++ b/Backend/routers/__init__.py
@@ -1,3 +1,3 @@
-# tdai_project/app/routers/__init__.py
+# catalogai_project/app/routers/__init__.py
 # Este arquivo pode estar vazio.
 # Ele marca o diretório 'routers' como um subpacote de 'app'.

--- a/Backend/routers/web_enrichment.py
+++ b/Backend/routers/web_enrichment.py
@@ -1,4 +1,4 @@
-# tdai_project/Backend/routers/web_enrichment.py
+# catalogai_project/Backend/routers/web_enrichment.py
 from fastapi import APIRouter, Depends, HTTPException, status, BackgroundTasks, Query
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError # Para capturar exceções do SQLAlchemy

--- a/Backend/services/__init__.py
+++ b/Backend/services/__init__.py
@@ -1,3 +1,3 @@
-# tdai_project/app/services/__init__.py
+# catalogai_project/app/services/__init__.py
 # Este arquivo pode estar vazio.
 # Ele marca o diretório 'services' como um subpacote de 'app'.

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -1,4 +1,4 @@
-# tdai_project/Backend/services/file_processing_service.py
+# catalogai_project/Backend/services/file_processing_service.py
 import pandas as pd
 import pdfplumber
 import csv

--- a/Backend/services/limit_service.py
+++ b/Backend/services/limit_service.py
@@ -1,4 +1,4 @@
-# tdai_project/Backend/services/limit_service.py
+# catalogai_project/Backend/services/limit_service.py
 from fastapi import HTTPException, status # Removido Depends se não for usado diretamente
 from sqlalchemy.orm import Session
 

--- a/Backend/services/web_data_extractor_service.py
+++ b/Backend/services/web_data_extractor_service.py
@@ -1,4 +1,4 @@
-# tdai_project/Backend/services/web_data_extractor_service.py
+# catalogai_project/Backend/services/web_data_extractor_service.py
 import asyncio
 from playwright.async_api import async_playwright, TimeoutError as PlaywrightTimeoutError
 from bs4 import BeautifulSoup

--- a/Backend/templates/password_reset_email.html
+++ b/Backend/templates/password_reset_email.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Reset de Senha - TDAI</title>
+    <title>Reset de Senha - CatalogAI</title>
     <style>
         body {
             font-family: Arial, sans-serif;
@@ -28,7 +28,7 @@
         .header h1 {
             margin: 0;
             font-size: 24px;
-            color: #0056b3; /* Cor principal do TDAI (exemplo) */
+            color: #0056b3; /* Cor principal do CatalogAI (exemplo) */
         }
         .content p {
             line-height: 1.6;
@@ -58,11 +58,11 @@
 <body>
     <div class="container">
         <div class="header">
-            <h1>TDAI - Sistema Inteligente</h1>
+            <h1>CatalogAI - Sistema Inteligente</h1>
         </div>
         <div class="content">
             <p>Olá {{ username }},</p>
-            <p>Recebemos uma solicitação para redefinir a senha da sua conta no sistema TDAI.</p>
+            <p>Recebemos uma solicitação para redefinir a senha da sua conta no sistema CatalogAI.</p>
             <p>Se foi você quem solicitou, por favor, clique no botão abaixo para criar uma nova senha. Este link é válido por {{ expiration_hours }} hora(s).</p>
             <div class="button-container">
                 <a href="{{ reset_url }}" class="button">Redefinir Minha Senha</a>
@@ -72,7 +72,7 @@
             <p>Se você não solicitou esta alteração, nenhuma ação é necessária e sua senha permanecerá a mesma. Por favor, ignore este email.</p>
         </div>
         <div class="footer">
-            <p>&copy; {{ current_year }} TDAI. Todos os direitos reservados.</p>
+            <p>&copy; {{ current_year }} CatalogAI. Todos os direitos reservados.</p>
             <p>Esta é uma mensagem automática, por favor não responda diretamente a este email.</p>
         </div>
     </div>

--- a/Frontend/app/.env.example
+++ b/Frontend/app/.env.example
@@ -1,4 +1,4 @@
-# Example environment variables for the TDAI frontend
+# Example environment variables for the CatalogAI frontend
 # Rename this file to .env and fill in the actual values before running the project
 
 # Base URL for the backend API

--- a/Frontend/app/src/components/Sidebar.jsx
+++ b/Frontend/app/src/components/Sidebar.jsx
@@ -39,7 +39,7 @@ const Sidebar = ({ isOpen, toggleSidebar }) => {
     <aside className={`sidebar ${isOpen ? 'open' : 'closed'}`}>
       <div className="sidebar-header">
         {/* Pode adicionar um logo ou título aqui */}
-        <h1 className="sidebar-title">{isOpen ? "TDAI" : "T"}</h1>
+        <h1 className="sidebar-title">{isOpen ? "CatalogAI" : "T"}</h1>
         {/* O botão de toggle pode ser movido para o Topbar se preferir */}
         {/* <button onClick={toggleSidebar} className="sidebar-toggle-btn">
           {isOpen ? <LuX /> : <LuMenu />}

--- a/Frontend/app/src/pages/DashboardPage.jsx
+++ b/Frontend/app/src/pages/DashboardPage.jsx
@@ -152,7 +152,7 @@ function DashboardPage() {
 
       {(!currentUser || !currentUser.is_superuser) && !loading && (
         <div style={{ padding: '20px', textAlign: 'center' }}>
-          <h2>Bem-vindo ao TDAI!</h2>
+          <h2>Bem-vindo ao CatalogAI!</h2>
           <p>Seu dashboard personalizado será implementado aqui em breve.</p>
         </div>
       )}

--- a/Frontend/app/src/pages/LoginPage.jsx
+++ b/Frontend/app/src/pages/LoginPage.jsx
@@ -72,7 +72,7 @@ const LoginPage = () => {
     return (
         <div className="login-page-wrapper">
             <div className="login-form-card">
-                <h2>Login TDAI</h2>
+                <h2>Login CatalogAI</h2>
                 <form onSubmit={handleSubmit}>
                     {error && <p className="error-message">{error}</p>}
                     <div className="form-group">

--- a/Prototipos/Frontend/Old/PROD 5.6.html
+++ b/Prototipos/Frontend/Old/PROD 5.6.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TDAI - Gestão de Produtos (Protótipo Frontend)</title>
+    <title>CatalogAI - Gestão de Produtos (Protótipo Frontend)</title>
     <style>
         :root {
             --sidebar-bg: #1f2a40; --sidebar-text: #cfd8e5; --main-bg: #f4f6f8;
@@ -93,7 +93,7 @@
 </head>
 <body>
     <aside class="sidebar">
-        <div class="logo">TDAI</div>
+        <div class="logo">CatalogAI</div>
         <nav>
             <a href="#dashboard">Dashboard</a>
             <a href="#produtos" class="active">Produtos</a>

--- a/Prototipos/Frontend/Old/Produtos 7.4.html
+++ b/Prototipos/Frontend/Old/Produtos 7.4.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TDAI - Gestão de Produtos v7.4 (Melhorias Cadastro)</title>
+    <title>CatalogAI - Gestão de Produtos v7.4 (Melhorias Cadastro)</title>
     <style>
         :root {
             --sidebar-bg: #1f2a40; --sidebar-text: #cfd8e5; --main-bg: #f4f6f8;
@@ -158,7 +158,7 @@
 </head>
 <body>
     <aside class="sidebar">
-        <div class="logo">TDAI</div>
+        <div class="logo">CatalogAI</div>
         <nav>
             <a href="#" onclick="showView('view-dashboard')" id="nav-dashboard">Dashboard</a>
             <a href="#" onclick="showView('view-produtos')" id="nav-produtos" class="active">Produtos</a>

--- a/Prototipos/Frontend/Old/Produtos 7.5.html
+++ b/Prototipos/Frontend/Old/Produtos 7.5.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TDAI - Gestão de Produtos v7.4 (Corrigido)</title>
+    <title>CatalogAI - Gestão de Produtos v7.4 (Corrigido)</title>
     <style>
         :root {
             --sidebar-bg: #1f2a40; --sidebar-text: #cfd8e5; --main-bg: #f4f6f8;
@@ -175,7 +175,7 @@
 </head>
 <body>
     <aside class="sidebar">
-        <div class="logo">TDAI</div>
+        <div class="logo">CatalogAI</div>
         <nav>
             <a href="#" onclick="showView('view-dashboard')" id="nav-dashboard">Dashboard</a>
             <a href="#" onclick="showView('view-produtos')" id="nav-produtos" class="active">Produtos</a>

--- a/Prototipos/Frontend/Old/prod 5.5.html
+++ b/Prototipos/Frontend/Old/prod 5.5.html
@@ -2,7 +2,7 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8">
-  <title>TDAI - Produtos & Categorias</title>
+  <title>CatalogAI - Produtos & Categorias</title>
   <meta name="viewport" content="width=device-width,initial-scale=1">
   <style>
     body {margin:0;padding:0;background:#f4f6fa;font-family:'Segoe UI',Arial,sans-serif;}
@@ -121,12 +121,12 @@ function showToast(msg) {
 }
 // Produto lista
 function getProdutos() {
-  let d = localStorage.getItem('tdai_produtos');
+  let d = localStorage.getItem('catalogai_produtos');
   if (!d) return [];
   try { return JSON.parse(d); } catch { return []; }
 }
 function saveProdutos(prods) {
-  localStorage.setItem('tdai_produtos', JSON.stringify(prods));
+  localStorage.setItem('catalogai_produtos', JSON.stringify(prods));
 }
 function renderProdList() {
   let list = getProdutos();
@@ -152,12 +152,12 @@ function limparProdutoForm() {
 }
 // --- Categoria ---
 function getCategorias() {
-  let data = localStorage.getItem('tdai_categorias2');
+  let data = localStorage.getItem('catalogai_categorias2');
   if (!data) return [];
   try { return JSON.parse(data); } catch { return []; }
 }
 function saveCategorias(cats) {
-  localStorage.setItem('tdai_categorias2', JSON.stringify(cats));
+  localStorage.setItem('catalogai_categorias2', JSON.stringify(cats));
 }
 function categoriasExemplo() {
   if(getCategorias().length) return;

--- a/Prototipos/Frontend/Old/prod 5.7.html
+++ b/Prototipos/Frontend/Old/prod 5.7.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TDAI - Gestão de Produtos v6 (UX Polido & i18n)</title>
+    <title>CatalogAI - Gestão de Produtos v6 (UX Polido & i18n)</title>
     <style>
         :root {
             --sidebar-bg: #1f2a40; --sidebar-text: #cfd8e5; --main-bg: #f4f6f8;
@@ -123,7 +123,7 @@
 </head>
 <body>
     <aside class="sidebar">
-        <div class="logo" data-lang-key="logo_text">TDAI</div>
+        <div class="logo" data-lang-key="logo_text">CatalogAI</div>
         <nav>
             <a href="#" onclick="showView('view-dashboard')" id="nav-dashboard" data-lang-key="nav_dashboard">Dashboard</a>
             <a href="#" onclick="showView('view-produtos')" id="nav-produtos" class="active" data-lang-key="nav_products">Produtos</a>
@@ -336,7 +336,7 @@
         // --- INTERNACIONALIZAÇÃO (i18n) ---
         const uiStrings = {
             pt: {
-                logo_text: "TDAI", nav_dashboard: "Dashboard", nav_products: "Produtos", nav_product_types: "Tipos de Produto", nav_settings: "Configurações",
+                logo_text: "CatalogAI", nav_dashboard: "Dashboard", nav_products: "Produtos", nav_product_types: "Tipos de Produto", nav_settings: "Configurações",
                 viewtitle_products: "Produtos", product_list_title: "Lista de Produtos", btn_new_product: "✨ Novo Produto", product_list_placeholder: "(Protótipo: Tabela de produtos iria aqui)",
                 manage_product_types_title: "Gerenciar Tipos de Produto", btn_clone_type: "Clonar Tipo", btn_new_type_admin: "Novo Tipo de Produto",
                 registered_types_title: "Tipos Cadastrados:", select_type_to_edit_msg: "Selecione um Tipo para ver/editar.",
@@ -371,7 +371,7 @@
                 alert_ia_fetching_suggestions: "IA buscando sugestões de valores...", alert_ia_suggestions_done: "Sugestões de valores carregadas!",
             },
             en: { // Basic English translations
-                logo_text: "TDAI", nav_dashboard: "Dashboard", nav_products: "Products", nav_product_types: "Product Types", nav_settings: "Settings",
+                logo_text: "CatalogAI", nav_dashboard: "Dashboard", nav_products: "Products", nav_product_types: "Product Types", nav_settings: "Settings",
                 viewtitle_products: "Products", product_list_title: "Product List", btn_new_product: "✨ New Product", product_list_placeholder: "(Prototype: Product table would go here)",
                 manage_product_types_title: "Manage Product Types", btn_clone_type: "Clone Type", btn_new_type_admin: "New Product Type",
                 registered_types_title: "Registered Types:", select_type_to_edit_msg: "Select a Type to view/edit.",

--- a/Prototipos/Frontend/Old/prod 7.3.html
+++ b/Prototipos/Frontend/Old/prod 7.3.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TDAI - Gestão de Produtos v7.3 (Abas e Exemplos Corrigidos)</title>
+    <title>CatalogAI - Gestão de Produtos v7.3 (Abas e Exemplos Corrigidos)</title>
     <style>
         :root {
             --sidebar-bg: #1f2a40; --sidebar-text: #cfd8e5; --main-bg: #f4f6f8;
@@ -156,7 +156,7 @@
 </head>
 <body>
     <aside class="sidebar">
-        <div class="logo">TDAI</div>
+        <div class="logo">CatalogAI</div>
         <nav>
             <a href="#" onclick="showView('view-dashboard')" id="nav-dashboard">Dashboard</a>
             <a href="#" onclick="showView('view-produtos')" id="nav-produtos" class="active">Produtos</a>

--- a/Prototipos/Frontend/Old/prod_good.html
+++ b/Prototipos/Frontend/Old/prod_good.html
@@ -247,7 +247,7 @@
           </div>
           <div class="form-group">
             <label for="productSKU">SKU: <span class="tooltip-icon" title="Código único do produto no seu sistema.">?</span></label>
-            <input type="text" id="productSKU" placeholder="Ex: TDAI-SMART-001">
+            <input type="text" id="productSKU" placeholder="Ex: CatalogAI-SMART-001">
             <span class="error-message" id="productSKUError"></span>
           </div>
           <div class="form-group">

--- a/Prototipos/Frontend/Old/produtos.html
+++ b/Prototipos/Frontend/Old/produtos.html
@@ -107,7 +107,7 @@
 </head>
 <body>
   <aside class="sidebar">
-    <div class="logo">TDAI</div>
+    <div class="logo">CatalogAI</div>
     <nav>
       <a href="#" onclick="showView('view-dashboard')">Dashboard</a>
       <a href="#" class="active" onclick="showView('view-produtos')">Produtos</a>

--- a/Prototipos/Frontend/Produtos 8.0.html
+++ b/Prototipos/Frontend/Produtos 8.0.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TDAI - Gestão de Produtos v7.7 (Depuração Tipos de Produto)</title>
+    <title>CatalogAI - Gestão de Produtos v7.7 (Depuração Tipos de Produto)</title>
     <style>
         :root {
             --sidebar-bg: #1f2a40; --sidebar-text: #cfd8e5; --main-bg: #f4f6f8;
@@ -183,7 +183,7 @@
 </head>
 <body>
     <aside class="sidebar">
-        <div class="logo">TDAI</div>
+        <div class="logo">CatalogAI</div>
         <nav>
             <a href="#" onclick="showView('view-dashboard')" id="nav-dashboard">Dashboard</a>
             <a href="#" onclick="showView('view-produtos')" id="nav-produtos" class="active">Produtos</a>
@@ -2030,7 +2030,7 @@ Exemplo de formato: [{"attributeName": "Cor", "suggestedValue": "Azul"}, {"attri
                 console.log("[initializeApp] loadProductTypesList OK");
                 applyProductTableFilters();
                 console.log("[initializeApp] applyProductTableFilters OK");
-                console.log("App TDAI inicializado com sucesso.");
+                console.log("App CatalogAI inicializado com sucesso.");
             } catch (e) {
                 console.error("Erro crítico durante a inicialização do app:", e);
                 const body = document.querySelector('body');

--- a/Prototipos/Frontend/allinone 200525.html
+++ b/Prototipos/Frontend/allinone 200525.html
@@ -374,7 +374,7 @@
 </head>
 <body>
   <aside class="sidebar">
-    <div class="logo">TDAI</div>
+    <div class="logo">CatalogAI</div>
     <nav>
       <a id="nav-dashboard" class="active">Dashboard</a>
       <a id="nav-produtos">Produtos</a>

--- a/README Backend.md
+++ b/README Backend.md
@@ -14,7 +14,7 @@
 
 * **Sem funções**: Versão antiga da documentação.
 
-## TDAI.pdf
+## CatalogAI.pdf
 
 * **Sem funções**: Documento visual/protótipo do sistema.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TDAI – Plataforma Inteligente de Enriquecimento e Geração de Conteúdo para Catálogos
+# CatalogAI – Plataforma Inteligente de Enriquecimento e Geração de Conteúdo para Catálogos
 
 > **Autor:** Julio Cesar Barizon Montes
 > **Licença:** [MIT](LICENSE)
@@ -7,7 +7,7 @@
 
 ## 🚀 Visão Geral
 
-O **TDAI** é uma plataforma SaaS de automação e inteligência artificial para catálogos de produtos. O sistema facilita o cadastro, enriquecimento e geração de títulos e descrições para grandes listas de produtos, reduzindo trabalho manual e elevando o padrão de qualidade do conteúdo – pronto para marketplaces, e-commerce e operações B2B.
+O **CatalogAI** é uma plataforma SaaS de automação e inteligência artificial para catálogos de produtos. O sistema facilita o cadastro, enriquecimento e geração de títulos e descrições para grandes listas de produtos, reduzindo trabalho manual e elevando o padrão de qualidade do conteúdo – pronto para marketplaces, e-commerce e operações B2B.
 
 * Upload em massa (planilhas, PDFs)
 * Enriquecimento automático via web scraping & IA
@@ -69,11 +69,11 @@ O **TDAI** é uma plataforma SaaS de automação e inteligência artificial para
 ## 🗂️ Arquitetura e Estrutura de Pastas
 
 ```
-TDAI-0525-Dev/
+CatalogAI-0525-Dev/
 ├── .gitignore
 ├── README.md
 ├── README.txt
-├── TDAI.pdf
+├── CatalogAI.pdf
 ├── run_backend.py
 ├── Backend/
 │   ├── __init__.py
@@ -274,8 +274,8 @@ npm test
 
 ```
 # Banco de Dados
-DATABASE_URL="postgresql://usuario:senha@localhost:5432/tdai_db"
-SQLITE_DB_FILE="tdai_app.db"  # usado automaticamente se DATABASE_URL estiver ausente
+DATABASE_URL="postgresql://usuario:senha@localhost:5432/catalogai_db"
+SQLITE_DB_FILE="catalogai_app.db"  # usado automaticamente se DATABASE_URL estiver ausente
 
 # Segurança
 SECRET_KEY="sua_chave_forte"
@@ -302,7 +302,7 @@ MAIL_PORT=587
 MAIL_SERVER="smtp.example.com"
 MAIL_STARTTLS=True
 MAIL_SSL_TLS=False
-MAIL_FROM_NAME="TDAI Platform"
+MAIL_FROM_NAME="CatalogAI Platform"
 
 # Frontend
 FRONTEND_URL="http://localhost:5173"

--- a/README.txt
+++ b/README.txt
@@ -1,10 +1,10 @@
-# TDAI - Backend do Sistema Inteligente de Geração de Títulos e Descrições
+# CatalogAI - Backend do Sistema Inteligente de Geração de Títulos e Descrições
 
-Este é o backend para o projeto TDAI (Titles and Descriptions Artificial Intelligence), um sistema SaaS projetado para auxiliar na gestão e enriquecimento de informações de produtos de e-commerce, com foco em geração de conteúdo por IA.
+Este é o backend para o projeto CatalogAI (Titles and Descriptions Artificial Intelligence), um sistema SaaS projetado para auxiliar na gestão e enriquecimento de informações de produtos de e-commerce, com foco em geração de conteúdo por IA.
 
 ## 📜 Sobre o Projeto
 
-O TDAI visa processar listas de itens de produtos (inicialmente automotivos, mas com potencial de expansão), que muitas vezes chegam com informações mínimas via planilhas ou catálogos PDF. O sistema enriquece essas informações buscando dados na web (sites de fornecedores, catálogos, Google Search) e, por fim, gera títulos e descrições otimizados utilizando inteligência artificial. O backend é construído com FastAPI e PostgreSQL.
+O CatalogAI visa processar listas de itens de produtos (inicialmente automotivos, mas com potencial de expansão), que muitas vezes chegam com informações mínimas via planilhas ou catálogos PDF. O sistema enriquece essas informações buscando dados na web (sites de fornecedores, catálogos, Google Search) e, por fim, gera títulos e descrições otimizados utilizando inteligência artificial. O backend é construído com FastAPI e PostgreSQL.
 
 ## ✨ Funcionalidades Principais do Backend
 
@@ -104,7 +104,7 @@ Siga os passos abaixo para configurar e executar o backend localmente.
 
 ```bash
 git clone <url-do-seu-repositorio>
-cd <PROJECT_ROOT_DIRECTORY_NAME> # Navegue até a raiz do projeto TDAI
+cd <PROJECT_ROOT_DIRECTORY_NAME> # Navegue até a raiz do projeto CatalogAI
 3. Criar e Ativar um Ambiente Virtual:
 
 Recomendado para isolar as dependências do projeto. Execute na raiz do projeto (<PROJECT_ROOT_DIRECTORY_NAME>):
@@ -148,8 +148,8 @@ Você precisará adicionar as seguintes variáveis (um arquivo .env.example seri
 Snippet de código
 
 # Backend/core/config.py espera estas variáveis
-DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DB_NAME" # Ex: postgresql://postgres:password@localhost:5432/tdai_db
-SQLITE_DB_FILE="tdai_app.db"  # usado se DATABASE_URL não estiver presente
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DB_NAME" # Ex: postgresql://postgres:password@localhost:5432/catalogai_db
+SQLITE_DB_FILE="catalogai_app.db"  # usado se DATABASE_URL não estiver presente
 SECRET_KEY="sua_chave_secreta_super_forte_aqui" # Importante para JWT
 
 REFRESH_SECRET_KEY="change-me"
@@ -181,7 +181,7 @@ MAIL_PASSWORD="..."
 MAIL_FROM="seu_email@example.com"
 MAIL_PORT=587
 MAIL_SERVER="smtp.example.com"
-MAIL_FROM_NAME="Equipe TDAI"
+MAIL_FROM_NAME="Equipe CatalogAI"
 MAIL_STARTTLS="True" # True ou False
 MAIL_SSL_TLS="False"  # True ou False
 USE_CREDENTIALS="True" # True ou False

--- a/run_backend.py
+++ b/run_backend.py
@@ -1,4 +1,4 @@
-# TDAI 2025/Project/run_backend.py
+# CatalogAI 2025/Project/run_backend.py
 import sys
 import os
 import uvicorn


### PR DESCRIPTION
## Summary
- rename references from TDAI to CatalogAI across backend, frontend, docs, and prototypes
- update env examples and configuration defaults
- rename TDAI.pdf to CatalogAI.pdf

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684858c98b38832fb220d0d05b68e5a5