### PR TITLE
Add logo in sidebar

### DIFF
--- a/Frontend/app/src/components/Sidebar.css
+++ b/Frontend/app/src/components/Sidebar.css
@@ -25,6 +25,13 @@
   margin-bottom: 1rem;
 }
 
+.sidebar-logo {
+  width: 40px;
+  height: 40px;
+  object-fit: contain;
+  margin: 0 auto 0.5rem;
+}
+
 .sidebar-title {
   margin: 0;
   font-size: 1.5rem;
@@ -33,6 +40,10 @@
 
 .sidebar.closed .sidebar-title {
   font-size: 1.2rem; /* Ajuste o tamanho para a versão recolhida */
+}
+
+.sidebar.closed .sidebar-logo {
+  margin-bottom: 0;
 }
 
 .sidebar-nav ul {

--- a/Frontend/app/src/components/Sidebar.jsx
+++ b/Frontend/app/src/components/Sidebar.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext'; // Se precisar do logout ou dados do usuário
 import './Sidebar.css'; // Certifique-se de que este arquivo CSS existe e está correto
+import LogoImg from '../assets/Logo.png';
 
 // Ícones (exemplo, substitua pelos seus ou remova se não usar)
 import {
@@ -38,8 +39,8 @@ const Sidebar = ({ isOpen, toggleSidebar }) => {
   return (
     <aside className={`sidebar ${isOpen ? 'open' : 'closed'}`}>
       <div className="sidebar-header">
-        {/* Pode adicionar um logo ou título aqui */}
-        <h1 className="sidebar-title">{isOpen ? "CatalogAI" : "T"}</h1>
+        <img src={LogoImg} alt="CatalogAI logo" className="sidebar-logo" />
+        {isOpen && <h1 className="sidebar-title">CatalogAI</h1>}
         {/* O botão de toggle pode ser movido para o Topbar se preferir */}
         {/* <button onClick={toggleSidebar} className="sidebar-toggle-btn">
           {isOpen ? <LuX /> : <LuMenu />}


### PR DESCRIPTION
## Summary
- show logo image in the sidebar header
- tweak sidebar styles for the logo

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68485d87183c832f8f4736064bc47476