### PR TITLE
Adjust sidebar active color

### DIFF
--- a/Frontend/app/src/components/Sidebar.css
+++ b/Frontend/app/src/components/Sidebar.css
@@ -79,8 +79,8 @@
 }
 
 .nav-link.active {
-  background-color: var(--primary);
-  color: #ffffff;
+  background-color: var(--sidebar-active-bg, #e0e0e0);
+  color: #000;
   font-weight: bold;
 }
 

--- a/Frontend/app/src/index.css
+++ b/Frontend/app/src/index.css
@@ -9,6 +9,7 @@
   --info: #6366f1;
   --warning: #f59e0b;
   --danger: #ef4444;
+  --sidebar-active-bg: #e0e0e0;
   --font: 'Helvetica Neue', Arial, sans-serif;
   --radius: 8px;
   --shadow-sm: 0 1px 4px rgba(0,0,0,0.1);


### PR DESCRIPTION
## Summary
- add sidebar active CSS variable for easier theming
- use the new variable for active nav links so selection is gray instead of blue

## Testing
- `pytest -q` *(fails: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68486682a7a0832fbeb7a08e1b9a052e