### PR TITLE
Update dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ sqlalchemy
 starlette
 trafilatura
 uvicorn
+httpx


### PR DESCRIPTION
## Summary
- add `httpx` to requirements for `fastapi` testing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68487deb4300832f969bfa090c1e41eb