### PR TITLE
Ensure pagination responses start at page 1

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -159,7 +159,8 @@ def read_produtos( # Nome da função mantido como no arquivo do usuário
         product_type_id=product_type_id,
         is_admin=current_user.is_superuser # Passando is_admin para o CRUD
     )
-    return {"items": produtos_db, "total_items": total_items, "page": skip // limit, "limit": limit}
+    page_number = skip // limit + 1
+    return {"items": produtos_db, "total_items": total_items, "page": page_number, "limit": limit}
 
 
 @router.put("/{produto_id}", response_model=schemas.ProdutoResponse) # CORRIGIDO AQUI

--- a/tests/test_produtos.py
+++ b/tests/test_produtos.py
@@ -1,0 +1,57 @@
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from Backend.main import app
+from Backend.database import Base, get_db
+from Backend import crud, crud_produtos, schemas
+from Backend.core.config import settings
+
+# disable heavy startup events
+app.router.on_startup.clear()
+
+engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+# setup initial data
+with TestingSessionLocal() as db:
+    crud.create_initial_data(db)
+    admin = crud.get_user_by_email(db, settings.FIRST_SUPERUSER_EMAIL)
+    for i in range(15):
+        crud_produtos.create_produto(db, schemas.ProdutoCreate(nome_base=f"P{i}"), user_id=admin.id)
+
+
+def get_admin_headers():
+    resp = client.post(
+        "/api/v1/auth/token",
+        data={"username": settings.FIRST_SUPERUSER_EMAIL, "password": settings.FIRST_SUPERUSER_PASSWORD},
+    )
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_pagination_returns_1_based_page():
+    headers = get_admin_headers()
+    resp = client.get("/api/v1/produtos", params={"skip": 0, "limit": 10}, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 1
+
+    resp = client.get("/api/v1/produtos", params={"skip": 10, "limit": 10}, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 2


### PR DESCRIPTION
## Summary
- fix pagination page numbering for `/produtos`
- test that `/produtos` endpoint returns 1-based page numbers

## Testing
- `pytest tests/test_produtos.py::test_pagination_returns_1_based_page -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68487de9cafc832f800d3a9e5674e462