### PR TITLE
Fix password reset email variables

### DIFF
--- a/Backend/core/email_utils.py
+++ b/Backend/core/email_utils.py
@@ -120,8 +120,7 @@ async def send_password_reset_email(email_to: EmailStr, username: str, reset_lin
     template_body = {
         "username": username,
         "reset_url": reset_link,
-        "project_name": settings.PROJECT_NAME,  # Passa o nome do projeto para o template
-        "expiration_hours": int(settings.ACCESS_TOKEN_EXPIRE_MINUTES / 60),
+        "expiration_hours": settings.ACCESS_TOKEN_EXPIRE_MINUTES // 60,
         "current_year": datetime.now().year,
     }
 


### PR DESCRIPTION
## Summary
- use `reset_url`, `expiration_hours` and `current_year` when sending password reset emails

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848802d2334832fa86b43803c0ca5f7