### PR TITLE
Update uso_ia pagination

### DIFF
--- a/Backend/routers/uso_ia.py
+++ b/Backend/routers/uso_ia.py
@@ -73,7 +73,12 @@ def read_usos_ia_usuario_logado(
         data_fim=data_fim
     )
     
-    return {"items": registros, "total_items": total_items, "page": skip // limit, "limit": limit}
+    return {
+        "items": registros,
+        "total_items": total_items,
+        "page": skip // limit + 1,
+        "limit": limit,
+    }
 
 
 # Endpoint para obter detalhes de um registro de uso de IA específico (se necessário)

--- a/tests/test_uso_ia.py
+++ b/tests/test_uso_ia.py
@@ -46,6 +46,16 @@ with TestingSessionLocal() as db:
             tipo_acao=models.TipoAcaoEnum.CRIACAO_TITULO_PRODUTO,
         ),
     )
+    # create extra registros for pagination tests
+    for i in range(15):
+        crud.create_registro_uso_ia(
+            db,
+            schemas.RegistroUsoIACreate(
+                user_id=normal_user.id,
+                produto_id=produto.id,
+                tipo_acao=models.TipoAcaoEnum.CRIACAO_TITULO_PRODUTO,
+            ),
+        )
 
 
 def get_admin_headers():
@@ -100,3 +110,16 @@ def test_product_creation_creates_uso_ia_record():
             .all()
         )
         assert len(registros) == 1
+
+
+def test_pagination_returns_1_based_page_for_uso_ia():
+    headers = get_user_headers()
+    resp = client.get("/api/v1/uso-ia", params={"skip": 0, "limit": 10}, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 1
+
+    resp = client.get("/api/v1/uso-ia", params={"skip": 10, "limit": 10}, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 2


### PR DESCRIPTION
## Summary
- start `page` numbering from 1 in `/uso-ia` responses
- ensure test database seeds uso IA records for pagination
- test listing in `/uso-ia` returns page values starting at 1

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68488029f1fc832f85f67f3866fe98f8