### PR TITLE
Avoid redundant product type lookup

### DIFF
--- a/Backend/routers/product_types.py
+++ b/Backend/routers/product_types.py
@@ -124,23 +124,26 @@ async def read_product_type_details_route(
     
     try:
         numeric_id = int(identifier)
-        logger.info("ROUTER: Identificador '%s' é numérico. Tentando buscar por ID: %s", identifier, numeric_id)
-        db_product_type = crud_product_types.get_product_type(db, product_type_id=numeric_id)
+        logger.info(
+            "ROUTER: Identificador '%s' é numérico. Tentando buscar por ID: %s",
+            identifier,
+            numeric_id,
+        )
+        logger.debug(
+            "ROUTER: Identificador '%s' é numérico. Tentando buscar por ID: %s",
+            identifier,
+            numeric_id,
+        )
+        db_product_type = crud_product_types.get_product_type(
+            db, product_type_id=numeric_id
+        )
         if db_product_type:
             logger.info(
                 "ROUTER: Encontrado por ID: %s - %s",
                 db_product_type.id,
                 db_product_type.friendly_name,
             )
-        logger.debug(
-            "ROUTER: Identificador '%s' é numérico. Tentando buscar por ID: %s",
-            identifier,
-            numeric_id,
-        )
-        db_product_type = crud_product_types.get_product_type(db, product_type_id=numeric_id) 
-        if db_product_type:
             logger.debug(
-
                 "ROUTER: Encontrado por ID: %s - %s",
                 db_product_type.id,
                 db_product_type.friendly_name,


### PR DESCRIPTION
## Summary
- remove duplicate query when reading product type details

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_684881ca3f44832f9c1fefa95a666453