### PR TITLE
Update uso_ia pagination

### DIFF
--- a/Backend/routers/uso_ia.py
+++ b/Backend/routers/uso_ia.py
@@ -73,10 +73,11 @@ def read_usos_ia_usuario_logado(
         data_fim=data_fim
     )
     
+    page_number = skip // limit + 1
     return {
         "items": registros,
         "total_items": total_items,
-        "page": skip // limit + 1,
+        "page": page_number,
         "limit": limit,
     }
 

--- a/tests/test_uso_ia.py
+++ b/tests/test_uso_ia.py
@@ -123,3 +123,11 @@ def test_pagination_returns_1_based_page_for_uso_ia():
     assert resp.status_code == 200
     data = resp.json()
     assert data["page"] == 2
+
+
+def test_first_page_number_for_uso_ia():
+    headers = get_user_headers()
+    resp = client.get("/api/v1/uso-ia", params={"skip": 0, "limit": 5}, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 1


### PR DESCRIPTION
## Summary
- ensure page numbering uses `skip // limit + 1` in `uso_ia`
- add regression test checking that the first page starts at `1`

## Testing
- `pytest -q tests/test_uso_ia.py::test_first_page_number_for_uso_ia -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684881c3ddec832fbe0f8d009c856327