### PR TITLE
Update README with peer dependency note

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,8 @@ acessar a plataforma e visualizar esse item inicial.
 ```sh
 cd Frontend/app
 npm install
+# Se a instalação falhar com erro ERESOLVE (conflito de peer dependencies),
+# execute `npm install --legacy-peer-deps` ou atualize o package.json para versões compatíveis.
 # Certifique-se de que as dependências de desenvolvimento (como @eslint/js)
 # foram instaladas. Elas são necessárias para o comando de lint.
 npm run lint            # Opcional: verifica padrões de código


### PR DESCRIPTION
## Summary
- mention potential peer dependency conflicts during frontend setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848892a7910832f8ef9a8f8a157d543