### PR TITLE
Clarify frontend peer dependency error

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,11 +228,14 @@ acessar a plataforma e visualizar esse item inicial.
 
 ### 4. **Configuração do Frontend**
 
+Siga os passos abaixo para rodar a interface em React.
+Caso o `npm install` retorne o erro `ERESOLVE` (conflito de *peer dependencies*),
+execute `npm install --legacy-peer-deps` ou atualize o `package.json` para
+versões compatíveis e tente novamente.
+
 ```sh
 cd Frontend/app
 npm install
-# Se a instalação falhar com erro ERESOLVE (conflito de peer dependencies),
-# execute `npm install --legacy-peer-deps` ou atualize o package.json para versões compatíveis.
 # Certifique-se de que as dependências de desenvolvimento (como @eslint/js)
 # foram instaladas. Elas são necessárias para o comando de lint.
 npm run lint            # Opcional: verifica padrões de código


### PR DESCRIPTION
## Summary
- clarify how to handle peer dependency errors in `npm install`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68488bbc9cd8832f964e52f17e33e756