### PR TITLE
Add catalog import preview workflow

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -320,6 +320,13 @@ class ProdutoResponse(ProdutoBase):
 class ProdutoBatchDeleteRequest(BaseModel):
     produto_ids: List[int]
 
+
+class ImportPreviewResponse(BaseModel):
+    headers: List[str]
+    sample_rows: List[Dict[str, Any]]
+    message: Optional[str] = None
+    error: Optional[str] = None
+
 class ProdutoPage(BaseModel):
     items: List[ProdutoResponse]
     total_items: int

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -1,0 +1,122 @@
+import React, { useState } from 'react';
+import Modal from '../common/Modal.jsx';
+import fornecedorService from '../../services/fornecedorService';
+
+const FIELD_OPTIONS = [
+  { value: 'nome_base', label: 'Nome Base' },
+  { value: 'sku_original', label: 'SKU' },
+  { value: 'descricao_original', label: 'Descrição' },
+  { value: 'marca', label: 'Marca' },
+  { value: 'categoria_original', label: 'Categoria' },
+  { value: 'ean_original', label: 'EAN' },
+  { value: 'preco_original', label: 'Preço' },
+  { value: 'imagem_url_original', label: 'URL Imagem' },
+];
+
+function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
+  const [step, setStep] = useState(1);
+  const [file, setFile] = useState(null);
+  const [preview, setPreview] = useState(null);
+  const [mapping, setMapping] = useState({});
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState('');
+
+  const handleFileChange = (e) => {
+    setFile(e.target.files[0]);
+  };
+
+  const handleGeneratePreview = async () => {
+    if (!file) return;
+    setLoading(true);
+    try {
+      const data = await fornecedorService.previewCatalogo(file);
+      setPreview(data);
+      setStep(2);
+    } catch (err) {
+      alert(err.detail || err.message || 'Erro ao gerar preview');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleMappingChange = (header, value) => {
+    setMapping((prev) => ({ ...prev, [header]: value }));
+  };
+
+  const handleImport = async () => {
+    if (!file) return;
+    setLoading(true);
+    try {
+      await fornecedorService.importCatalogo(fornecedorId, file, mapping);
+      setMessage('Importação concluída com sucesso');
+      setStep(3);
+    } catch (err) {
+      alert(err.detail || err.message || 'Erro ao importar catálogo');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const renderStep1 = () => (
+    <div>
+      <input type="file" accept=".csv,.xls,.xlsx,.pdf" onChange={handleFileChange} />
+      <button onClick={handleGeneratePreview} disabled={!file || loading}>
+        {loading ? 'Enviando...' : 'Enviar'}
+      </button>
+    </div>
+  );
+
+  const renderStep2 = () => {
+    if (!preview) return null;
+    if (preview.message && !preview.headers?.length) {
+      return <p>{preview.message}</p>;
+    }
+    return (
+      <div>
+        <table className="mapping-table">
+          <thead>
+            <tr>
+              <th>Coluna Detectada</th>
+              <th>Mapear para</th>
+            </tr>
+          </thead>
+          <tbody>
+            {preview.headers.map((h) => (
+              <tr key={h}>
+                <td>{h}</td>
+                <td>
+                  <select value={mapping[h] || ''} onChange={(e) => handleMappingChange(h, e.target.value)}>
+                    <option value="">Ignorar</option>
+                    {FIELD_OPTIONS.map((opt) => (
+                      <option key={opt.value} value={opt.value}>{opt.label}</option>
+                    ))}
+                  </select>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <button onClick={handleImport} disabled={loading}>
+          {loading ? 'Importando...' : 'Importar'}
+        </button>
+      </div>
+    );
+  };
+
+  const renderStep3 = () => (
+    <div>
+      <p>{message || 'Processo finalizado.'}</p>
+      <button onClick={onClose}>Fechar</button>
+    </div>
+  );
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Importar Catálogo">
+      {step === 1 && renderStep1()}
+      {step === 2 && renderStep2()}
+      {step === 3 && renderStep3()}
+    </Modal>
+  );
+}
+
+export default ImportCatalogWizard;

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -85,10 +85,28 @@ export const deleteFornecedor = async (fornecedorId) => {
   }
 };
 
-export const importCatalogo = async (fornecedorId, file) => {
+export const previewCatalogo = async (file) => {
   try {
     const formData = new FormData();
     formData.append('file', file);
+    const response = await apiClient.post('/produtos/importar-catalogo-preview/', formData);
+    return response.data;
+  } catch (error) {
+    console.error('Erro ao gerar preview do catálogo:', JSON.stringify(error.response?.data || error.message || error));
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao solicitar preview do catálogo');
+  }
+};
+
+export const importCatalogo = async (fornecedorId, file, mapping = null) => {
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    if (mapping) {
+      formData.append('mapeamento_colunas_usuario', JSON.stringify(mapping));
+    }
     const response = await apiClient.post(`/produtos/importar-catalogo/${fornecedorId}/`, formData);
     return response.data;
   } catch (error) {
@@ -109,5 +127,6 @@ export default {
   createFornecedor,
   updateFornecedor,
   deleteFornecedor,
+  previewCatalogo,
   importCatalogo,
 };


### PR DESCRIPTION
## Summary
- add catalog preview endpoint and mapping support to produto router
- extend file_processing_service with preview helpers
- create ImportPreviewResponse schema for previews
- update fornecedorService with preview/import mapping
- add ImportCatalogWizard component for manual column mapping

## Testing
- `pip install -r requirements-backend.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.2)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_68489f1a0d80832fbf516ea4ccf1f62f