### PR TITLE
Improve password reset email config handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,9 @@ MAIL_SERVER="smtp.example.com"
 MAIL_STARTTLS=True
 MAIL_SSL_TLS=False
 MAIL_FROM_NAME="CatalogAI Platform"
+# When these email settings are not provided password reset emails will not be sent.
+# Set RAISE_ON_MISSING_EMAIL_CONFIG=true to raise an error instead of ignoring it.
+RAISE_ON_MISSING_EMAIL_CONFIG=False
 
 # Additional SMTP configuration
 SMTP_SERVER="smtp.seuprovedor.com"

--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -65,6 +65,11 @@ class Settings(BaseSettings):
     VALIDATE_CERTS: bool = True
     MAIL_FROM_NAME: Optional[str] = os.getenv("MAIL_FROM_NAME", "CatalogAI Platform")
 
+    # When True, functions like send_password_reset_email will raise an
+    # exception instead of returning silently if the email configuration is
+    # incomplete. Defaults to False for backward compatibility.
+    RAISE_ON_MISSING_EMAIL_CONFIG: bool = os.getenv("RAISE_ON_MISSING_EMAIL_CONFIG", "False").lower() in ("true", "1", "t", "yes")
+
     GOOGLE_CLIENT_ID: Optional[str] = os.getenv("GOOGLE_CLIENT_ID")
     GOOGLE_CLIENT_SECRET: Optional[str] = os.getenv("GOOGLE_CLIENT_SECRET")
     GOOGLE_REDIRECT_URI: Optional[str] = os.getenv("GOOGLE_REDIRECT_URI", "http://localhost:8000/api/v1/auth/google/callback")

--- a/Backend/core/email_utils.py
+++ b/Backend/core/email_utils.py
@@ -98,20 +98,25 @@ async def send_email(
 
 
 # NOVA FUNÇÃO ADICIONADA
-async def send_password_reset_email(email_to: EmailStr, username: str, reset_link: str):
-    """
-    Envia um email de redefinição de senha para o usuário.
-    """
+async def send_password_reset_email(
+    email_to: EmailStr,
+    username: str,
+    reset_link: str,
+    *,
+    raise_if_unconfigured: Optional[bool] = None,
+):
+    """Envia um email de redefinição de senha para o usuário."""
+
+    if raise_if_unconfigured is None:
+        raise_if_unconfigured = settings.RAISE_ON_MISSING_EMAIL_CONFIG
+
     if not conf:
         logger.warning(
             "Tentativa de enviar email de reset de senha para %s, mas a configuração de email está desabilitada.",
             email_to,
         )
-        # Em um cenário real, você pode querer levantar uma exceção aqui
-        # ou retornar um status que indique que o email não pôde ser enviado.
-        # Por enquanto, apenas logamos e não enviamos.
-        # Se esta função for chamada de um endpoint, o endpoint deve lidar com a falha.
-        # raise HTTPException(status_code=500, detail="Serviço de email não configurado.")
+        if raise_if_unconfigured:
+            raise RuntimeError("Configuração de email ausente")
         return
 
     subject = "Redefinição de Senha - CatalogAI"

--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ npm run dev                 # Roda o frontend em http://localhost:5173
 
 Todas as variáveis necessárias para o backend e o frontend estão documentadas em [`.env.example`](./.env.example).
 Copie este arquivo para `.env` e preencha com seus valores antes de iniciar a aplicação.
+Para que o envio de emails de recuperação de senha funcione é obrigatório definir `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM` e `MAIL_SERVER`.
 
 ### 6. **Testes**
 
@@ -308,6 +309,7 @@ MAIL_SERVER="smtp.example.com"
 MAIL_STARTTLS=True
 MAIL_SSL_TLS=False
 MAIL_FROM_NAME="CatalogAI Platform"
+RAISE_ON_MISSING_EMAIL_CONFIG=False  # opcional: gera erro se a configuração de email estiver incompleta
 
 # Frontend
 FRONTEND_URL="http://localhost:5173"

--- a/README.txt
+++ b/README.txt
@@ -186,6 +186,8 @@ MAIL_STARTTLS="True" # True ou False
 MAIL_SSL_TLS="False"  # True ou False
 USE_CREDENTIALS="True" # True ou False
 VALIDATE_CERTS="True"  # True ou False
+RAISE_ON_MISSING_EMAIL_CONFIG="False"  # opcional: gera erro se a configuracao estiver incompleta
+# Preencha todas as variáveis acima para que o envio de emails de recuperação de senha funcione
 
 # URL do Frontend (para links em emails, etc.)
 FRONTEND_URL="http://localhost:5173" # Ou a porta do seu frontend Vite/React


### PR DESCRIPTION
## Summary
- document email env vars required for password reset
- add optional runtime error for missing email config
- expose `RAISE_ON_MISSING_EMAIL_CONFIG` setting

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848a8046254832f8ac3d5deedbde131