### PR TITLE
Add automated dependency install for tests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,28 @@
+name: Python tests
+
+on:
+  push:
+    paths:
+      - '**.py'
+      - 'requirements-backend.txt'
+      - '.github/workflows/python-tests.yml'
+      - 'tests/**'
+  pull_request:
+    paths:
+      - '**.py'
+      - 'requirements-backend.txt'
+      - '.github/workflows/python-tests.yml'
+      - 'tests/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: pip install -r requirements-backend.txt
+    - name: Run tests
+      run: pytest

--- a/README.md
+++ b/README.md
@@ -263,10 +263,11 @@ Copie este arquivo para `.env` e preencha com seus valores antes de iniciar a ap
 
 ### 6. **Testes**
 
+Execute o script `scripts/run_tests.sh` para instalar automaticamente as dependên
+cias do backend e rodar o `pytest`.
+
 ```sh
-# Backend
-pip install -r requirements-backend.txt
-pytest
+./scripts/run_tests.sh
 
 # Frontend
 cd Frontend/app
@@ -387,11 +388,10 @@ console.log(historico.items);
 
 ## 🧪 Testes
 
-Os testes do backend dependem das bibliotecas listadas em `requirements-backend.txt`. Para executá-los:
+Os testes do backend dependem das bibliotecas listadas em `requirements-backend.txt`. Utilize o script abaixo, que já instala essas dependências antes de rodar os testes:
 
 ```sh
-pip install -r requirements-backend.txt
-pytest
+./scripts/run_tests.sh
 ```
 
 ---

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+pip install -r requirements-backend.txt
+pytest "$@"


### PR DESCRIPTION
## Summary
- add `scripts/run_tests.sh` helper
- update README instructions to use the new script
- add GitHub Actions workflow to install requirements and run tests

## Testing
- `scripts/run_tests.sh` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.2)*

------
https://chatgpt.com/codex/tasks/task_e_6848a8018e50832fadf24862a5851bd3