### PR TITLE
Add Dockerfile.test for pytest

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -18,11 +18,8 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-python@v5
-      with:
-        python-version: '3.11'
-    - name: Install dependencies
-      run: pip install -r requirements-backend.txt
-    - name: Run tests
-      run: pytest
+      - uses: actions/checkout@v4
+      - name: Build test image
+        run: docker build -f Dockerfile.test -t catalogai-test .
+      - name: Run tests
+        run: docker run --rm catalogai-test

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY requirements-backend.txt .
+RUN pip install --no-cache-dir -r requirements-backend.txt
+COPY . .
+CMD ["pytest"]

--- a/README.md
+++ b/README.md
@@ -283,6 +283,18 @@ cd Frontend/app
 npm test
 ```
 
+Se preferir utilizar **Docker**, construa a imagem de testes com:
+
+```sh
+docker build -f Dockerfile.test -t catalogai-test .
+```
+
+E execute os testes via container:
+
+```sh
+docker run --rm catalogai-test
+```
+
 ---
 
 ## ⚙️ Variáveis de Ambiente – Exemplo `.env`
@@ -410,6 +422,18 @@ que realiza a instalação das dependências e roda os testes:
 
 ```sh
 ./scripts/run_tests.sh
+```
+
+Também é possível executar os testes em um container Docker. Construa a imagem:
+
+```sh
+docker build -f Dockerfile.test -t catalogai-test .
+```
+
+E rode:
+
+```sh
+docker run --rm catalogai-test
 ```
 
 ---


### PR DESCRIPTION
## Summary
- add Dockerfile.test to run pytest inside container
- document docker-based testing steps
- update GitHub Actions workflow to use docker image for tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*
- `pip install -r requirements-backend.txt` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.2)*

------
https://chatgpt.com/codex/tasks/task_e_6848b46fc224832fbe5d4dc2739bf07c