### PR TITLE
Add mandatory env vars section and configurable email errors

### DIFF
--- a/Backend/core/email_utils.py
+++ b/Backend/core/email_utils.py
@@ -41,17 +41,24 @@ else:
 async def send_email(
     email_to: EmailStr,
     subject: str,
-    html_content: str, # Alterado de body para html_content para clareza
+    html_content: str,  # Alterado de body para html_content para clareza
     # attachments: Optional[List[UploadFile]] = None, # Se precisar enviar anexos
-    template_body: Optional[Dict[str, Any]] = None, # Para usar com templates
-    template_name: Optional[str] = None
+    template_body: Optional[Dict[str, Any]] = None,  # Para usar com templates
+    template_name: Optional[str] = None,
+    *,
+    raise_if_unconfigured: Optional[bool] = None,
 ):
+    if raise_if_unconfigured is None:
+        raise_if_unconfigured = settings.RAISE_ON_MISSING_EMAIL_CONFIG
+
     if not conf:
         logger.warning(
             "Tentativa de enviar email para %s com assunto '%s', mas a configuração de email está desabilitada.",
             email_to,
             subject,
         )
+        if raise_if_unconfigured:
+            raise RuntimeError("Configuração de email ausente")
         return
 
     message_data = {

--- a/README.md
+++ b/README.md
@@ -262,6 +262,13 @@ Todas as variáveis necessárias para o backend e o frontend estão documentadas
 Copie este arquivo para `.env` e preencha com seus valores antes de iniciar a aplicação.
 Para que o envio de emails de recuperação de senha funcione é obrigatório definir `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM` e `MAIL_SERVER`.
 
+Principais variáveis obrigatórias:
+- `SECRET_KEY` e `REFRESH_SECRET_KEY`
+- `FIRST_SUPERUSER_EMAIL` e `FIRST_SUPERUSER_PASSWORD`
+- `ADMIN_EMAIL` e `ADMIN_PASSWORD`
+- `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM` e `MAIL_SERVER`
+
+
 ### 6. **Testes**
 
 Antes de executar os testes do backend, instale as dependências listadas em


### PR DESCRIPTION
## Summary
- document required environment variables in README
- allow `send_email` to raise errors when email config is missing

## Testing
- `pip install -r requirements-backend.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848b4fd1d10832f95f441a3d6bd6029