### PR TITLE
Fix PostgreSQL requirement docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ CatalogAI-0525-Dev/
 
 * Python 3.8+
 * Node.js 18+
-* PostgreSQL 12+
+* PostgreSQL 12+ (obrigatório em produção; SQLite pode ser usado apenas para desenvolvimento e testes)
 * Git
 * Navegadores Playwright (para scraping):
   `playwright install`
@@ -457,7 +457,7 @@ Esta etapa inclui avanços importantes de qualidade:
 ## 💬 FAQ
 
 **P:** Posso usar outro banco de dados?
-**R:** O suporte principal é para PostgreSQL, mas há fallback para SQLite em dev.
+**R:** A aplicação depende de funcionalidades específicas do PostgreSQL (como índices parciais). Utilize PostgreSQL em produção; o SQLite está disponível apenas para desenvolvimento e testes.
 
 **P:** Como funciona o limite de IA?
 **R:** Cada plano tem créditos e limites definidos; ao atingir, novos enriquecimentos/gerações são bloqueados.


### PR DESCRIPTION
## Summary
- highlight that PostgreSQL is mandatory in production
- clarify FAQ about supported databases

## Testing
- `./scripts/run_tests.sh` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.2)*

------
https://chatgpt.com/codex/tasks/task_e_6848b52065e0832faa0b6310944dfda0