### PR TITLE
Handle enum inputs for uso IA queries

### DIFF
--- a/Backend/crud_registros_uso_ia.py
+++ b/Backend/crud_registros_uso_ia.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from sqlalchemy import func
 from sqlalchemy.orm import Session
@@ -20,10 +20,16 @@ def get_registros_uso_ia(
     user_id: int,
     skip: int = 0,
     limit: int = 100,
-    tipo_acao: Optional[str] = None,
+    tipo_acao: Optional[models.TipoAcaoEnum] = None,
     data_inicio: Optional[datetime] = None,
     data_fim: Optional[datetime] = None,
 ) -> List[models.RegistroUsoIA]:
+    if isinstance(tipo_acao, str):
+        try:
+            tipo_acao = models.TipoAcaoEnum(tipo_acao)
+        except ValueError as exc:
+            raise ValueError(f"tipo_acao inválido: {tipo_acao}") from exc
+
     query = db.query(models.RegistroUsoIA).filter(models.RegistroUsoIA.user_id == user_id)
     if tipo_acao:
         query = query.filter(models.RegistroUsoIA.tipo_acao == tipo_acao)
@@ -42,10 +48,16 @@ def get_registros_uso_ia(
 def count_registros_uso_ia(
     db: Session,
     user_id: int,
-    tipo_acao: Optional[str] = None,
+    tipo_acao: Optional[models.TipoAcaoEnum] = None,
     data_inicio: Optional[datetime] = None,
     data_fim: Optional[datetime] = None,
 ) -> int:
+    if isinstance(tipo_acao, str):
+        try:
+            tipo_acao = models.TipoAcaoEnum(tipo_acao)
+        except ValueError as exc:
+            raise ValueError(f"tipo_acao inválido: {tipo_acao}") from exc
+
     query = db.query(func.count(models.RegistroUsoIA.id)).filter(models.RegistroUsoIA.user_id == user_id)
     if tipo_acao:
         query = query.filter(models.RegistroUsoIA.tipo_acao == tipo_acao)

--- a/Backend/routers/uso_ia.py
+++ b/Backend/routers/uso_ia.py
@@ -55,20 +55,25 @@ def read_usos_ia_usuario_logado(
     Lista os registros de uso de IA para o usuário autenticado, com filtros e paginação.
     """
     # FIX: Change 'get_registros_uso_ia_by_user' to 'get_registros_uso_ia'
-    registros = crud.get_registros_uso_ia( # Corrected function name
+    try:
+        tipo_enum = models.TipoAcaoEnum(tipo_geracao) if tipo_geracao else None
+    except ValueError:
+        raise HTTPException(status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail="tipo_geracao inválido")
+
+    registros = crud.get_registros_uso_ia(
         db,
         user_id=current_user.id,
         skip=skip,
         limit=limit,
-        tipo_acao=tipo_geracao, # Changed from tipo_geracao to tipo_acao to match crud function
+        tipo_acao=tipo_enum,
         data_inicio=data_inicio,
         data_fim=data_fim
     )
     # FIX: Change 'count_registros_uso_ia_by_user' to 'count_registros_uso_ia'
-    total_items = crud.count_registros_uso_ia( # Corrected function name
+    total_items = crud.count_registros_uso_ia(
         db,
         user_id=current_user.id,
-        tipo_acao=tipo_geracao, # Changed from tipo_geracao to tipo_acao to match crud function
+        tipo_acao=tipo_enum,
         data_inicio=data_inicio,
         data_fim=data_fim
     )


### PR DESCRIPTION
## Summary
- validate `tipo_acao` parameters against `TipoAcaoEnum`
- raise validation errors for invalid strings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848b523aadc832f84f3e30b26ce1317