### PR TITLE
Raise error when email config missing by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,8 +39,8 @@ MAIL_STARTTLS=True
 MAIL_SSL_TLS=False
 MAIL_FROM_NAME="CatalogAI Platform"
 # When these email settings are not provided password reset emails will not be sent.
-# Set RAISE_ON_MISSING_EMAIL_CONFIG=true to raise an error instead of ignoring it.
-RAISE_ON_MISSING_EMAIL_CONFIG=False
+# Set RAISE_ON_MISSING_EMAIL_CONFIG=false to ignore the missing configuration instead of raising an error.
+RAISE_ON_MISSING_EMAIL_CONFIG=True
 
 # Additional SMTP configuration
 SMTP_SERVER="smtp.seuprovedor.com"

--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -67,8 +67,9 @@ class Settings(BaseSettings):
 
     # When True, functions like send_password_reset_email will raise an
     # exception instead of returning silently if the email configuration is
-    # incomplete. Defaults to False for backward compatibility.
-    RAISE_ON_MISSING_EMAIL_CONFIG: bool = os.getenv("RAISE_ON_MISSING_EMAIL_CONFIG", "False").lower() in ("true", "1", "t", "yes")
+    # incomplete. Defaults to True so callers are notified when emails are
+    # skipped due to missing settings.
+    RAISE_ON_MISSING_EMAIL_CONFIG: bool = os.getenv("RAISE_ON_MISSING_EMAIL_CONFIG", "True").lower() in ("true", "1", "t", "yes")
 
     GOOGLE_CLIENT_ID: Optional[str] = os.getenv("GOOGLE_CLIENT_ID")
     GOOGLE_CLIENT_SECRET: Optional[str] = os.getenv("GOOGLE_CLIENT_SECRET")

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ npm run dev                 # Roda o frontend em http://localhost:5173
 
 Todas as variáveis necessárias para o backend e o frontend estão documentadas em [`.env.example`](./.env.example).
 Copie este arquivo para `.env` e preencha com seus valores antes de iniciar a aplicação.
-Para que o envio de emails de recuperação de senha funcione é obrigatório definir `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM` e `MAIL_SERVER`.
+Para que o envio de emails de recuperação de senha funcione é obrigatório definir `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM` e `MAIL_SERVER`. Por padrão o backend gera erro caso essas configurações estejam ausentes; defina `RAISE_ON_MISSING_EMAIL_CONFIG=false` se preferir apenas registrar um aviso.
 
 ### 6. **Testes**
 
@@ -318,7 +318,7 @@ MAIL_SERVER="smtp.example.com"
 MAIL_STARTTLS=True
 MAIL_SSL_TLS=False
 MAIL_FROM_NAME="CatalogAI Platform"
-RAISE_ON_MISSING_EMAIL_CONFIG=False  # opcional: gera erro se a configuração de email estiver incompleta
+RAISE_ON_MISSING_EMAIL_CONFIG=True  # gera erro se a configuração de email estiver incompleta (defina como False para ignorar)
 
 # Frontend
 FRONTEND_URL="http://localhost:5173"

--- a/README.txt
+++ b/README.txt
@@ -186,7 +186,9 @@ MAIL_STARTTLS="True" # True ou False
 MAIL_SSL_TLS="False"  # True ou False
 USE_CREDENTIALS="True" # True ou False
 VALIDATE_CERTS="True"  # True ou False
-RAISE_ON_MISSING_EMAIL_CONFIG="False"  # opcional: gera erro se a configuracao estiver incompleta
+RAISE_ON_MISSING_EMAIL_CONFIG="True"  # gera erro se a configuracao estiver incompleta (defina como False para ignorar)
+# Por padrão o backend gera erro caso as variáveis acima não estejam configuradas corretamente.
+# Ajuste RAISE_ON_MISSING_EMAIL_CONFIG="False" se preferir apenas um aviso no log.
 # Preencha todas as variáveis acima para que o envio de emails de recuperação de senha funcione
 
 # URL do Frontend (para links em emails, etc.)


### PR DESCRIPTION
## Summary
- raise errors by default when email configuration is missing
- document new default behaviour in `.env.example`, `README.md` and `README.txt`

## Testing
- `scripts/run_tests.sh` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848b52af354832f9f0a23da8be7e007