### PR TITLE
Add skip/limit validation

### DIFF
--- a/Backend/crud_fornecedores.py
+++ b/Backend/crud_fornecedores.py
@@ -34,6 +34,10 @@ def get_fornecedores_by_user(
     limit: int = 10,
     search: Optional[str] = None,
 ) -> List[Fornecedor]:
+    if skip < 0:
+        raise ValueError("skip must be non-negative")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
     query = db.query(Fornecedor)
     if not is_admin and user_id:
         query = query.filter(Fornecedor.user_id == user_id)

--- a/Backend/crud_historico.py
+++ b/Backend/crud_historico.py
@@ -21,6 +21,10 @@ def get_registros_historico(
     entidade: Optional[str] = None,
     acao: Optional[models.TipoAcaoSistemaEnum] = None,
 ) -> List[models.RegistroHistorico]:
+    if skip < 0:
+        raise ValueError("skip must be non-negative")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
     query = db.query(models.RegistroHistorico)
     if user_id is not None:
         query = query.filter(models.RegistroHistorico.user_id == user_id)

--- a/Backend/crud_product_types.py
+++ b/Backend/crud_product_types.py
@@ -83,6 +83,10 @@ def get_product_type_by_key_name(db: Session, key_name: str, user_id: Optional[i
 
 
 def get_product_types_for_user(db: Session, user_id: Optional[int], skip: int = 0, limit: int = 100, search: Optional[str] = None) -> List[ProductType]:
+    if skip < 0:
+        raise ValueError("skip must be non-negative")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
     query = db.query(ProductType).options(selectinload(ProductType.attribute_templates))
     
     # Filtra para tipos do usuário específico OU tipos globais (user_id IS NULL)

--- a/Backend/crud_produtos.py
+++ b/Backend/crud_produtos.py
@@ -81,6 +81,10 @@ def get_produtos_by_user(
     status_titulo_ia: Optional[StatusGeracaoIAEnum] = None, # Adicionado
     status_descricao_ia: Optional[StatusGeracaoIAEnum] = None # Adicionado
 ) -> List[Produto]:
+    if skip < 0:
+        raise ValueError("skip must be non-negative")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
     query = db.query(Produto).options(
         selectinload(Produto.fornecedor),
         selectinload(Produto.product_type) # Carrega product_type, mas não seus atributos aqui para a lista

--- a/Backend/crud_registros_uso_ia.py
+++ b/Backend/crud_registros_uso_ia.py
@@ -24,6 +24,10 @@ def get_registros_uso_ia(
     data_inicio: Optional[datetime] = None,
     data_fim: Optional[datetime] = None,
 ) -> List[models.RegistroUsoIA]:
+    if skip < 0:
+        raise ValueError("skip must be non-negative")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
     query = db.query(models.RegistroUsoIA).filter(models.RegistroUsoIA.user_id == user_id)
     if tipo_acao:
         query = query.filter(models.RegistroUsoIA.tipo_acao == tipo_acao)
@@ -63,6 +67,10 @@ def get_usos_ia_by_produto(
     skip: int = 0,
     limit: int = 100,
 ) -> List[models.RegistroUsoIA]:
+    if skip < 0:
+        raise ValueError("skip must be non-negative")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
     return (
         db.query(models.RegistroUsoIA)
         .filter(

--- a/Backend/crud_users.py
+++ b/Backend/crud_users.py
@@ -20,6 +20,10 @@ def get_user_by_email(db: Session, email: str) -> Optional[User]:
     return db.query(User).filter(User.email == email).first()
 
 def get_users(db: Session, skip: int = 0, limit: int = 100) -> List[User]:
+    if skip < 0:
+        raise ValueError("skip must be non-negative")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
     return db.query(User).offset(skip).limit(limit).all()
 
 def create_user(db: Session, user: schemas.UserCreate) -> User:
@@ -151,6 +155,10 @@ def get_role_by_name(db: Session, name: str) -> Optional[Role]:
     return db.query(Role).filter(Role.name == name).first()
 
 def get_roles(db: Session, skip: int = 0, limit: int = 10) -> List[Role]:
+    if skip < 0:
+        raise ValueError("skip must be non-negative")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
     return db.query(Role).offset(skip).limit(limit).all()
 
 def create_role(db: Session, role: schemas.RoleCreate) -> Role:
@@ -168,6 +176,10 @@ def get_plano_by_name(db: Session, nome: str) -> Optional[Plano]:
     return db.query(Plano).filter(Plano.nome == nome).first()
 
 def get_planos(db: Session, skip: int = 0, limit: int = 10) -> List[Plano]:
+    if skip < 0:
+        raise ValueError("skip must be non-negative")
+    if limit <= 0:
+        raise ValueError("limit must be positive")
     return db.query(Plano).offset(skip).limit(limit).all()
 
 def create_plano(db: Session, plano: schemas.PlanoCreate) -> Plano:

--- a/Backend/routers/product_types.py
+++ b/Backend/routers/product_types.py
@@ -87,6 +87,10 @@ def read_product_types_endpoint(
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user)
 ):
+    if skip < 0:
+        raise HTTPException(status_code=400, detail="skip must be non-negative")
+    if limit <= 0:
+        raise HTTPException(status_code=400, detail="limit must be positive")
     logger.info(
         "ROUTER (read_product_types): iniciando busca para usuário ID %s",
         current_user.id,


### PR DESCRIPTION
## Summary
- validate `skip` and `limit` before running DB queries

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_6848b53bd830832fad06eec363ffbb6b