### PR TITLE
Handle missing SQLAlchemy in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
 import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import sessionmaker
-
-from Backend.database import Base
-import Backend.crud as crud
-import Backend.schemas as schemas
 
 SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
 
 @pytest.fixture()
 def db_session():
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+    from Backend.database import Base
+    import Backend.crud as crud
+    import Backend.schemas as schemas
+
     engine = create_engine(
         SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
     )

--- a/tests/test_admin_analytics.py
+++ b/tests/test_admin_analytics.py
@@ -1,4 +1,5 @@
 import pytest
+pytest.importorskip("sqlalchemy")
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/tests/test_fornecedores.py
+++ b/tests/test_fornecedores.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("sqlalchemy")
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/tests/test_historico.py
+++ b/tests/test_historico.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("sqlalchemy")
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/tests/test_limit_service.py
+++ b/tests/test_limit_service.py
@@ -1,4 +1,5 @@
 import pytest
+pytest.importorskip("sqlalchemy")
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 

--- a/tests/test_produtos.py
+++ b/tests/test_produtos.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("sqlalchemy")
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,5 @@
+import pytest
+pytest.importorskip("sqlalchemy")
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker

--- a/tests/test_uso_ia.py
+++ b/tests/test_uso_ia.py
@@ -1,4 +1,5 @@
 import pytest
+pytest.importorskip("sqlalchemy")
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker


### PR DESCRIPTION
## Summary
- skip backend tests that rely on SQLAlchemy when it isn't installed
- lazily import SQLAlchemy-dependent modules in the db_session fixture

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6848b915c768832f8b47d144ba068803