### PR TITLE
Fix case-insensitive queries without ILIKE

### DIFF
--- a/Backend/crud_fornecedores.py
+++ b/Backend/crud_fornecedores.py
@@ -4,6 +4,8 @@ from typing import List, Optional
 from sqlalchemy import func, or_
 from sqlalchemy.orm import Session
 
+from Backend import utils
+
 from Backend.models import Fornecedor
 from Backend import schemas
 
@@ -39,12 +41,11 @@ def get_fornecedores_by_user(
         query = query.filter(Fornecedor.user_id == user_id)
 
     if search:
-        search_term = f"%{search.lower()}%"
         query = query.filter(
             or_(
-                func.lower(Fornecedor.nome).ilike(search_term),
-                func.lower(Fornecedor.email_contato).ilike(search_term),
-                func.lower(Fornecedor.contato_principal).ilike(search_term),
+                utils.case_insensitive_like(Fornecedor.nome, search),
+                utils.case_insensitive_like(Fornecedor.email_contato, search),
+                utils.case_insensitive_like(Fornecedor.contato_principal, search),
             )
         )
     return query.order_by(Fornecedor.nome).offset(skip).limit(limit).all()
@@ -60,12 +61,11 @@ def count_fornecedores_by_user(
         query = query.filter(Fornecedor.user_id == user_id)
 
     if search:
-        search_term = f"%{search.lower()}%"
         query = query.filter(
             or_(
-                func.lower(Fornecedor.nome).ilike(search_term),
-                func.lower(Fornecedor.email_contato).ilike(search_term),
-                func.lower(Fornecedor.contato_principal).ilike(search_term),
+                utils.case_insensitive_like(Fornecedor.nome, search),
+                utils.case_insensitive_like(Fornecedor.email_contato, search),
+                utils.case_insensitive_like(Fornecedor.contato_principal, search),
             )
         )
     return query.scalar() or 0

--- a/Backend/crud_product_types.py
+++ b/Backend/crud_product_types.py
@@ -7,6 +7,7 @@ from sqlalchemy.exc import IntegrityError
 
 from Backend.models import Produto, ProductType, AttributeTemplate
 from Backend import schemas
+from Backend import utils
 
 logger = logging.getLogger(__name__)
 
@@ -94,12 +95,11 @@ def get_product_types_for_user(db: Session, user_id: Optional[int], skip: int = 
         query = query.filter(ProductType.user_id == None) # Apenas globais
 
     if search:
-        search_term = f"%{search.lower()}%"
         query = query.filter(
             or_(
-                func.lower(ProductType.key_name).ilike(search_term),
-                func.lower(ProductType.friendly_name).ilike(search_term),
-                func.lower(ProductType.description).ilike(search_term)
+                utils.case_insensitive_like(ProductType.key_name, search),
+                utils.case_insensitive_like(ProductType.friendly_name, search),
+                utils.case_insensitive_like(ProductType.description, search)
             )
         )
         
@@ -113,12 +113,11 @@ def count_product_types_for_user(db: Session, user_id: Optional[int], search: Op
         query = query.filter(ProductType.user_id == None)
 
     if search:
-        search_term = f"%{search.lower()}%"
         query = query.filter(
             or_(
-                func.lower(ProductType.key_name).ilike(search_term),
-                func.lower(ProductType.friendly_name).ilike(search_term),
-                func.lower(ProductType.description).ilike(search_term)
+                utils.case_insensitive_like(ProductType.key_name, search),
+                utils.case_insensitive_like(ProductType.friendly_name, search),
+                utils.case_insensitive_like(ProductType.description, search)
             )
         )
     count = query.scalar()

--- a/Backend/crud_produtos.py
+++ b/Backend/crud_produtos.py
@@ -11,6 +11,7 @@ from Backend.core.config import settings
 from Backend.models import Produto, Fornecedor, ProductType, StatusEnriquecimentoEnum, StatusGeracaoIAEnum
 from fastapi import UploadFile
 from Backend import schemas
+from Backend import utils
 
 logger = logging.getLogger(__name__)
 
@@ -92,17 +93,16 @@ def get_produtos_by_user(
         query = query.filter(Produto.user_id == user_id)
 
     if search:
-        search_term = f"%{search.lower()}%"
         query = query.filter(
             or_(
-                func.lower(Produto.nome_base).ilike(search_term),
-                func.lower(Produto.nome_chat_api).ilike(search_term),
-                func.lower(Produto.descricao_original).ilike(search_term),
-                func.lower(Produto.descricao_chat_api).ilike(search_term),
-                func.lower(Produto.sku).ilike(search_term),
-                func.lower(Produto.ean).ilike(search_term),
-                func.lower(Produto.marca).ilike(search_term),
-                func.lower(Produto.modelo).ilike(search_term)
+                utils.case_insensitive_like(Produto.nome_base, search),
+                utils.case_insensitive_like(Produto.nome_chat_api, search),
+                utils.case_insensitive_like(Produto.descricao_original, search),
+                utils.case_insensitive_like(Produto.descricao_chat_api, search),
+                utils.case_insensitive_like(Produto.sku, search),
+                utils.case_insensitive_like(Produto.ean, search),
+                utils.case_insensitive_like(Produto.marca, search),
+                utils.case_insensitive_like(Produto.modelo, search)
             )
         )
     
@@ -111,7 +111,7 @@ def get_produtos_by_user(
     if product_type_id is not None:
         query = query.filter(Produto.product_type_id == product_type_id)
     if categoria:
-        query = query.filter(func.lower(Produto.categoria_original).ilike(f"%{categoria.lower()}%")) # Ou categoria_mapeada
+        query = query.filter(utils.case_insensitive_like(Produto.categoria_original, categoria))  # Ou categoria_mapeada
     if status_enriquecimento_web:
         query = query.filter(Produto.status_enriquecimento_web == status_enriquecimento_web)
     if status_titulo_ia:
@@ -154,17 +154,16 @@ def count_produtos_by_user(
         query = query.filter(Produto.user_id == user_id)
 
     if search:
-        search_term = f"%{search.lower()}%"
         query = query.filter(
             or_(
-                func.lower(Produto.nome_base).ilike(search_term),
-                func.lower(Produto.nome_chat_api).ilike(search_term),
-                func.lower(Produto.descricao_original).ilike(search_term),
-                func.lower(Produto.descricao_chat_api).ilike(search_term),
-                func.lower(Produto.sku).ilike(search_term),
-                func.lower(Produto.ean).ilike(search_term),
-                func.lower(Produto.marca).ilike(search_term),
-                func.lower(Produto.modelo).ilike(search_term)
+                utils.case_insensitive_like(Produto.nome_base, search),
+                utils.case_insensitive_like(Produto.nome_chat_api, search),
+                utils.case_insensitive_like(Produto.descricao_original, search),
+                utils.case_insensitive_like(Produto.descricao_chat_api, search),
+                utils.case_insensitive_like(Produto.sku, search),
+                utils.case_insensitive_like(Produto.ean, search),
+                utils.case_insensitive_like(Produto.marca, search),
+                utils.case_insensitive_like(Produto.modelo, search)
             )
         )
     if fornecedor_id is not None:
@@ -172,7 +171,7 @@ def count_produtos_by_user(
     if product_type_id is not None:
         query = query.filter(Produto.product_type_id == product_type_id)
     if categoria:
-        query = query.filter(func.lower(Produto.categoria_original).ilike(f"%{categoria.lower()}%"))
+        query = query.filter(utils.case_insensitive_like(Produto.categoria_original, categoria))
     if status_enriquecimento_web:
         query = query.filter(Produto.status_enriquecimento_web == status_enriquecimento_web)
     if status_titulo_ia:

--- a/Backend/crud_registros_uso_ia.py
+++ b/Backend/crud_registros_uso_ia.py
@@ -87,7 +87,7 @@ def count_usos_ia_by_user_and_type_no_mes_corrente(
         .filter(
             models.RegistroUsoIA.user_id == user_id,
             models.RegistroUsoIA.created_at >= inicio_mes,
-            models.RegistroUsoIA.tipo_acao.ilike(f"{tipo_geracao_prefix}%"),
+            func.lower(models.RegistroUsoIA.tipo_acao).like(f"{tipo_geracao_prefix.lower()}%"),
         )
         .scalar()
         or 0

--- a/Backend/routers/admin_analytics.py
+++ b/Backend/routers/admin_analytics.py
@@ -43,8 +43,8 @@ async def get_total_counts_endpoint(db: Session = Depends(get_db)):
         
         # FIX APLICADO AQUI: Adicionado o cast para String para permitir o operador ILIKE em colunas ENUM
         total_enriquecimentos_mes = db.query(func.count(models.RegistroUsoIA.id)).filter(
-            models.RegistroUsoIA.created_at >= start_of_month, # Using created_at
-            cast(models.RegistroUsoIA.tipo_acao, String).ilike("%enriquecimento_web%") 
+            models.RegistroUsoIA.created_at >= start_of_month,
+            func.lower(cast(models.RegistroUsoIA.tipo_acao, String)).like("%enriquecimento_web%")
         ).scalar() or 0
 
         return schemas.TotalCounts(

--- a/Backend/routers/fornecedores.py
+++ b/Backend/routers/fornecedores.py
@@ -11,7 +11,8 @@ from Backend import models
 from Backend import schemas  # schemas é importado
 from Backend import crud_historico
 from Backend import database
-from . import auth_utils # Para obter o usuário 
+from . import auth_utils # Para obter o usuário
+from Backend import utils
 
 logger = logging.getLogger(__name__)
 
@@ -74,7 +75,9 @@ def read_user_fornecedores(
         # Admin vê todos, mas ainda pode filtrar por termo_busca
         fornecedores = db.query(models.Fornecedor)
         if termo_busca:
-            fornecedores = fornecedores.filter(models.Fornecedor.nome.ilike(f"%{termo_busca}%"))
+            fornecedores = fornecedores.filter(
+                utils.case_insensitive_like(models.Fornecedor.nome, termo_busca)
+            )
         total_items = fornecedores.count() # Conta após o filtro
         items_paginados = fornecedores.order_by(models.Fornecedor.nome).offset(skip).limit(limit).all()
     else:

--- a/Backend/routers/search.py
+++ b/Backend/routers/search.py
@@ -7,6 +7,7 @@ from sqlalchemy import func
 from Backend.database import get_db
 from Backend import models, schemas
 from . import auth_utils
+from Backend import utils
 
 router = APIRouter(prefix="/search", tags=["Search"], dependencies=[Depends(auth_utils.get_current_active_user)])
 
@@ -22,8 +23,7 @@ def search_all(
 
     prod_query = db.query(models.Produto.id, models.Produto.nome_base, models.Produto.created_at)
     if q:
-        term = f"%{q.lower()}%"
-        prod_query = prod_query.filter(func.lower(models.Produto.nome_base).ilike(term))
+        prod_query = prod_query.filter(utils.case_insensitive_like(models.Produto.nome_base, q))
     if not current_user.is_superuser:
         prod_query = prod_query.filter(models.Produto.user_id == current_user.id)
     prod_query = prod_query.order_by(models.Produto.created_at.desc())
@@ -32,7 +32,7 @@ def search_all(
 
     forn_query = db.query(models.Fornecedor.id, models.Fornecedor.nome, models.Fornecedor.created_at)
     if q:
-        forn_query = forn_query.filter(func.lower(models.Fornecedor.nome).ilike(term))
+        forn_query = forn_query.filter(utils.case_insensitive_like(models.Fornecedor.nome, q))
     if not current_user.is_superuser:
         forn_query = forn_query.filter(models.Fornecedor.user_id == current_user.id)
     forn_query = forn_query.order_by(models.Fornecedor.created_at.desc())
@@ -41,7 +41,7 @@ def search_all(
 
     pt_query = db.query(models.ProductType.id, models.ProductType.friendly_name, models.ProductType.created_at)
     if q:
-        pt_query = pt_query.filter(func.lower(models.ProductType.friendly_name).ilike(term))
+        pt_query = pt_query.filter(utils.case_insensitive_like(models.ProductType.friendly_name, q))
     if not current_user.is_superuser:
         pt_query = pt_query.filter((models.ProductType.user_id == current_user.id) | (models.ProductType.user_id.is_(None)))
     pt_query = pt_query.order_by(models.ProductType.created_at.desc())
@@ -51,7 +51,7 @@ def search_all(
     if current_user.is_superuser:
         user_query = db.query(models.User.id, models.User.email, models.User.created_at)
         if q:
-            user_query = user_query.filter(func.lower(models.User.email).ilike(term))
+            user_query = user_query.filter(utils.case_insensitive_like(models.User.email, q))
         user_query = user_query.order_by(models.User.created_at.desc())
         for user in user_query.limit(limit).all():
             results_items.append((user.created_at, schemas.SearchItem(id=user.id, type="usuario", name=user.email)))

--- a/Backend/utils.py
+++ b/Backend/utils.py
@@ -1,0 +1,11 @@
+from sqlalchemy import func
+from sqlalchemy.sql import ColumnElement
+
+
+def case_insensitive_like(column: ColumnElement, value: str, *, prefix: bool = False):
+    """Return a case-insensitive LIKE expression.
+
+    If ``prefix`` is True, match only the start of the value.
+    """
+    pattern = f"{value.lower()}%" if prefix else f"%{value.lower()}%"
+    return func.lower(column).like(pattern)


### PR DESCRIPTION
## Summary
- add `case_insensitive_like` helper
- use the helper in CRUD modules and routers
- remove all direct `ilike` usage for better DB compatibility

## Testing
- `./scripts/run_tests.sh` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6848b547ee30832fba78b47762974b0e