### PR TITLE
Improve PDF fallback handling

### DIFF
--- a/tests/test_pdf_no_tables.py
+++ b/tests/test_pdf_no_tables.py
@@ -1,0 +1,40 @@
+import asyncio
+import io
+import subprocess
+import sys
+
+import pytest
+
+# Ensure reportlab is available
+try:
+    import reportlab # type: ignore
+except ImportError:  # pragma: no cover - install at runtime
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "reportlab"])
+    import reportlab # type: ignore
+
+from reportlab.pdfgen import canvas
+
+from Backend.services import file_processing_service
+
+
+def _create_pdf(pages_text):
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf)
+    for i, text in enumerate(pages_text):
+        c.drawString(100, 750, text)
+        if i < len(pages_text) - 1:
+            c.showPage()
+    c.save()
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def test_processar_pdf_sem_tabelas_extrai_texto():
+    pdf_bytes = _create_pdf(["Primeira pagina", "Segunda pagina"])
+    res = asyncio.run(
+        file_processing_service.processar_arquivo_pdf(pdf_bytes, usar_llm=False)
+    )
+    assert len(res) == 2
+    assert res[0]["dados_brutos_adicionais"]["texto_completo_pagina_1"].startswith("Primeira")
+    assert res[1]["dados_brutos_adicionais"]["texto_completo_pagina_2"].startswith("Segunda")
+


### PR DESCRIPTION
## Summary
- enhance PDF processing to read each page when tables aren't found
- optionally send page text to the LLM
- log which pages were read and processed
- add regression test covering PDFs without tables

## Testing
- `scripts/run_tests.sh tests/test_api_basic.py::test_root_endpoint tests/test_pdf_no_tables.py::test_processar_pdf_sem_tabelas_extrai_texto -q`

------
https://chatgpt.com/codex/tasks/task_e_684944ecc5d8832fa8b3d30e17fb4449