### PR TITLE
Add error report to catalog import

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -327,6 +327,11 @@ class ImportPreviewResponse(BaseModel):
     message: Optional[str] = None
     error: Optional[str] = None
 
+
+class ImportCatalogoResponse(BaseModel):
+    produtos_criados: List[ProdutoResponse]
+    erros: List[Dict[str, Any]]
+
 class ProdutoPage(BaseModel):
     items: List[ProdutoResponse]
     total_items: int
@@ -478,6 +483,7 @@ FornecedorResponse.model_rebuild()
 AttributeTemplateResponse.model_rebuild()
 ProductTypeResponse.model_rebuild()
 ProdutoResponse.model_rebuild()
+ImportCatalogoResponse.model_rebuild()
 RegistroUsoIAResponse.model_rebuild()
 RegistroHistoricoResponse.model_rebuild()
 UserActivity.model_rebuild()

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -84,10 +84,10 @@ def _processar_linha_padronizada(
             primeiro_valor_util = next((v for v in dados_brutos_nao_mapeados.values() if v), None)
             if primeiro_valor_util:
                  produto_dados_padronizados["nome_base"] = primeiro_valor_util
-            else: # Se realmente não há nada que possa ser um nome/identificador
-                return None # Ignora a linha
+            else:  # Se realmente não há nada que possa ser um nome/identificador
+                return {"motivo_descarte": "Faltam nome_base e sku_original", "linha_original": linha_original}
         else:
-            return None # Ignora a linha
+            return {"motivo_descarte": "Faltam nome_base e sku_original", "linha_original": linha_original}
 
     # Adiciona os campos não mapeados ao dicionário principal
     if dados_brutos_nao_mapeados:

--- a/README.md
+++ b/README.md
@@ -424,6 +424,26 @@ const historico = await usoIAService.getMeuHistoricoUsoIA({ skip: 0, limit: 10 }
 console.log(historico.items);
 ```
 
+### Importação de catálogos
+
+O endpoint `/produtos/importar-catalogo/{fornecedor_id}/` agora retorna um
+relatório de erros junto com os produtos criados. O formato da resposta é:
+
+```json
+{
+  "produtos_criados": [ /* lista de produtos */ ],
+  "erros": [
+    {
+      "motivo_descarte": "Faltam nome_base e sku_original",
+      "linha_original": { /* dados enviados */ }
+    }
+  ]
+}
+```
+
+Cada item em `erros` descreve a linha descartada e o motivo para facilitar a
+correção do arquivo de origem.
+
 ---
 
 ## 🧪 Testes

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,8 @@
 #!/bin/sh
 set -e
 pip install -r requirements-backend.txt
+export FIRST_SUPERUSER_EMAIL="admin@example.com"
+export FIRST_SUPERUSER_PASSWORD="adminpass"
+export ADMIN_EMAIL="admin@example.com"
+export ADMIN_PASSWORD="adminpass"
 pytest "$@"


### PR DESCRIPTION
## Summary
- return discard reason from `_processar_linha_padronizada`
- propagate discarded lines in `importar_catalogo_fornecedor`
- expose list of created products and errors through new `ImportCatalogoResponse`
- document new response format in README
- basic test for catalog import error report
- adjust run_tests script for CI

## Testing
- `./scripts/run_tests.sh` *(fails: OperationalError: no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_684944ecee50832f87691e3fb7908fb9