### PR TITLE
Install pytest for backend tests

### DIFF
--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -24,3 +24,5 @@ google-api-python-client==2.119.0
 lxml==4.9.3
 psycopg2-binary
 jinja2
+pytest==8.2.1
+pytest-asyncio==0.23.6

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -e
 pip install -r requirements-backend.txt
+pip install pytest pytest-asyncio
 export FIRST_SUPERUSER_EMAIL="admin@example.com"
 export FIRST_SUPERUSER_PASSWORD="adminpass"
 export ADMIN_EMAIL="admin@example.com"


### PR DESCRIPTION
## Summary
- add pytest and pytest-asyncio to backend requirements
- ensure run_tests.sh explicitly installs them

## Testing
- `./scripts/run_tests.sh` *(fails: sqlalchemy.exc.OperationalError)*

------
https://chatgpt.com/codex/tasks/task_e_684952ac30b4832f8ba8d0a8d29db8aa