### PR TITLE
Add pytest-asyncio

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,8 +276,8 @@ Principais variáveis obrigatórias:
 ### 6. **Testes**
 
 Antes de executar os testes do backend, instale as dependências listadas em
-`requirements-backend.txt`, que incluem pacotes como **SQLAlchemy**. Para isso,
-rode:
+`requirements-backend.txt`, que incluem pacotes como **SQLAlchemy** e as
+dependências de testes `pytest` e `pytest-asyncio`. Para isso, rode:
 
 ```sh
 pip install -r requirements-backend.txt
@@ -449,7 +449,8 @@ correção do arquivo de origem.
 ## 🧪 Testes
 
 Os testes do backend dependem das bibliotecas listadas em `requirements-backend.txt`,
-que incluem pacotes como **SQLAlchemy**. Instale-as com:
+que incluem pacotes como **SQLAlchemy** e as dependências `pytest` e
+`pytest-asyncio`. Instale-as com:
 
 ```sh
 pip install -r requirements-backend.txt

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -24,3 +24,5 @@ google-api-python-client==2.119.0
 lxml==4.9.3
 psycopg2-binary
 jinja2
+pytest
+pytest-asyncio

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -24,3 +24,4 @@ google-api-python-client==2.119.0
 psycopg2-binary
 jinja2
 pytest
+pytest-asyncio


### PR DESCRIPTION
## Summary
- include pytest and pytest-asyncio in backend requirements
- mention pytest-asyncio in test instructions

## Testing
- `pip install -r requirements-backend.txt`
- `pytest tests/test_file_processing_service.py::test_processar_arquivo_csv_encodings -vv`

------
https://chatgpt.com/codex/tasks/task_e_684952adc310832fbd139f47efe540a1