### PR TITLE
Add catalog import file feature

### DIFF
--- a/Backend/alembic/versions/c1f4cd5f7a6a_add_catalogimportfile_table.py
+++ b/Backend/alembic/versions/c1f4cd5f7a6a_add_catalogimportfile_table.py
@@ -1,0 +1,36 @@
+"""add CatalogImportFile table
+
+Revision ID: c1f4cd5f7a6a
+Revises: 3c84dee9f02e
+Create Date: 2025-06-20 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'c1f4cd5f7a6a'
+down_revision: Union[str, None] = '3c84dee9f02e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        'catalog_import_files',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('fornecedor_id', sa.Integer(), nullable=True),
+        sa.Column('original_filename', sa.String(), nullable=False),
+        sa.Column('stored_filename', sa.String(), nullable=False),
+        sa.Column('status', sa.String(), nullable=False, server_default='UPLOADED'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()'), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ),
+        sa.ForeignKeyConstraint(['fornecedor_id'], ['fornecedores.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_index(op.f('ix_catalog_import_files_id'), 'catalog_import_files', ['id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_catalog_import_files_id'), table_name='catalog_import_files')
+    op.drop_table('catalog_import_files')

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -349,3 +349,18 @@ class RegistroHistorico(Base):
     created_at = Column(DateTime(timezone=True), server_default=func.now())
 
     usuario = relationship("User", back_populates="historicos")
+
+
+class CatalogImportFile(Base):
+    __tablename__ = "catalog_import_files"
+
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
+    fornecedor_id = Column(Integer, ForeignKey("fornecedores.id"), nullable=True)
+    original_filename = Column(String, nullable=False)
+    stored_filename = Column(String, nullable=False)
+    status = Column(String, nullable=False, default="UPLOADED")
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+
+    user = relationship("User")
+    fornecedor = relationship("Fornecedor")

--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -1,6 +1,6 @@
 # Backend/routers/produtos.py
 
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Dict, Any
 
 from fastapi import (
     APIRouter,
@@ -30,6 +30,7 @@ from Backend import database
 from Backend.services import file_processing_service
 from . import auth_utils # Para obter o usuário logado
 from Backend.core import config # Pode ser necessário para settings, se usado diretamente
+from Backend.core.config import settings
 
 router = APIRouter(
     prefix="/produtos",
@@ -339,14 +340,26 @@ async def importar_catalogo_preview(
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user),
 ):
-    """Retorna cabeçalhos detectados e linhas de amostra do arquivo enviado."""
-    content = await file.read()
-    ext = Path(file.filename).suffix.lower()
+    """Salva o arquivo enviado, gera preview e registra no banco."""
+    saved = await file_processing_service.save_uploaded_catalog(file)
+    saved.user_id = current_user.id
+    db.add(saved)
+    db.commit()
+    db.refresh(saved)
+
+    ext = Path(saved.stored_filename).suffix.lower()
+    file_path = Path(settings.UPLOAD_DIRECTORY) / "catalogs" / saved.stored_filename
+    if not file_path.is_absolute():
+        file_path = Path(__file__).resolve().parent.parent / file_path
+    content = file_path.read_bytes()
+
     try:
         preview = await file_processing_service.gerar_preview(content, ext)
-        return preview
     except ValueError:
         raise HTTPException(status_code=400, detail="Formato de arquivo não suportado")
+
+    preview["file_id"] = saved.id
+    return preview
 
 
 @router.post(
@@ -424,3 +437,39 @@ async def importar_catalogo_fornecedor(
             ),
         )
     return {"produtos_criados": created, "erros": erros}
+
+
+@router.post("/importar-catalogo-finalizar/{file_id}/")
+async def importar_catalogo_finalizar(
+    file_id: int,
+    db: Session = Depends(database.get_db),
+    current_user: models.User = Depends(auth_utils.get_current_active_user),
+):
+    """Processa o arquivo salvo e marca o registro como importado."""
+    catalog_file = db.query(models.CatalogImportFile).filter_by(id=file_id, user_id=current_user.id).first()
+    if not catalog_file:
+        raise HTTPException(status_code=404, detail="Arquivo não encontrado")
+
+    file_path = Path(settings.UPLOAD_DIRECTORY) / "catalogs" / catalog_file.stored_filename
+    if not file_path.is_absolute():
+        file_path = Path(__file__).resolve().parent.parent / file_path
+    if not file_path.exists():
+        raise HTTPException(status_code=404, detail="Arquivo não encontrado no disco")
+
+    content = file_path.read_bytes()
+    ext = file_path.suffix.lower()
+
+    if ext in [".xlsx", ".xls"]:
+        produtos = await file_processing_service.processar_arquivo_excel(content)
+    elif ext == ".csv":
+        produtos = await file_processing_service.processar_arquivo_csv(content)
+    elif ext == ".pdf":
+        produtos = await file_processing_service.processar_arquivo_pdf(content)
+    else:
+        raise HTTPException(status_code=400, detail="Formato de arquivo não suportado")
+
+    catalog_file.status = "IMPORTED"
+    db.add(catalog_file)
+    db.commit()
+
+    return {"produtos": produtos}

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -322,6 +322,7 @@ class ProdutoBatchDeleteRequest(BaseModel):
 
 
 class ImportPreviewResponse(BaseModel):
+    file_id: int
     headers: List[str]
     sample_rows: List[Dict[str, Any]]
     message: Optional[str] = None
@@ -391,6 +392,27 @@ class HistoricoPage(BaseModel):
     total_items: int
     page: int
     limit: int
+
+
+class CatalogImportFileBase(BaseModel):
+    original_filename: str
+    stored_filename: str
+    status: str
+
+
+class CatalogImportFileCreate(CatalogImportFileBase):
+    user_id: int
+    fornecedor_id: Optional[int] = None
+
+
+class CatalogImportFileResponse(CatalogImportFileBase):
+    id: int
+    user_id: int
+    fornecedor_id: Optional[int] = None
+    created_at: datetime
+
+    class Config:
+        from_attributes = True
 
 # --- Password Recovery Schemas ---
 class PasswordResetSchema(BaseModel):
@@ -486,6 +508,7 @@ ProdutoResponse.model_rebuild()
 ImportCatalogoResponse.model_rebuild()
 RegistroUsoIAResponse.model_rebuild()
 RegistroHistoricoResponse.model_rebuild()
+CatalogImportFileResponse.model_rebuild()
 UserActivity.model_rebuild()
 SocialLoginConfig.model_rebuild()
 

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -5,10 +5,39 @@ import csv
 import io  # Para ler o conteúdo do arquivo em memória
 import chardet
 from typing import List, Dict, Any, Union, Optional
+from pathlib import Path
+from uuid import uuid4
+from fastapi import UploadFile
+
 from Backend.core.logging_config import get_logger
+from Backend.core.config import settings
+from Backend import models
 from Backend.services import web_data_extractor_service
 
 logger = get_logger(__name__)
+
+
+async def save_uploaded_catalog(file: UploadFile) -> models.CatalogImportFile:
+    """Salva o arquivo de catálogo no disco e retorna um objeto CatalogImportFile."""
+    directory = Path(settings.UPLOAD_DIRECTORY) / "catalogs"
+    if not directory.is_absolute():
+        directory = Path(__file__).resolve().parent.parent / directory
+    directory.mkdir(parents=True, exist_ok=True)
+
+    ext = Path(file.filename).suffix
+    unique_name = f"{uuid4().hex}{ext}"
+    stored_path = directory / unique_name
+
+    content = await file.read()
+    with open(stored_path, "wb") as f_out:
+        f_out.write(content)
+    await file.close()
+
+    return models.CatalogImportFile(
+        original_filename=file.filename,
+        stored_filename=unique_name,
+        status="UPLOADED",
+    )
 
 def _limpar_valor_extraido(valor: Any) -> Optional[str]:
     """Helper para limpar strings ou converter outros tipos para string, retornando None se vazio."""

--- a/tests/test_catalog_import_file.py
+++ b/tests/test_catalog_import_file.py
@@ -1,0 +1,78 @@
+import io
+from pathlib import Path
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from Backend.main import app
+from Backend.database import Base, get_db
+from Backend import crud, schemas, models
+from Backend.core.config import settings
+
+app.router.on_startup.clear()
+
+engine = create_engine("sqlite:///:memory:", connect_args={"check_same_thread": False})
+TestingSessionLocal = sessionmaker(bind=engine)
+Base.metadata.create_all(bind=engine)
+
+
+def override_get_db():
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+app.dependency_overrides[get_db] = override_get_db
+client = TestClient(app)
+
+with TestingSessionLocal() as db:
+    crud.create_initial_data(db)
+
+
+def get_admin_headers():
+    resp = client.post(
+        "/api/v1/auth/token",
+        data={"username": settings.FIRST_SUPERUSER_EMAIL, "password": settings.FIRST_SUPERUSER_PASSWORD},
+    )
+    assert resp.status_code == 200
+    token = resp.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
+def test_preview_saves_file_and_record():
+    headers = get_admin_headers()
+    csv_content = "nome,sku\nA,1\n"
+    files = {"file": ("catalogo.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+    resp = client.post("/api/v1/produtos/importar-catalogo-preview/", files=files, headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "file_id" in data
+    file_id = data["file_id"]
+
+    with TestingSessionLocal() as db:
+        record = db.query(models.CatalogImportFile).get(file_id)
+        assert record is not None
+        assert record.status == "UPLOADED"
+        path = Path(__file__).resolve().parents[1] / "Backend" / "static" / "uploads" / "catalogs" / record.stored_filename
+        assert path.exists()
+
+
+def test_finalize_updates_status():
+    headers = get_admin_headers()
+    csv_content = "nome,sku\nB,2\n"
+    files = {"file": ("catalogo.csv", io.BytesIO(csv_content.encode()), "text/csv")}
+    resp = client.post("/api/v1/produtos/importar-catalogo-preview/", files=files, headers=headers)
+    assert resp.status_code == 200
+    file_id = resp.json()["file_id"]
+
+    resp = client.post(f"/api/v1/produtos/importar-catalogo-finalizar/{file_id}/", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "produtos" in data
+    assert len(data["produtos"]) == 1
+
+    with TestingSessionLocal() as db:
+        record = db.query(models.CatalogImportFile).get(file_id)
+        assert record.status == "IMPORTED"


### PR DESCRIPTION
## Summary
- track uploaded catalog files in a new `CatalogImportFile` table
- allow saving uploaded catalog files for preview
- add endpoint to finalize catalog import
- implement helper to save uploaded catalog files
- test preview and finalize steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68497b122968832fa83651cfe3e02552