### PR TITLE
Atualização do fluxo de importação de catálogo

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -17,6 +17,8 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   const [step, setStep] = useState(1);
   const [file, setFile] = useState(null);
   const [preview, setPreview] = useState(null);
+  const [fileId, setFileId] = useState(null);
+  const [sampleRows, setSampleRows] = useState([]);
   const [mapping, setMapping] = useState({});
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
@@ -30,7 +32,9 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     setLoading(true);
     try {
       const data = await fornecedorService.previewCatalogo(file);
-      setPreview(data);
+      setPreview({ headers: data.headers });
+      setFileId(data.fileId);
+      setSampleRows(data.sampleRows || []);
       setStep(2);
     } catch (err) {
       alert(err.detail || err.message || 'Erro ao gerar preview');
@@ -43,11 +47,20 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     setMapping((prev) => ({ ...prev, [header]: value }));
   };
 
-  const handleImport = async () => {
-    if (!file) return;
+  const handleRowChange = (rowIndex, header, value) => {
+    setSampleRows((prev) => {
+      const updated = [...prev];
+      const row = { ...updated[rowIndex], [header]: value };
+      updated[rowIndex] = row;
+      return updated;
+    });
+  };
+
+  const handleConfirmImport = async () => {
+    if (!fileId) return;
     setLoading(true);
     try {
-      await fornecedorService.importCatalogo(fornecedorId, file, mapping);
+      await fornecedorService.finalizarImportacaoCatalogo(fileId, mapping, sampleRows);
       setMessage('Importação concluída com sucesso');
       setStep(3);
     } catch (err) {
@@ -61,7 +74,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     <div>
       <input type="file" accept=".csv,.xls,.xlsx,.pdf" onChange={handleFileChange} />
       <button onClick={handleGeneratePreview} disabled={!file || loading}>
-        {loading ? 'Enviando...' : 'Enviar'}
+        {loading ? 'Enviando...' : 'Gerar Preview'}
       </button>
     </div>
   );
@@ -96,8 +109,33 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
             ))}
           </tbody>
         </table>
-        <button onClick={handleImport} disabled={loading}>
-          {loading ? 'Importando...' : 'Importar'}
+        {sampleRows.length > 0 && (
+          <table className="preview-table">
+            <thead>
+              <tr>
+                {preview.headers.map((h) => (
+                  <th key={h}>{h}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {sampleRows.map((row, rowIdx) => (
+                <tr key={rowIdx}>
+                  {preview.headers.map((h) => (
+                    <td key={h}>
+                      <input
+                        value={row[h] || ''}
+                        onChange={(e) => handleRowChange(rowIdx, h, e.target.value)}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+        <button onClick={handleConfirmImport} disabled={loading}>
+          {loading ? 'Importando...' : 'Confirmar Importação'}
         </button>
       </div>
     );

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import ImportCatalogWizard from '../ImportCatalogWizard.jsx';
+
+jest.mock('../../../services/fornecedorService', () => ({
+  __esModule: true,
+  default: {
+    previewCatalogo: jest.fn(() => Promise.resolve({
+      fileId: 'f1',
+      headers: ['Nome'],
+      sampleRows: [{ Nome: 'Item' }],
+    })),
+    finalizarImportacaoCatalogo: jest.fn(() => Promise.resolve({ success: true })),
+  },
+}));
+import fornecedorService from '../../../services/fornecedorService';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+test('shows preview rows and sends fileId on confirm', async () => {
+  render(<ImportCatalogWizard isOpen={true} onClose={() => {}} fornecedorId={1} />);
+  const fileInput = document.querySelector('input[type="file"]');
+  const file = new File(['a'], 'test.csv', { type: 'text/csv' });
+  await userEvent.upload(fileInput, file);
+  await userEvent.click(screen.getByText('Gerar Preview'));
+  expect(await screen.findByDisplayValue('Item')).toBeInTheDocument();
+  await userEvent.click(screen.getByText('Confirmar Importação'));
+  expect(fornecedorService.finalizarImportacaoCatalogo).toHaveBeenCalledWith('f1', expect.any(Object), expect.any(Array));
+});

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -90,7 +90,12 @@ export const previewCatalogo = async (file) => {
     const formData = new FormData();
     formData.append('file', file);
     const response = await apiClient.post('/produtos/importar-catalogo-preview/', formData);
-    return response.data;
+    const { file_id, headers, sample_rows } = response.data;
+    return {
+      fileId: file_id,
+      headers,
+      sampleRows: sample_rows,
+    };
   } catch (error) {
     console.error('Erro ao gerar preview do catálogo:', JSON.stringify(error.response?.data || error.message || error));
     if (error.response && error.response.data) {
@@ -121,6 +126,28 @@ export const importCatalogo = async (fornecedorId, file, mapping = null) => {
   }
 };
 
+export const finalizarImportacaoCatalogo = async (fileId, mapping = null, rows = null) => {
+  try {
+    const payload = {
+      file_id: fileId,
+    };
+    if (mapping) {
+      payload.mapping = mapping;
+    }
+    if (rows) {
+      payload.rows = rows;
+    }
+    const response = await apiClient.post(`/produtos/importar-catalogo-finalizar/${fileId}/`, payload);
+    return response.data;
+  } catch (error) {
+    console.error(`Erro ao finalizar importação do catálogo ${fileId}:`, JSON.stringify(error.response?.data || error.message || error));
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao confirmar importação do catálogo');
+  }
+};
+
 export default {
   getFornecedores,
   getFornecedorById,
@@ -129,4 +156,5 @@ export default {
   deleteFornecedor,
   previewCatalogo,
   importCatalogo,
+  finalizarImportacaoCatalogo,
 };


### PR DESCRIPTION
## Summary
- ajuste no serviço `fornecedorService.previewCatalogo` para retornar `fileId`, `headers` e `sampleRows`
- criação de endpoint de finalização no serviço
- atualização do `ImportCatalogWizard` para edição do preview e envio com `fileId`
- adição de teste do wizard cobrindo uso do `fileId`

## Testing
- `npm run lint` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@eslint/js')*
- `npm test` *(fails to execute tests: Jest encountered an unexpected token)*
- `./scripts/run_tests.sh` *(fails: OperationalError no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_68497b126134832fa31c7fd92a0a30b0