### PR TITLE
Add PDF preview images in catalog preview

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -22,3 +22,4 @@ python-multipart==0.0.9
 SQLAlchemy==2.0.29
 trafilatura==1.6.2
 uvicorn[standard]==0.27.1
+pdf2image==1.17.0

--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -344,6 +344,9 @@ async def importar_catalogo_preview(
     ext = Path(file.filename).suffix.lower()
     try:
         preview = await file_processing_service.gerar_preview(content, ext)
+        if ext == ".pdf":
+            preview_images = file_processing_service.pdf_pages_to_images(content)
+            preview["preview_images"] = preview_images
         return preview
     except ValueError:
         raise HTTPException(status_code=400, detail="Formato de arquivo não suportado")

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -324,6 +324,7 @@ class ProdutoBatchDeleteRequest(BaseModel):
 class ImportPreviewResponse(BaseModel):
     headers: List[str]
     sample_rows: List[Dict[str, Any]]
+    preview_images: Optional[List[str]] = None
     message: Optional[str] = None
     error: Optional[str] = None
 

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -73,6 +73,18 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     }
     return (
       <div>
+        {preview.preview_images && (
+          <div className="preview-images">
+            {preview.preview_images.map((img, idx) => (
+              <img
+                key={idx}
+                src={`data:image/png;base64,${img}`}
+                alt={`Página ${idx + 1}`}
+                style={{ maxWidth: '100px', marginRight: '4px' }}
+              />
+            ))}
+          </div>
+        )}
         <table className="mapping-table">
           <thead>
             <tr>

--- a/tests/test_pdf_pages_to_images.py
+++ b/tests/test_pdf_pages_to_images.py
@@ -1,0 +1,31 @@
+import io
+import base64
+import subprocess
+import sys
+
+# ensure reportlab available
+try:
+    from reportlab.pdfgen import canvas
+except ImportError:  # pragma: no cover - install at runtime
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "reportlab"])
+    from reportlab.pdfgen import canvas
+
+from Backend.services.file_processing_service import pdf_pages_to_images
+
+
+def _create_pdf():
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf)
+    c.drawString(100, 750, "Hello")
+    c.showPage()
+    c.save()
+    buf.seek(0)
+    return buf.getvalue()
+
+
+def test_pdf_pages_to_images_basic():
+    pdf_bytes = _create_pdf()
+    images = pdf_pages_to_images(pdf_bytes)
+    assert len(images) >= 1
+    decoded = base64.b64decode(images[0])
+    assert decoded.startswith(b"\x89PNG")


### PR DESCRIPTION
## Summary
- support pdf2image in backend
- add pdf_pages_to_images service function
- allow ImportPreviewResponse to return preview_images
- generate preview images for PDF uploads
- show preview images in catalog import wizard
- test pdf_pages_to_images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError lxml, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68497be1a3a0832fa9c534018f680159