### PR TITLE
Refactor inline styles to CSS files

### DIFF
--- a/Frontend/app/src/components/common/PaginationControls.css
+++ b/Frontend/app/src/components/common/PaginationControls.css
@@ -1,0 +1,30 @@
+/* Frontend/app/src/components/common/PaginationControls.css */
+
+.pagination-controls {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  text-align: center;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.pagination-button {
+  padding: 0.5em 1em;
+}
+
+.pagination-info {
+  margin: 0 10px;
+  font-size: 0.9em;
+  color: #555;
+}
+
+.total-items {
+  margin-left: 0.5rem;
+}
+
+.items-per-page-select {
+  margin-left: 0.5rem;
+}

--- a/Frontend/app/src/components/common/PaginationControls.jsx
+++ b/Frontend/app/src/components/common/PaginationControls.jsx
@@ -1,5 +1,6 @@
 // Frontend/app/src/components/common/PaginationControls.jsx
 import React from 'react';
+import './PaginationControls.css';
 
 function PaginationControls({
   currentPage,
@@ -28,42 +29,30 @@ function PaginationControls({
   };
 
   return (
-    <div
-      className="pagination-controls"
-      style={{
-        marginTop: '1.5rem',
-        marginBottom: '0.5rem',
-        textAlign: 'center',
-        display: 'flex',
-        justifyContent: 'center',
-        alignItems: 'center',
-        gap: '10px',
-        flexWrap: 'wrap',
-      }}
-    >
+    <div className="pagination-controls">
       <button
         onClick={handlePrevious}
         disabled={currentPage === 0 || isLoading}
-        style={{ padding: '0.5em 1em' }}
+        className="pagination-button"
       >
         Anterior
       </button>
-      <span style={{ margin: '0 10px', fontSize: '0.9em', color: '#555' }}>
+      <span className="pagination-info">
         Página {currentPage + 1} de {totalPages}
         {typeof totalItems === 'number' && (
-          <span style={{ marginLeft: '0.5rem' }}>({totalItems} itens)</span>
+          <span className="total-items">({totalItems} itens)</span>
         )}
       </span>
       <button
         onClick={handleNext}
         disabled={currentPage === totalPages - 1 || isLoading}
-        style={{ padding: '0.5em 1em' }}
+        className="pagination-button"
       >
         Próxima
       </button>
       {typeof itemsPerPage === 'number' && onItemsPerPageChange && (
         <select
-          style={{ marginLeft: '0.5rem' }}
+          className="items-per-page-select"
           value={itemsPerPage}
           onChange={(e) => onItemsPerPageChange(e.target.value)}
         >

--- a/Frontend/app/src/components/fornecedores/FornecedorTable.css
+++ b/Frontend/app/src/components/fornecedores/FornecedorTable.css
@@ -1,0 +1,9 @@
+/* Frontend/app/src/components/fornecedores/FornecedorTable.css */
+
+.fornecedor-table {
+  width: 100%;
+}
+
+.clickable-row {
+  cursor: pointer;
+}

--- a/Frontend/app/src/components/fornecedores/FornecedorTable.jsx
+++ b/Frontend/app/src/components/fornecedores/FornecedorTable.jsx
@@ -1,12 +1,13 @@
 // Frontend/app/src/components/fornecedores/FornecedorTable.jsx
 import React from 'react';
+import './FornecedorTable.css';
 
 function FornecedorTable({ fornecedores, onRowClick, onSelectRow, selectedIds, onSelectAllRows, isLoading }) {
   if (isLoading && (!fornecedores || fornecedores.length === 0)) {
     return <p>Carregando tabela de fornecedores...</p>;
   }
   return (
-    <table style={{ width: '100%' }} id="forn-table">
+    <table className="fornecedor-table" id="forn-table">
       <thead>
         <tr>
           <th className="select">
@@ -25,7 +26,7 @@ function FornecedorTable({ fornecedores, onRowClick, onSelectRow, selectedIds, o
       </thead>
       <tbody>
         {fornecedores.length > 0 ? fornecedores.map(f => (
-          <tr key={f.id} onClick={() => onRowClick(f)} style={{ cursor: 'pointer' }}>
+          <tr key={f.id} onClick={() => onRowClick(f)} className="clickable-row">
             <td className="select" onClick={(e) => e.stopPropagation()}>
               <input 
                 type="checkbox" 

--- a/Frontend/app/src/pages/DashboardPage.css
+++ b/Frontend/app/src/pages/DashboardPage.css
@@ -1,0 +1,31 @@
+/* Frontend/app/src/pages/DashboardPage.css */
+
+.dashboard-loading {
+  padding: 20px;
+}
+
+.dashboard-welcome {
+  padding: 20px;
+  text-align: center;
+}
+
+.search-results-table th.left {
+  text-align: left;
+}
+
+.search-results-table th.right {
+  text-align: right;
+}
+
+.search-results-table td.bold-cell {
+  font-weight: 600;
+}
+
+.search-results-table td.text-right {
+  text-align: right;
+}
+
+.search-results-table td.no-results {
+  text-align: center;
+  padding: 20px;
+}

--- a/Frontend/app/src/pages/DashboardPage.jsx
+++ b/Frontend/app/src/pages/DashboardPage.jsx
@@ -1,6 +1,7 @@
 // Frontend/app/src/pages/DashboardPage.jsx
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import './DashboardPage.css';
 import authService from '../services/authService'; // Mantido para getCurrentUser
 import adminService from '../services/adminService'; // NOVO: Importar o adminService
 import { showErrorToast } from '../utils/notifications';
@@ -130,7 +131,7 @@ function DashboardPage() {
   const alertsData = mockDashboardData;
 
   if (loading) {
-    return <p style={{padding: "20px"}}>Carregando dashboard...</p>;
+    return <p className="dashboard-loading">Carregando dashboard...</p>;
   }
 
   return (
@@ -152,7 +153,7 @@ function DashboardPage() {
       )}
 
       {(!currentUser || !currentUser.is_superuser) && !loading && (
-        <div style={{ padding: '20px', textAlign: 'center' }}>
+        <div className="dashboard-welcome">
           <h2>Bem-vindo ao CatalogAI!</h2>
           <p>Seu dashboard personalizado será implementado aqui em breve.</p>
         </div>
@@ -208,10 +209,10 @@ function DashboardPage() {
             <table>
               <thead>
                   <tr>
-                    <th style={{ textAlign: 'left' }}>Tipo</th>
-                    <th style={{ textAlign: 'left' }}>Nome</th>
-                    <th style={{ textAlign: 'left' }}>Status</th>
-                    <th style={{ textAlign: 'right' }}>Ação</th>
+                    <th className="left">Tipo</th>
+                    <th className="left">Nome</th>
+                    <th className="left">Status</th>
+                    <th className="right">Ação</th>
                   </tr>
                 </thead>
                 <tbody>
@@ -219,9 +220,9 @@ function DashboardPage() {
                     searchResults.map(item => (
                       <tr key={item.id}>
                         <td>{item.type}</td>
-                        <td style={{ fontWeight: 600 }}>{item.name}</td>
+                        <td className="bold-cell">{item.name}</td>
                         <td>-</td>
-                        <td style={{ textAlign: 'right' }}>
+                        <td className="text-right">
                           <button
                             className="btn-detalhe"
                             onClick={() => navigate(`/produtos?id=${item.id}`)}
@@ -234,7 +235,7 @@ function DashboardPage() {
                   ) : (
                     searchTerm.trim() !== '' && (
                       <tr>
-                        <td colSpan="4" style={{ textAlign: 'center', padding: '20px' }}>
+                        <td colSpan="4" className="no-results">
                           Nenhum resultado encontrado.
                         </td>
                       </tr>

--- a/Frontend/app/src/pages/EnriquecimentoPage.css
+++ b/Frontend/app/src/pages/EnriquecimentoPage.css
@@ -1,0 +1,18 @@
+/* Frontend/app/src/pages/EnriquecimentoPage.css */
+
+.error-text {
+  color: red;
+  padding: 1rem;
+}
+
+.btn-info {
+  background-color: var(--info);
+  color: #fff;
+}
+
+.enrich-note {
+  font-size: 0.9rem;
+  color: #777;
+  text-align: right;
+  margin-top: 1rem;
+}

--- a/Frontend/app/src/pages/EnriquecimentoPage.jsx
+++ b/Frontend/app/src/pages/EnriquecimentoPage.jsx
@@ -1,5 +1,6 @@
 // Frontend/app/src/pages/EnriquecimentoPage.jsx
 import React, { useState, useEffect, useCallback } from 'react';
+import './EnriquecimentoPage.css';
 import productService from '../services/productService';
 import usoIAService from '../services/usoIAService';
 import ProductTable from '../components/produtos/ProductTable';
@@ -216,7 +217,7 @@ function EnriquecimentoPage() {
 
   return (
     <div>
-      <div className="search-container" style={{ marginTop: 0, marginBottom: '1.5rem' }}>
+      <div className="search-container">
         <label htmlFor="search-enr-prod">Buscar Produtos para Enriquecer:</label>
         <input
           type="text"
@@ -233,7 +234,7 @@ function EnriquecimentoPage() {
           <h3>Produtos para Enriquecimento Web</h3>
         </div>
 
-        {error && !loading && <p style={{ color: 'red', padding: '1rem' }}>Erro ao carregar produtos: {error}</p>}
+        {error && !loading && <p className="error-text">Erro ao carregar produtos: {error}</p>}
 
         <ProductTable
             produtos={produtos}
@@ -257,16 +258,16 @@ function EnriquecimentoPage() {
             />
         )}
 
-        <div className="table-actions" style={{ marginTop: '1.5rem' }}>
+        <div className="table-actions">
           <button
             onClick={handleEnrichSelected}
             disabled={loading || actionLoading || selectedProductIds.size === 0} // Usar .size
-            style={{backgroundColor: 'var(--info)'}}
+            className="btn-info"
           >
             {actionLoading ? 'Processando...' : `Enriquecer Web (${selectedProductIds.size}) Selecionado(s)`}
           </button>
         </div>
-        <div style={{fontSize: '.9rem', color: '#777', textAlign: 'right', marginTop: '1rem'}}>
+        <div className="enrich-note">
             * O status do enriquecimento será atualizado na tabela conforme o processo ocorre no backend. Clique numa linha para ver logs (se disponíveis).
         </div>
       </div>


### PR DESCRIPTION
## Summary
- move PaginationControls styles to dedicated CSS
- clean up FornecedorTable styles
- add page styles for Dashboard and Enriquecimento pages
- import new styles and remove inline style props

## Testing
- `npm test --silent` *(fails: jest not found)*
- `npm --prefix Frontend/app run lint` *(fails with lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68497fdd8380832f93c2b0b8668d79e9