### PR TITLE
Add theme context with persistence

### DIFF
--- a/Frontend/app/src/contexts/ThemeContext.jsx
+++ b/Frontend/app/src/contexts/ThemeContext.jsx
@@ -1,0 +1,38 @@
+// Frontend/app/src/contexts/ThemeContext.jsx
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+const ThemeContext = createContext(null);
+
+export const ThemeProvider = ({ children }) => {
+  const [theme, setTheme] = useState('light');
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme');
+    if (storedTheme === 'light' || storedTheme === 'dark') {
+      setTheme(storedTheme);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (context === undefined || context === null) {
+    throw new Error('useTheme deve ser usado dentro de um ThemeProvider');
+  }
+  return context;
+};

--- a/Frontend/app/src/main.jsx
+++ b/Frontend/app/src/main.jsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.jsx'; // App.jsx já contém o Router e os Providers
+import { ThemeProvider } from './contexts/ThemeContext.jsx';
 import './index.css';
 
 const rootElement = document.getElementById('root');
@@ -9,6 +10,8 @@ const root = ReactDOM.createRoot(rootElement);
 
 root.render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- implement `ThemeContext` to toggle light/dark and persist preference
- wrap app in `ThemeProvider`

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm test` *(fails: jest environment missing)*

------
https://chatgpt.com/codex/tasks/task_e_68498f61c9e8832fbe6ba76717bc2abe