### PR TITLE
Add frontend theme toggle

### DIFF
--- a/Frontend/app/src/App.jsx
+++ b/Frontend/app/src/App.jsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route, Navigate, useLocation } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 import { ProductTypeProvider } from './contexts/ProductTypeContext'; // Certifique-se que o caminho está correto
+import { ThemeProvider, useTheme } from './contexts/ThemeContext';
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
 
@@ -75,6 +76,28 @@ function AppContent() {
   );
 }
 
+function ProvidersWrapper() {
+  const { mode } = useTheme();
+
+  return (
+    <>
+      <AppContent />
+      <ToastContainer
+        position="top-right"
+        autoClose={5000}
+        hideProgressBar={false}
+        newestOnTop={false}
+        closeOnClick
+        rtl={false}
+        pauseOnFocusLoss
+        draggable
+        pauseOnHover
+        theme={mode === 'dark' ? 'dark' : 'colored'}
+      />
+    </>
+  );
+}
+
 function App() {
   useEffect(() => {
     logger.log("App.jsx está a ser renderizado com AuthProvider e ProductTypeProvider");
@@ -82,23 +105,13 @@ function App() {
 
   return (
     <Router>
-      <AuthProvider>
-        <ProductTypeProvider> {/* Envolve com ProductTypeProvider se ele também usa useAuth ou precisa estar no contexto */}
-          <AppContent />
-          <ToastContainer
-            position="top-right"
-            autoClose={5000}
-            hideProgressBar={false}
-            newestOnTop={false}
-            closeOnClick
-            rtl={false}
-            pauseOnFocusLoss
-            draggable
-            pauseOnHover
-            theme="colored"
-          />
-        </ProductTypeProvider>
-      </AuthProvider>
+      <ThemeProvider>
+        <AuthProvider>
+          <ProductTypeProvider>
+            <ProvidersWrapper />
+          </ProductTypeProvider>
+        </AuthProvider>
+      </ThemeProvider>
     </Router>
   );
 }

--- a/Frontend/app/src/components/Topbar.jsx
+++ b/Frontend/app/src/components/Topbar.jsx
@@ -2,7 +2,8 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
-import { LuMenu } from 'react-icons/lu';
+import { LuMenu, LuSun, LuMoon } from 'react-icons/lu';
+import { useTheme } from '../contexts/ThemeContext';
 import UserMenu from './UserMenu.jsx';
 // Se você criar um AuthContext, importe-o:
 // import { AuthContext } from '../contexts/AuthContext';
@@ -11,6 +12,7 @@ import UserMenu from './UserMenu.jsx';
 function Topbar({ viewTitle, toggleSidebar }) {
   const navigate = useNavigate();
   const { logout } = useAuth();
+  const { mode, toggleTheme } = useTheme();
 
   return (
     <header className="topbar">
@@ -18,6 +20,9 @@ function Topbar({ viewTitle, toggleSidebar }) {
         <LuMenu />
       </button>
       <h1>{viewTitle || "Dashboard"}</h1>
+      <button onClick={toggleTheme} className="theme-toggle-btn" aria-label="Alternar tema">
+        {mode === 'dark' ? <LuSun /> : <LuMoon />}
+      </button>
       <UserMenu onLogout={logout} onNavigate={path => navigate(path)} />
     </header>
   );

--- a/Frontend/app/src/contexts/ThemeContext.jsx
+++ b/Frontend/app/src/contexts/ThemeContext.jsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+const ThemeContext = createContext(null);
+
+export const ThemeProvider = ({ children }) => {
+  const [mode, setMode] = useState(() => localStorage.getItem('themeMode') || 'light');
+
+  useEffect(() => {
+    const root = document.documentElement;
+    if (mode === 'dark') {
+      root.classList.add('dark');
+    } else {
+      root.classList.remove('dark');
+    }
+    localStorage.setItem('themeMode', mode);
+  }, [mode]);
+
+  const toggleTheme = () => setMode(prev => (prev === 'dark' ? 'light' : 'dark'));
+
+  const value = { mode, toggleTheme };
+
+  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
+};
+
+export const useTheme = () => {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error('useTheme deve ser usado dentro de ThemeProvider');
+  }
+  return context;
+};

--- a/Frontend/app/src/index.css
+++ b/Frontend/app/src/index.css
@@ -33,6 +33,18 @@
   -moz-osx-font-smoothing: grayscale;
 }
 
+:root.dark {
+  color-scheme: dark;
+  --sidebar-bg: #1f2937;
+  --sidebar-text: #cbd5e1;
+  --main-bg: #0f172a;
+  --card-bg: #1e293b;
+  --primary: #f3f4f6;
+  --sidebar-active-bg: #334155;
+  --text-color-light: #94a3b8;
+  --border-color: #475569;
+}
+
 * { 
   box-sizing: border-box; 
   margin: 0; 
@@ -174,6 +186,17 @@ button[disabled], button:disabled {
   color: var(--primary);
 }
 .sidebar-toggle-btn:hover {
+  filter: brightness(90%);
+}
+.theme-toggle-btn {
+  background: none;
+  border: none;
+  font-size: 1.25rem;
+  margin-right: 1rem;
+  cursor: pointer;
+  color: var(--primary);
+}
+.theme-toggle-btn:hover {
   filter: brightness(90%);
 }
 .topbar h1 {

--- a/Frontend/app/src/utils/notifications.js
+++ b/Frontend/app/src/utils/notifications.js
@@ -1,7 +1,7 @@
 // Frontend/app/src/utils/notifications.js
 import { toast } from 'react-toastify';
 
-const defaultToastOptions = {
+const baseOptions = {
   position: "top-right",
   autoClose: 4000,
   hideProgressBar: false,
@@ -9,24 +9,28 @@ const defaultToastOptions = {
   pauseOnHover: true,
   draggable: true,
   progress: undefined,
-  theme: "light",
 };
 
+const getOptions = () => ({
+  ...baseOptions,
+  theme: document.documentElement.classList.contains('dark') ? 'dark' : 'light',
+});
+
 export const showSuccessToast = (message) => {
-  toast.success(message, defaultToastOptions);
+  toast.success(message, getOptions());
 };
 
 export const showErrorToast = (message) => {
   toast.error(message, {
-    ...defaultToastOptions,
-    autoClose: 7000, 
+    ...getOptions(),
+    autoClose: 7000,
   });
 };
 
 export const showInfoToast = (message) => {
-  toast.info(message, defaultToastOptions);
+  toast.info(message, getOptions());
 };
 
 export const showWarningToast = (message) => {
-  toast.warn(message, defaultToastOptions);
+  toast.warn(message, getOptions());
 };


### PR DESCRIPTION
## Summary
- create `ThemeContext` for dark mode handling
- add theme toggle button in Topbar
- wrap application with `ThemeProvider` and adapt ToastContainer theme
- adjust toast helpers to respect active theme
- provide dark-theme variables and styling for toggle button

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498f62e9ec832fbf289be0cc57523c