### PR TITLE
Fix duplicate field in ImportPreviewResponse

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -325,7 +325,6 @@ class ImportPreviewResponse(BaseModel):
     file_id: int
     headers: List[str]
     sample_rows: List[Dict[str, Any]]
-    preview_images: List[str] | None = None
     preview_images: Optional[List[str]] = None
     message: Optional[str] = None
     error: Optional[str] = None


### PR DESCRIPTION
## Summary
- clean up `ImportPreviewResponse` schema definition
- ensure a single optional `preview_images` field remains

## Testing
- `scripts/run_tests.sh` *(fails: ModuleNotFoundError: No module named 'pdf2image')*

------
https://chatgpt.com/codex/tasks/task_e_68499140ba30832f8d6329bc4b4a1999