### PR TITLE
Add theme toggle tests

### DIFF
--- a/Frontend/app/src/components/common/__tests__/ThemeToggle.test.jsx
+++ b/Frontend/app/src/components/common/__tests__/ThemeToggle.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+global.TextEncoder = TextEncoder;
+global.TextDecoder = TextDecoder;
+import userEvent from '@testing-library/user-event';
+import Topbar from '../../Topbar.jsx';
+import { ThemeProvider } from '../../../contexts/ThemeContext.jsx';
+
+jest.mock('../../../contexts/AuthContext.jsx', () => ({
+  useAuth: () => ({ logout: jest.fn() })
+}));
+
+jest.mock('react-router-dom', () => ({
+  useNavigate: () => jest.fn()
+}));
+
+const renderWithTheme = () =>
+  render(
+    <ThemeProvider>
+      <Topbar toggleSidebar={() => {}} />
+    </ThemeProvider>
+  );
+
+test('applies theme from localStorage on mount', () => {
+  localStorage.setItem('theme', 'dark');
+  renderWithTheme();
+  expect(document.body).toHaveClass('dark');
+});
+
+test('toggle button toggles dark class on body', async () => {
+  localStorage.setItem('theme', 'light');
+  const user = userEvent.setup();
+  renderWithTheme();
+  const button = screen.getByRole('button', { name: /alternar tema/i });
+  await user.click(button);
+  expect(document.body).toHaveClass('dark');
+  await user.click(button);
+  expect(document.body).not.toHaveClass('dark');
+});

--- a/Frontend/app/src/contexts/ThemeContext.jsx
+++ b/Frontend/app/src/contexts/ThemeContext.jsx
@@ -1,49 +1,23 @@
 
-import React, { createContext, useContext, useState, useEffect } from 'react';
-// Frontend/app/src/contexts/ThemeContext.jsx
 import React, { createContext, useContext, useEffect, useState } from 'react';
 
 const ThemeContext = createContext(null);
 
 export const ThemeProvider = ({ children }) => {
-
-  const [mode, setMode] = useState(() => localStorage.getItem('themeMode') || 'light');
+  const [mode, setMode] = useState(() => {
+    const stored = localStorage.getItem('theme');
+    return stored === 'dark' ? 'dark' : 'light';
+  });
 
   useEffect(() => {
-    const root = document.documentElement;
-    if (mode === 'dark') {
-      root.classList.add('dark');
-    } else {
-      root.classList.remove('dark');
-    }
-    localStorage.setItem('themeMode', mode);
+    document.body.classList.toggle('dark', mode === 'dark');
+    localStorage.setItem('theme', mode);
   }, [mode]);
 
   const toggleTheme = () => setMode(prev => (prev === 'dark' ? 'light' : 'dark'));
 
-  const value = { mode, toggleTheme };
-
-  return <ThemeContext.Provider value={value}>{children}</ThemeContext.Provider>;
-  const [theme, setTheme] = useState('light');
-
-  useEffect(() => {
-    const storedTheme = localStorage.getItem('theme');
-    if (storedTheme === 'light' || storedTheme === 'dark') {
-      setTheme(storedTheme);
-    }
-  }, []);
-
-  useEffect(() => {
-    document.body.classList.toggle('dark', theme === 'dark');
-    localStorage.setItem('theme', theme);
-  }, [theme]);
-
-  const toggleTheme = () => {
-    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
-  };
-
   return (
-    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+    <ThemeContext.Provider value={{ mode, toggleTheme }}>
       {children}
     </ThemeContext.Provider>
   );
@@ -51,8 +25,6 @@ export const ThemeProvider = ({ children }) => {
 
 export const useTheme = () => {
   const context = useContext(ThemeContext);
-  if (!context) {
-    throw new Error('useTheme deve ser usado dentro de ThemeProvider');
   if (context === undefined || context === null) {
     throw new Error('useTheme deve ser usado dentro de um ThemeProvider');
   }


### PR DESCRIPTION
## Summary
- fix broken ThemeContext implementation
- add ThemeToggle test verifying dark mode class is applied and toggled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684990f791f4832f9aac71fead4bb376