### PR TITLE
Fix preview endpoint file_id

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -355,10 +355,6 @@ async def importar_catalogo_preview(
 
     try:
         preview = await file_processing_service.gerar_preview(content, ext)
-        if ext == ".pdf":
-            preview_images = file_processing_service.pdf_pages_to_images(content)
-            preview["preview_images"] = preview_images
-        return preview
     except ValueError:
         raise HTTPException(status_code=400, detail="Formato de arquivo não suportado")
 


### PR DESCRIPTION
## Summary
- ensure preview endpoint always assigns `file_id` before returning

## Testing
- `scripts/run_tests.sh` *(fails: OperationalError no such table: users)*

------
https://chatgpt.com/codex/tasks/task_e_6849913f7264832fb051ca3dc765a199