### PR TITLE
Update catalog import finalization

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -446,6 +446,7 @@ async def importar_catalogo_fornecedor(
 @router.post("/importar-catalogo-finalizar/{file_id}/")
 async def importar_catalogo_finalizar(
     file_id: int,
+    product_type_id: int = Body(..., embed=True),
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user),
 ):
@@ -464,11 +465,11 @@ async def importar_catalogo_finalizar(
     ext = file_path.suffix.lower()
 
     if ext in [".xlsx", ".xls"]:
-        produtos = await file_processing_service.processar_arquivo_excel(content)
+        produtos = await file_processing_service.processar_arquivo_excel(content, product_type_id=product_type_id)
     elif ext == ".csv":
-        produtos = await file_processing_service.processar_arquivo_csv(content)
+        produtos = await file_processing_service.processar_arquivo_csv(content, product_type_id=product_type_id)
     elif ext == ".pdf":
-        produtos = await file_processing_service.processar_arquivo_pdf(content)
+        produtos = await file_processing_service.processar_arquivo_pdf(content, product_type_id=product_type_id)
     else:
         raise HTTPException(status_code=400, detail="Formato de arquivo não suportado")
 

--- a/README.md
+++ b/README.md
@@ -444,6 +444,11 @@ relatório de erros junto com os produtos criados. O formato da resposta é:
 Cada item em `erros` descreve a linha descartada e o motivo para facilitar a
 correção do arquivo de origem.
 
+Ao finalizar a importação de um arquivo previamente enviado com
+`/produtos/importar-catalogo-finalizar/{file_id}/`, é necessário informar
+o `product_type_id` no corpo da requisição. Esse identificador será anexado a
+todos os produtos extraídos do arquivo.
+
 ---
 
 ## 🧪 Testes

--- a/tests/test_catalog_import_file.py
+++ b/tests/test_catalog_import_file.py
@@ -67,7 +67,14 @@ def test_finalize_updates_status():
     assert resp.status_code == 200
     file_id = resp.json()["file_id"]
 
-    resp = client.post(f"/api/v1/produtos/importar-catalogo-finalizar/{file_id}/", headers=headers)
+    with TestingSessionLocal() as db:
+        pt_id = db.query(models.ProductType.id).first()[0]
+
+    resp = client.post(
+        f"/api/v1/produtos/importar-catalogo-finalizar/{file_id}/",
+        headers=headers,
+        json={"product_type_id": pt_id},
+    )
     assert resp.status_code == 200
     data = resp.json()
     assert "produtos" in data


### PR DESCRIPTION
## Summary
- attach `product_type_id` when finalizing catalog import
- support `product_type_id` in file processing service
- test catalog import with required product type
- document new parameter for `/importar-catalogo-finalizar/{file_id}/`

## Testing
- `./scripts/run_tests.sh` *(fails: 21 failed, 17 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684998aa2080832fa524b7ec81e66857