### PR TITLE
Fix frontend JS syntax errors

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -300,12 +300,6 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   );
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title="Importar Catálogo">
-      {step === 1 && renderStep1()}
-      {step === 2 && renderStep2()}
-      {step === 3 && renderStep3()}
-      {step === 4 && renderStep4()}
-    </Modal>
     <>
       <Modal isOpen={isOpen} onClose={onClose} title="Importar Catálogo">
         {step === 1 && renderStep1()}

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -129,11 +129,10 @@ export const importCatalogo = async (fornecedorId, file, mapping = null) => {
 
 export const finalizarImportacaoCatalogo = async (
   fileId,
-  productTypeId,
   mapping = null,
   rows = null,
+  productTypeId = null,
 ) => {
-export const finalizarImportacaoCatalogo = async (fileId, mapping = null, rows = null, productTypeId = null) => {
   try {
     const payload = {
       file_id: fileId,


### PR DESCRIPTION
## Summary
- clean up duplicated function definition in `fornecedorService.js`
- remove duplicate modal markup in `ImportCatalogWizard.jsx`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find eslint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849a3c80ce8832f90093bceee53b1d8