### PR TITLE
Fix catalog import wizard type selection

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -94,6 +94,9 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     const id = parseInt(e.target.value, 10);
     const type = productTypes.find((pt) => pt.id === id);
     setSelectedType(type || null);
+    if (!Number.isNaN(id)) {
+      setProductTypeId(id);
+    }
   };
 
   const handleSaveNewType = async () => {
@@ -129,9 +132,6 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     try {
       await fornecedorService.finalizarImportacaoCatalogo(
         fileId,
-        productTypeId,
-        mapping,
-        sampleRows,
         mapping,
         sampleRows,
         selectedType.id

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -44,9 +44,9 @@ test('shows preview rows and sends productTypeId on confirm', async () => {
   await userEvent.click(screen.getByText('Confirmar Importação'));
   expect(fornecedorService.finalizarImportacaoCatalogo).toHaveBeenCalledWith(
     'f1',
-    '1',
     expect.any(Object),
     expect.any(Array),
+    1,
   );
   expect(await screen.findByText('Item')).toBeInTheDocument();
   await userEvent.selectOptions(screen.getByLabelText(/Tipo de Produto/i), '1');


### PR DESCRIPTION
## Summary
- update selected type state to propagate product type ID
- fix parameter order for import completion request
- adjust ImportCatalogWizard tests

## Testing
- `./scripts/run_tests.sh` *(fails: 18 errors during collection)*
- `npm test --silent` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a980d174832fb378a9a20b046c59