### PR TITLE
Unify async pdf page image function

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -5,7 +5,6 @@ import csv
 import io  # Para ler o conteúdo do arquivo em memória
 import chardet
 import base64
-from pdf2image import convert_from_bytes
 from typing import List, Dict, Any, Union, Optional
 from pathlib import Path
 from uuid import uuid4
@@ -376,21 +375,6 @@ async def preview_arquivo_pdf(conteudo_arquivo: bytes, max_rows: int = 5) -> Dic
         return {"error": f"Falha ao ler arquivo PDF: {str(e)}"}
 
 
-def pdf_pages_to_images(conteudo_arquivo: bytes, max_pages: int = 1) -> List[str]:
-    """Converte páginas de um PDF em imagens base64."""
-    try:
-        pages = convert_from_bytes(conteudo_arquivo, fmt="png")
-        images_b64: List[str] = []
-        for i, page in enumerate(pages):
-            if i >= max_pages:
-                break
-            buf = io.BytesIO()
-            page.save(buf, format="PNG")
-            images_b64.append(base64.b64encode(buf.getvalue()).decode("utf-8"))
-        return images_b64
-    except Exception as e:
-        logger.error("Erro ao converter PDF em imagens: %s", e)
-        return []
 
 
 async def gerar_preview(conteudo_arquivo: bytes, ext: str, max_rows: int = 5) -> Dict[str, Any]:

--- a/tests/test_pdf_pages_to_images.py
+++ b/tests/test_pdf_pages_to_images.py
@@ -11,6 +11,7 @@ except ImportError:  # pragma: no cover - install at runtime
     from reportlab.pdfgen import canvas
 
 from Backend.services.file_processing_service import pdf_pages_to_images
+import pytest
 
 
 def _create_pdf():
@@ -23,9 +24,10 @@ def _create_pdf():
     return buf.getvalue()
 
 
-def test_pdf_pages_to_images_basic():
+@pytest.mark.asyncio
+async def test_pdf_pages_to_images_basic():
     pdf_bytes = _create_pdf()
-    images = pdf_pages_to_images(pdf_bytes)
+    images = await pdf_pages_to_images(pdf_bytes)
     assert len(images) >= 1
     decoded = base64.b64decode(images[0])
     assert decoded.startswith(b"\x89PNG")


### PR DESCRIPTION
## Summary
- drop old synchronous `pdf_pages_to_images`
- ensure only async version remains and adjust import
- update tests to await the function

## Testing
- `pytest tests/test_pdf_pages_to_images.py tests/test_file_processing_service.py -q`
- `pytest -q` *(fails: ValidationError during collection)*

------
https://chatgpt.com/codex/tasks/task_e_684a845b3844832facc74bf7a330bf6c