### PR TITLE
Fix engine setup in import catalog test

### DIFF
--- a/tests/test_import_catalogo.py
+++ b/tests/test_import_catalogo.py
@@ -1,7 +1,6 @@
 import io
 from fastapi.testclient import TestClient
 from sqlalchemy import create_engine
-from sqlalchemy.pool import StaticPool
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -14,7 +13,6 @@ from Backend.core.config import settings
 app.router.on_startup.clear()
 
 engine = create_engine(
-    "sqlite:///:memory:", connect_args={"check_same_thread": False}, poolclass=StaticPool
     "sqlite:///:memory:",
     connect_args={"check_same_thread": False},
     poolclass=StaticPool,


### PR DESCRIPTION
## Summary
- deduplicate `StaticPool` import
- fix `create_engine` call in `test_import_catalogo.py`

## Testing
- `pytest tests/test_import_catalogo.py -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_e_684a89dce910832fb4101f295252dc41