### PR TITLE
Add fornecedor_id handling to catalog import

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -18,8 +18,18 @@ from Backend.services import web_data_extractor_service
 logger = get_logger(__name__)
 
 
-async def save_uploaded_catalog(file: UploadFile) -> models.CatalogImportFile:
-    """Salva o arquivo de catálogo no disco e retorna um objeto CatalogImportFile."""
+async def save_uploaded_catalog(
+    file: UploadFile, fornecedor_id: Optional[int] = None
+) -> models.CatalogImportFile:
+    """Salva o arquivo de catálogo no disco e retorna um objeto CatalogImportFile.
+
+    Parameters
+    ----------
+    file: UploadFile
+        Arquivo recebido na requisição.
+    fornecedor_id: Optional[int]
+        Identificador do fornecedor para o qual o catálogo será importado.
+    """
     directory = Path(settings.UPLOAD_DIRECTORY) / "catalogs"
     if not directory.is_absolute():
         directory = Path(__file__).resolve().parent.parent / directory
@@ -38,6 +48,7 @@ async def save_uploaded_catalog(file: UploadFile) -> models.CatalogImportFile:
         original_filename=file.filename,
         stored_filename=unique_name,
         status="UPLOADED",
+        fornecedor_id=fornecedor_id,
     )
 
 def _limpar_valor_extraido(valor: Any) -> Optional[str]:


### PR DESCRIPTION
## Summary
- extend `save_uploaded_catalog` to accept `fornecedor_id`
- save fornecedor_id during catalog preview
- reprocess file on finalize and persist fornecedor_id
- test supplier assignment and processing of full files

## Testing
- `pytest -q tests/test_catalog_import_file.py`

------
https://chatgpt.com/codex/tasks/task_e_684a93960280832f8c8a00a6e74e07bf