### PR TITLE
Deduplicate requirements

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install backend requirements
+        run: pip install -r requirements-backend.txt
       - name: Build test image
         run: docker build -f Dockerfile.test -t catalogai-test .
       - name: Run tests

--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -23,4 +23,3 @@ python-multipart==0.0.9
 SQLAlchemy==2.0.29
 trafilatura==1.6.2
 uvicorn[standard]==0.27.1
-pdf2image==1.17.0

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -24,7 +24,5 @@ google-api-python-client==2.119.0
 lxml==4.9.3
 psycopg2-binary
 jinja2
-pytest
-pytest-asyncio
 pytest==8.2.1
 pytest-asyncio==0.23.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,3 @@ starlette
 trafilatura
 uvicorn
 httpx
-httpx


### PR DESCRIPTION
## Summary
- remove duplicate pdf2image entry in backend requirements
- drop repeated pytest packages in backend requirements list
- clean duplicate httpx line in root requirements
- run pip install in CI before building the Docker image

## Testing
- `pip install -r requirements-backend.txt`
- `pytest -q` *(fails: test_preview_saves_file_and_record, test_finalize_updates_status, test_pdf_pages_to_images_returns_base64, test_historico_created_on_product_crud, test_list_historico_endpoint, test_get_tipos_acao_endpoint, test_historico_criado_para_produtos_importados, test_pdf_pages_to_images_basic, test_admin_can_view_usos_ia_of_other_user_product)*

------
https://chatgpt.com/codex/tasks/task_e_684a93987e88832fa8ed23aa2f5acd7e