### PR TITLE
Fix catalog import fornecedor_id preview

### DIFF
--- a/tests/test_catalog_import_file.py
+++ b/tests/test_catalog_import_file.py
@@ -73,6 +73,7 @@ def test_preview_saves_file_and_record():
         record = db.query(models.CatalogImportFile).get(file_id)
         assert record is not None
         assert record.status == "UPLOADED"
+        assert record.fornecedor_id == fornec_id
         path = (
             Path(__file__).resolve().parents[1]
             / "Backend"


### PR DESCRIPTION
## Summary
- ensure `fornecedor_id` saved during preview is asserted in tests

## Testing
- `pytest tests/test_catalog_import_file.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684aa25ca2f8832f83b9a552cc312210