### PR TITLE
Update finalize catalog import to use fornecedorId

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -132,6 +132,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     try {
       await fornecedorService.finalizarImportacaoCatalogo(
         fileId,
+        fornecedorId,
         mapping,
         sampleRows,
         selectedType.id

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -44,16 +44,12 @@ test('shows preview rows and sends productTypeId on confirm', async () => {
   await userEvent.click(screen.getByText('Confirmar Importação'));
   expect(fornecedorService.finalizarImportacaoCatalogo).toHaveBeenCalledWith(
     'f1',
+    1,
     expect.any(Object),
     expect.any(Array),
     1,
   );
-  expect(await screen.findByText('Item')).toBeInTheDocument();
-  await userEvent.selectOptions(screen.getByLabelText(/Tipo de Produto/i), '1');
-  await userEvent.click(screen.getByText('Continuar'));
-  await userEvent.type(screen.getAllByRole('textbox')[0], 'X');
-  await userEvent.click(screen.getByText('Confirmar Importação'));
-  expect(fornecedorService.finalizarImportacaoCatalogo).toHaveBeenCalledWith('f1', expect.any(Object), expect.any(Array), 1);
+  expect(await screen.findByText('Importação concluída com sucesso')).toBeInTheDocument();
 });
 
 test('calls onClose after finishing import', async () => {
@@ -66,9 +62,6 @@ test('calls onClose after finishing import', async () => {
   await userEvent.selectOptions(screen.getByRole('combobox'), '1');
   await userEvent.click(screen.getByText('Continuar'));
   await userEvent.click(await screen.findByText('Confirmar Importação'));
-  await userEvent.selectOptions(await screen.findByLabelText(/Tipo de Produto/i), '1');
-  await userEvent.click(screen.getByText('Continuar'));
-  await userEvent.click(screen.getByText('Confirmar Importação'));
   await userEvent.click(screen.getByText('Fechar'));
   expect(onClose).toHaveBeenCalled();
 });

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -129,12 +129,13 @@ export const importCatalogo = async (fornecedorId, file, mapping = null) => {
 
 export const finalizarImportacaoCatalogo = async (
   fileId,
+  fornecedorId,
   mapping = null,
   rows = null,
   productTypeId = null,
 ) => {
   try {
-    const payload = { file_id: fileId };
+    const payload = { file_id: fileId, fornecedor_id: fornecedorId };
     if (productTypeId) payload.product_type_id = productTypeId;
     if (mapping) {
       payload.mapping = mapping;


### PR DESCRIPTION
## Summary
- support passing `fornecedorId` to `finalizarImportacaoCatalogo`
- forward `fornecedorId` from `ImportCatalogWizard`
- adjust wizard tests for the new function signature

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684aa66132f4832f903bbd1a8f05e03b