### PR TITLE
Add chardet requirement

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -1,5 +1,6 @@
 alembic==1.13.1
 authlib==1.2.1
+chardet==5.2.0
 beautifulsoup4==4.12.2
 extruct==0.16.0
 fastapi-mail==1.4.1


### PR DESCRIPTION
## Summary
- add `chardet==5.2.0` to `Backend/requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for jose, pandas, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684aa66e6370832fb4efe9d625602c4f