### PR TITLE
Add pdf2image dependency to requirements

### DIFF
--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -15,6 +15,7 @@ httpx==0.27.0
 pandas==2.2.2
 openpyxl==3.1.2
 pdfplumber==0.10.2
+pdf2image==1.17.0
 python-magic==0.4.27
 playwright==1.43.0
 beautifulsoup4==4.12.2

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -15,6 +15,7 @@ httpx==0.27.0
 pandas==2.2.2
 openpyxl==3.1.2
 pdfplumber==0.10.2
+pdf2image==1.17.0
 python-magic==0.4.27
 playwright==1.43.0
 beautifulsoup4==4.12.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ chardet
 pandas
 passlib
 pdfplumber
+pdf2image==1.17.0
 playwright
 pydantic
 pydantic-settings


### PR DESCRIPTION
## Summary
- include `pdf2image==1.17.0` in backend requirements
- mirror dependency in full and base requirement files
- verify Docker and CI install backend requirements
- run tests for `pdf_pages_to_images`

## Testing
- `./scripts/run_tests.sh tests/test_file_processing_service.py tests/test_pdf_pages_to_images.py` *(fails: poppler not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684aa67002a4832f80d76630c9c935a4