### PR TITLE
Update catalog finalize docs and confirm supplier ID usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,8 +446,8 @@ correção do arquivo de origem.
 
 Ao finalizar a importação de um arquivo previamente enviado com
 `/produtos/importar-catalogo-finalizar/{file_id}/`, é necessário informar
-o `product_type_id` no corpo da requisição. Esse identificador será anexado a
-todos os produtos extraídos do arquivo.
+tanto o `product_type_id` quanto o `fornecedor_id` no corpo da requisição.
+Esses identificadores serão anexados a todos os produtos extraídos do arquivo.
 
 ---
 


### PR DESCRIPTION
## Summary
- document that `/produtos/importar-catalogo-finalizar/{file_id}/` requires both `product_type_id` and `fornecedor_id`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ab7aad5d8832f8391f6a373492b37