### PR TITLE
Add full-screen loading overlay

### DIFF
--- a/Frontend/app/src/App.jsx
+++ b/Frontend/app/src/App.jsx
@@ -20,7 +20,7 @@ import RecuperarSenhaPage from './pages/RecuperarSenhaPage';
 import ResetSenhaPage from './pages/ResetSenhaPage';
 import ProtectedRoute from './components/ProtectedRoute';
 // Importe outras páginas e componentes necessários
-import LoadingPopup from './components/common/LoadingPopup.jsx';
+import LoadingOverlay from './components/common/LoadingOverlay.jsx';
 
 import './App.css';
 import logger from './utils/logger';
@@ -37,7 +37,7 @@ function AppContent() {
   // ou deixar o ProtectedRoute lidar com isso individualmente.
   // Para evitar piscar a tela de login, é bom ter um estado de carregamento aqui.
   if (isLoading) {
-    return <LoadingPopup isOpen={true} message="Carregando Aplicação..." />;
+    return <LoadingOverlay isOpen={true} message="Carregando Aplicação..." />;
   }
 
   return (

--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '../contexts/AuthContext';
 import Modal from './common/Modal';
-import LoadingPopup from './common/LoadingPopup.jsx';
+import LoadingOverlay from './common/LoadingOverlay.jsx';
 import { showSuccessToast, showErrorToast, showInfoToast, showWarningToast } from '../utils/notifications'; 
 import productService from '../services/productService'; 
 import fornecedorService from '../services/fornecedorService'; 
@@ -717,7 +717,7 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
             onClose={handleCloseNewTypeModal}
             onCreated={handleNewTypeCreated}
         />
-        <LoadingPopup
+        <LoadingOverlay
             isOpen={isLoading || isEnrichingWeb || isGeneratingIA || isSuggestingGemini}
             message="Processando..."
         />

--- a/Frontend/app/src/components/ProtectedRoute.jsx
+++ b/Frontend/app/src/components/ProtectedRoute.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useAuth } from '../contexts/AuthContext';
 import logger from '../utils/logger';
-import LoadingPopup from './common/LoadingPopup.jsx';
+import LoadingOverlay from './common/LoadingOverlay.jsx';
 
 const ProtectedRoute = ({ children, allowedRoles }) => {
     const { isAuthenticated, user, isLoading } = useAuth();
@@ -13,7 +13,7 @@ const ProtectedRoute = ({ children, allowedRoles }) => {
         // pode-se exibir um loader global ou simplesmente não renderizar nada ainda.
         // Retornar null ou um spinner evita renderização prematura da página de login
         // ou do conteúdo protegido.
-        return <LoadingPopup isOpen={true} message="Carregando autenticação..." />;
+        return <LoadingOverlay isOpen={true} message="Carregando autenticação..." />;
     }
 
     if (!isAuthenticated) {

--- a/Frontend/app/src/components/common/LoadingOverlay.css
+++ b/Frontend/app/src/components/common/LoadingOverlay.css
@@ -1,0 +1,23 @@
+.loading-overlay-content {
+  text-align: center;
+}
+
+.loading-logo {
+  width: 100px;
+  margin-bottom: 20px;
+}
+
+.loading-spinner {
+  width: 50px;
+  height: 50px;
+  border: 6px solid #ddd;
+  border-top-color: #333;
+  border-radius: 50%;
+  animation: loading-spin 1s linear infinite;
+  margin: 0 auto 10px auto;
+}
+
+@keyframes loading-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/Frontend/app/src/components/common/LoadingOverlay.jsx
+++ b/Frontend/app/src/components/common/LoadingOverlay.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import './LoadingOverlay.css';
+import LogoImg from '../../assets/Logo.png';
+
+function LoadingOverlay({ isOpen, message = 'Carregando...' }) {
+  if (!isOpen) return null;
+
+  return (
+    <div className="modal-overlay loading-overlay">
+      <div className="loading-overlay-content">
+        <img src={LogoImg} alt="CatalogAI logo" className="loading-logo" />
+        <div className="loading-spinner" />
+        <p>{message}</p>
+      </div>
+    </div>
+  );
+}
+
+export default LoadingOverlay;

--- a/Frontend/app/src/components/common/__tests__/LoadingOverlay.test.jsx
+++ b/Frontend/app/src/components/common/__tests__/LoadingOverlay.test.jsx
@@ -1,0 +1,8 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import LoadingOverlay from '../LoadingOverlay.jsx';
+
+test('renders overlay when open', () => {
+  render(<LoadingOverlay isOpen={true} message="Loading test" />);
+  expect(screen.getByText('Loading test')).toBeInTheDocument();
+});

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import Modal from '../common/Modal.jsx';
 import fornecedorService from '../../services/fornecedorService';
 import { useProductTypes } from '../../contexts/ProductTypeContext';
-import LoadingPopup from '../common/LoadingPopup.jsx';
+import LoadingOverlay from '../common/LoadingOverlay.jsx';
 
 const BASE_FIELD_OPTIONS = [
   { value: 'nome_base', label: 'Nome Base' },
@@ -308,7 +308,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
           <button className="btn-success" onClick={handleSaveNewType} disabled={isSubmittingType}>{isSubmittingType ? 'Salvando...' : 'Salvar Tipo'}</button>
         </div>
       </Modal>
-      <LoadingPopup isOpen={loading || isSubmittingType} message="Processando..." />
+      <LoadingOverlay isOpen={loading || isSubmittingType} message="Processando..." />
     </>
   );
 }

--- a/Frontend/app/src/pages/DashboardPage.jsx
+++ b/Frontend/app/src/pages/DashboardPage.jsx
@@ -7,7 +7,7 @@ import adminService from '../services/adminService'; // NOVO: Importar o adminSe
 import { showErrorToast } from '../utils/notifications';
 import searchService from '../services/searchService';
 import DOMPurify from 'dompurify';
-import LoadingPopup from '../components/common/LoadingPopup.jsx';
+import LoadingOverlay from '../components/common/LoadingOverlay.jsx';
 
 // Alerts exibidos enquanto funcionalidades não estão completas
 const mockDashboardData = {
@@ -132,7 +132,7 @@ function DashboardPage() {
   const alertsData = mockDashboardData;
 
   if (loading) {
-    return <LoadingPopup isOpen={true} message="Carregando dashboard..." />;
+    return <LoadingOverlay isOpen={true} message="Carregando dashboard..." />;
   }
 
   return (

--- a/Frontend/app/src/pages/TiposProdutoPage.jsx
+++ b/Frontend/app/src/pages/TiposProdutoPage.jsx
@@ -10,7 +10,7 @@ import AttributeTemplateList from '../components/product_types/AttributeTemplate
 import AttributeTemplateModal from '../components/product_types/AttributeTemplateModal';
 
 import './TiposProdutoPage.css';
-import LoadingPopup from '../components/common/LoadingPopup.jsx';
+import LoadingOverlay from '../components/common/LoadingOverlay.jsx';
 
 function TiposProdutoPage() {
   const { productTypes, isLoading, error, refreshProductTypes, updateProductType } = useProductTypes();
@@ -149,7 +149,7 @@ function TiposProdutoPage() {
   };
 
   if (isLoading && productTypes.length === 0) {
-    return <LoadingPopup isOpen={true} message="Carregando tipos de produto..." />;
+    return <LoadingOverlay isOpen={true} message="Carregando tipos de produto..." />;
   }
 
   if (error) {


### PR DESCRIPTION
## Summary
- implement `LoadingOverlay` to provide a full-screen loading indicator with the app logo
- use the new overlay in App startup, ProtectedRoute, Dashboard, product type page, product editor and import wizard
- add unit test for the overlay component

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ab8acfadc832fba3d02480e7b3037