### PR TITLE
Support multi-page PDF preview

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -442,6 +442,7 @@ async def upload_produto_image(  # Nome da função mantido como no arquivo do u
 async def importar_catalogo_preview(
     file: UploadFile = File(...),
     fornecedor_id: Optional[int] = Form(None),
+    page_count: int = Query(1, ge=1, description="Número de páginas de preview do PDF"),
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user),
 ):
@@ -464,7 +465,9 @@ async def importar_catalogo_preview(
         raise HTTPException(status_code=400, detail="Formato de arquivo não suportado")
 
     if ext == ".pdf":
-        preview_images = await file_processing_service.pdf_pages_to_images(content)
+        preview_images = await file_processing_service.pdf_pages_to_images(
+            content, max_pages=page_count
+        )
         preview["preview_images"] = preview_images
 
     preview["file_id"] = saved.id

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -326,6 +326,8 @@ class ImportPreviewResponse(BaseModel):
     headers: List[str]
     sample_rows: List[Dict[str, Any]]
     preview_images: Optional[List[str]] = None
+    num_pages: Optional[int] = None
+    table_pages: Optional[List[int]] = None
     message: Optional[str] = None
     error: Optional[str] = None
 

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -366,21 +366,43 @@ async def preview_arquivo_pdf(conteudo_arquivo: bytes, max_rows: int = 5) -> Dic
     """Tenta extrair cabeçalhos e linhas de amostra de tabelas em um PDF."""
     try:
         with pdfplumber.open(io.BytesIO(conteudo_arquivo)) as pdf:
-            for page in pdf.pages:
-                tables = page.extract_tables(table_settings={"vertical_strategy": "lines", "horizontal_strategy": "lines"})
+            num_pages = len(pdf.pages)
+            table_pages: List[int] = []
+            headers: List[str] = []
+            sample_rows: List[Dict[str, Any]] = []
+            for idx, page in enumerate(pdf.pages):
+                tables = page.extract_tables(
+                    table_settings={"vertical_strategy": "lines", "horizontal_strategy": "lines"}
+                )
                 if tables:
-                    primeira_tabela = tables[0]
-                    if len(primeira_tabela) < 2:
-                        continue
-                    headers_raw = primeira_tabela[0]
-                    headers = [str(h).strip() if h is not None else f"coluna_vazia_{idx}" for idx, h in enumerate(headers_raw)]
-                    sample_rows = []
-                    for row in primeira_tabela[1: max_rows + 1]:
-                        if len(row) != len(headers):
+                    table_pages.append(idx + 1)
+                    if not headers:
+                        primeira_tabela = tables[0]
+                        if len(primeira_tabela) < 2:
                             continue
-                        sample_rows.append({headers[i]: row[i] for i in range(len(headers))})
-                    return {"headers": headers, "sample_rows": sample_rows}
-        return {"headers": [], "sample_rows": [], "message": "Nenhuma tabela encontrada no PDF"}
+                        headers_raw = primeira_tabela[0]
+                        headers = [
+                            str(h).strip() if h is not None else f"coluna_vazia_{h_idx}"
+                            for h_idx, h in enumerate(headers_raw)
+                        ]
+                        for row in primeira_tabela[1 : max_rows + 1]:
+                            if len(row) != len(headers):
+                                continue
+                            sample_rows.append({headers[i]: row[i] for i in range(len(headers))})
+            if headers:
+                return {
+                    "headers": headers,
+                    "sample_rows": sample_rows,
+                    "num_pages": num_pages,
+                    "table_pages": table_pages,
+                }
+            return {
+                "headers": [],
+                "sample_rows": [],
+                "num_pages": num_pages,
+                "table_pages": table_pages,
+                "message": "Nenhuma tabela encontrada no PDF",
+            }
     except Exception as e:
         logger.error("Erro ao gerar preview de arquivo PDF: %s", e)
         return {"error": f"Falha ao ler arquivo PDF: {str(e)}"}

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -15,6 +15,8 @@ const BASE_FIELD_OPTIONS = [
   { value: 'imagem_url_original', label: 'URL Imagem' },
 ];
 
+const PREVIEW_PAGE_COUNT = 3;
+
 function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   const [step, setStep] = useState(1);
   const [file, setFile] = useState(null);
@@ -29,6 +31,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   const [isNewTypeModalOpen, setIsNewTypeModalOpen] = useState(false);
   const [newTypeName, setNewTypeName] = useState('');
   const [isSubmittingType, setIsSubmittingType] = useState(false);
+  const [currentPreviewPage, setCurrentPreviewPage] = useState(0);
 
   const { productTypes, addProductType } = useProductTypes();
 
@@ -46,6 +49,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       setSelectedType(null);
       setNewTypeName('');
       setIsNewTypeModalOpen(false);
+      setCurrentPreviewPage(0);
     }
   }, [isOpen]);
 
@@ -57,10 +61,16 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     if (!file) return;
     setLoading(true);
     try {
-      const data = await fornecedorService.previewCatalogo(file);
-      setPreview({ headers: data.headers, previewImages: data.previewImages || [] });
+      const data = await fornecedorService.previewCatalogo(file, PREVIEW_PAGE_COUNT);
+      setPreview({
+        headers: data.headers,
+        previewImages: data.previewImages || [],
+        numPages: data.numPages,
+        tablePages: data.tablePages || [],
+      });
       setFileId(data.fileId);
       setSampleRows(data.sampleRows || []);
+      setCurrentPreviewPage(0);
       setStep(2);
     } catch (err) {
       alert(err.detail || err.message || 'Erro ao gerar preview');
@@ -165,14 +175,35 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       <div>
         {preview.previewImages && preview.previewImages.length > 0 && (
           <div className="pdf-preview-images">
-            {preview.previewImages.map((img, idx) => (
-              <img
-                key={idx}
-                src={`data:image/png;base64,${img}`}
-                alt={`Página ${idx + 1}`}
-                style={{ maxWidth: '100%', marginBottom: '1em' }}
-              />
-            ))}
+            <div className="preview-nav">
+              <button
+                type="button"
+                onClick={() => setCurrentPreviewPage((p) => Math.max(p - 1, 0))}
+                disabled={currentPreviewPage === 0}
+              >
+                Anterior
+              </button>
+              <span style={{ margin: '0 1em' }}>
+                Página {currentPreviewPage + 1} de {preview.numPages || preview.previewImages.length}
+              </span>
+              <button
+                type="button"
+                onClick={() =>
+                  setCurrentPreviewPage((p) => Math.min(p + 1, preview.previewImages.length - 1))
+                }
+                disabled={currentPreviewPage >= preview.previewImages.length - 1}
+              >
+                Próxima
+              </button>
+            </div>
+            <img
+              src={`data:image/png;base64,${preview.previewImages[currentPreviewPage]}`}
+              alt={`Página ${currentPreviewPage + 1}`}
+              style={{ maxWidth: '100%', marginBottom: '1em' }}
+            />
+            {preview.tablePages && preview.tablePages.length > 0 && (
+              <p>Páginas com tabelas: {preview.tablePages.join(', ')}</p>
+            )}
           </div>
         )}
         {sampleRows.length > 0 && (

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -85,17 +85,19 @@ export const deleteFornecedor = async (fornecedorId) => {
   }
 };
 
-export const previewCatalogo = async (file) => {
+export const previewCatalogo = async (file, pageCount = 1) => {
   try {
     const formData = new FormData();
     formData.append('file', file);
-    const response = await apiClient.post('/produtos/importar-catalogo-preview/', formData);
-    const { file_id, headers, sample_rows, preview_images } = response.data;
+    const response = await apiClient.post('/produtos/importar-catalogo-preview/', formData, { params: { page_count: pageCount } });
+    const { file_id, headers, sample_rows, preview_images, num_pages, table_pages } = response.data;
     return {
       fileId: file_id,
       headers,
       sampleRows: sample_rows,
       previewImages: preview_images,
+      numPages: num_pages,
+      tablePages: table_pages,
     };
   } catch (error) {
     console.error('Erro ao gerar preview do catálogo:', JSON.stringify(error.response?.data || error.message || error));

--- a/tests/test_file_processing_service.py
+++ b/tests/test_file_processing_service.py
@@ -43,3 +43,18 @@ async def test_pdf_pages_to_images_returns_base64():
     assert len(images) == 1
     decoded = base64.b64decode(images[0])
     assert decoded.startswith(b"\x89PNG")
+
+
+@pytest.mark.asyncio
+async def test_preview_arquivo_pdf_returns_page_info():
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf)
+    c.drawString(100, 750, "Hello")
+    c.showPage()
+    c.drawString(100, 750, "World")
+    c.save()
+    pdf_bytes = buf.getvalue()
+
+    res = await file_processing_service.preview_arquivo_pdf(pdf_bytes)
+    assert res.get("num_pages") == 2
+    assert res.get("table_pages") == [] or isinstance(res.get("table_pages"), list)

--- a/tests/test_pdf_pages_to_images.py
+++ b/tests/test_pdf_pages_to_images.py
@@ -14,11 +14,13 @@ from Backend.services.file_processing_service import pdf_pages_to_images
 import pytest
 
 
-def _create_pdf():
+def _create_pdf(pages=1):
     buf = io.BytesIO()
     c = canvas.Canvas(buf)
-    c.drawString(100, 750, "Hello")
-    c.showPage()
+    for i in range(pages):
+        c.drawString(100, 750, f"Page {i + 1}")
+        if i < pages - 1:
+            c.showPage()
     c.save()
     buf.seek(0)
     return buf.getvalue()
@@ -31,3 +33,10 @@ async def test_pdf_pages_to_images_basic():
     assert len(images) >= 1
     decoded = base64.b64decode(images[0])
     assert decoded.startswith(b"\x89PNG")
+
+
+@pytest.mark.asyncio
+async def test_pdf_pages_respects_max_pages():
+    pdf_bytes = _create_pdf(pages=3)
+    images = await pdf_pages_to_images(pdf_bytes, max_pages=2)
+    assert len(images) == 2


### PR DESCRIPTION
## Summary
- allow preview endpoint to specify the amount of PDF pages to return
- include number of PDF pages and detected table pages in API response
- update frontend wizard to show multiple preview pages with navigation
- update fornecedorService helper to send page_count and receive page info
- test new preview information and pdf image limits

## Testing
- `./scripts/run_tests.sh` *(fails: 8 failed, 35 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684ac3e82818832f8743b58c4ec4b36c