### PR TITLE
Remove fileId check from import wizard

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -123,7 +123,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   };
 
   const handleConfirmImport = async () => {
-    if (!fileId || !productTypeId) return;
+    if (!productTypeId) return;
     if (!selectedType) {
       alert('Selecione um tipo de produto.');
       return;

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -65,3 +65,28 @@ test('calls onClose after finishing import', async () => {
   await userEvent.click(screen.getByText('Fechar'));
   expect(onClose).toHaveBeenCalled();
 });
+
+test('confirms import even when fileId is missing', async () => {
+  fornecedorService.previewCatalogo.mockResolvedValueOnce({
+    fileId: null,
+    headers: ['Nome'],
+    sampleRows: [{ Nome: 'Item' }],
+    previewImages: [],
+  });
+
+  render(<ImportCatalogWizard isOpen={true} onClose={() => {}} fornecedorId={1} />);
+  const fileInput = document.querySelector('input[type="file"]');
+  const file = new File(['a'], 'test.csv', { type: 'text/csv' });
+  await userEvent.upload(fileInput, file);
+  await userEvent.click(screen.getByText('Gerar Preview'));
+  await userEvent.selectOptions(screen.getByRole('combobox'), '1');
+  await userEvent.click(screen.getByText('Continuar'));
+  await userEvent.click(screen.getByText('Confirmar Importação'));
+  expect(fornecedorService.finalizarImportacaoCatalogo).toHaveBeenCalledWith(
+    null,
+    1,
+    expect.any(Object),
+    expect.any(Array),
+    1,
+  );
+});


### PR DESCRIPTION
## Summary
- stop checking for fileId when confirming catalog import
- add test for confirmation without fileId

## Testing
- `./scripts/run_tests.sh` *(fails: test_catalog_import_file, test_file_processing_service, test_historico, test_import_catalogo, test_pdf_pages_to_images, test_uso_ia and others)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ac59cebc0832f892936b551aae58d