### PR TITLE
Add duplicate filter and unique indexes for Produto

### DIFF
--- a/Backend/alembic/versions/d5a5e8bdfbd1_add_unique_indices_produto_sku_ean.py
+++ b/Backend/alembic/versions/d5a5e8bdfbd1_add_unique_indices_produto_sku_ean.py
@@ -1,0 +1,24 @@
+"""add unique indices for sku and ean per user
+
+Revision ID: d5a5e8bdfbd1
+Revises: c1f4cd5f7a6a
+Create Date: 2025-06-30 00:00:00.000000
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'd5a5e8bdfbd1'
+down_revision: Union[str, None] = 'c1f4cd5f7a6a'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_unique_constraint('uq_produtos_user_sku', 'produtos', ['user_id', 'sku'])
+    op.create_unique_constraint('uq_produtos_user_ean', 'produtos', ['user_id', 'ean'])
+
+
+def downgrade() -> None:
+    op.drop_constraint('uq_produtos_user_ean', 'produtos', type_='unique')
+    op.drop_constraint('uq_produtos_user_sku', 'produtos', type_='unique')

--- a/Backend/models.py
+++ b/Backend/models.py
@@ -302,8 +302,10 @@ class Produto(Base):
     # Índices para otimizar buscas comuns
     __table_args__ = (
         Index('ix_produtos_user_id_nome_base', 'user_id', 'nome_base'),
-        Index('ix_produtos_user_id_sku', 'user_id', 'sku', unique=False), # SKU pode não ser único globalmente, mas talvez por usuário
-        Index('ix_produtos_user_id_ean', 'user_id', 'ean', unique=False), # Mesma lógica para EAN
+        Index('ix_produtos_user_id_sku', 'user_id', 'sku', unique=False),
+        Index('ix_produtos_user_id_ean', 'user_id', 'ean', unique=False),
+        UniqueConstraint('user_id', 'sku', name='uq_produtos_user_sku'),
+        UniqueConstraint('user_id', 'ean', name='uq_produtos_user_ean'),
     )
 
 

--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -540,9 +540,10 @@ async def importar_catalogo_fornecedor(
 
     created: List[models.Produto] = []
     if produtos_create:
-        created = crud_produtos.create_produtos_bulk(
+        created, dup_errors = crud_produtos.create_produtos_bulk(
             db, produtos_create, user_id=current_user.id
         )
+        erros.extend(dup_errors)
         for db_produto in created:
             crud.create_registro_uso_ia(
                 db,
@@ -656,9 +657,10 @@ async def importar_catalogo_finalizar(
 
     created: List[models.Produto] = []
     if produtos_create:
-        created = crud_produtos.create_produtos_bulk(
+        created, dup_errors = crud_produtos.create_produtos_bulk(
             db, produtos_create, user_id=current_user.id
         )
+        erros.extend(dup_errors)
         for db_produto in created:
             crud.create_registro_uso_ia(
                 db,


### PR DESCRIPTION
## Summary
- enforce per-user unique constraints on SKU and EAN
- filter duplicates in bulk creation and report them as errors
- propagate duplicate errors to import endpoints
- migration for new constraints
- test duplicate handling during catalog import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684ac5a9ce30832fb12c535af2b7e655