### PR TITLE
Add catalog import file listing endpoint and tests

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -104,6 +104,30 @@ def create_produto(  # Nome da função mantido como no arquivo do usuário
     return db_produto
 
 
+@router.get("/catalog-import-files/", response_model=schemas.CatalogImportFilePage)
+def list_catalog_import_files(
+    db: Session = Depends(database.get_db),
+    fornecedor_id: Optional[int] = Query(None, description="ID do fornecedor"),
+    skip: int = Query(0, ge=0, description="Número de itens para pular"),
+    limit: int = Query(10, ge=1, le=100, description="Número máximo de itens por página"),
+    current_user: models.User = Depends(auth_utils.get_current_active_user),
+):
+    query = db.query(models.CatalogImportFile).filter(models.CatalogImportFile.user_id == current_user.id)
+    if fornecedor_id is not None:
+        query = query.filter(models.CatalogImportFile.fornecedor_id == fornecedor_id)
+    total_items = query.count()
+    items = (
+        query.order_by(models.CatalogImportFile.created_at.desc())
+        .offset(skip)
+        .limit(limit)
+        .all()
+    )
+    page = skip // limit + 1
+    return {"items": items, "total_items": total_items, "page": page, "limit": limit}
+
+
+
+
 @router.get("/{produto_id}", response_model=schemas.ProdutoResponse)  # CORRIGIDO AQUI
 def read_produto(  # Nome da função mantido como no arquivo do usuário
     produto_id: int,
@@ -687,3 +711,5 @@ async def importar_catalogo_finalizar(
     db.commit()
 
     return {"produtos_criados": created, "erros": erros}
+
+

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -417,6 +417,12 @@ class CatalogImportFileResponse(CatalogImportFileBase):
     class Config:
         from_attributes = True
 
+class CatalogImportFilePage(BaseModel):
+    items: List[CatalogImportFileResponse]
+    total_items: int
+    page: int
+    limit: int
+
 # --- Password Recovery Schemas ---
 class PasswordResetSchema(BaseModel):
     new_password: str = Field(..., min_length=8)

--- a/tests/test_catalog_import_file.py
+++ b/tests/test_catalog_import_file.py
@@ -152,3 +152,65 @@ def test_finalize_processes_full_file():
         produtos = db.query(models.Produto).all()
         assert len(produtos) == 10  # 2 existentes + 8 novos
         assert all(p.fornecedor_id == fornec_id for p in produtos[2:])
+
+
+def test_list_catalog_files_pagination():
+    headers = get_admin_headers()
+    with TestingSessionLocal() as db:
+        admin = crud.get_user_by_email(db, settings.FIRST_SUPERUSER_EMAIL)
+        fornec_id = db.query(models.Fornecedor.id).first()[0]
+        for i in range(15):
+            db.add(
+                models.CatalogImportFile(
+                    user_id=admin.id,
+                    fornecedor_id=fornec_id,
+                    original_filename=f"file{i}.csv",
+                    stored_filename=f"stored{i}.csv",
+                )
+            )
+        db.commit()
+
+    resp = client.get(
+        "/api/v1/produtos/catalog-import-files/",
+        params={"skip": 10, "limit": 10},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["page"] == 2
+    assert data["limit"] == 10
+
+
+def test_list_catalog_files_filter_by_fornecedor():
+    headers = get_admin_headers()
+    with TestingSessionLocal() as db:
+        admin = crud.get_user_by_email(db, settings.FIRST_SUPERUSER_EMAIL)
+        fornec_base = db.query(models.Fornecedor).first()
+        new_forn = crud.create_fornecedor(db, schemas.FornecedorCreate(nome="F2"), user_id=admin.id)
+        new_forn_id = new_forn.id
+        db.add(
+            models.CatalogImportFile(
+                user_id=admin.id,
+                fornecedor_id=new_forn_id,
+                original_filename="f.csv",
+                stored_filename="s.csv",
+            )
+        )
+        db.add(
+            models.CatalogImportFile(
+                user_id=admin.id,
+                fornecedor_id=fornec_base.id,
+                original_filename="b.csv",
+                stored_filename="b.csv",
+            )
+        )
+        db.commit()
+
+    resp = client.get(
+        "/api/v1/produtos/catalog-import-files/",
+        params={"fornecedor_id": new_forn_id},
+        headers=headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert all(item["fornecedor_id"] == new_forn_id for item in data["items"])


### PR DESCRIPTION
## Summary
- add `CatalogImportFilePage` schema
- expose new `GET /catalog-import-files/` endpoint filtering by user/fornecedor and ordered by creation date
- test catalog import file pagination and filtering

## Testing
- `pytest tests/test_catalog_import_file.py::test_list_catalog_files_pagination -q`
- `pytest tests/test_catalog_import_file.py::test_list_catalog_files_filter_by_fornecedor -q`
- `pytest tests/test_catalog_import_file.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684ac68f6a94832faeb328df59ef23fd