### PR TITLE
Add catalog file listing for suppliers

### DIFF
--- a/Frontend/app/src/components/fornecedores/CatalogFileList.jsx
+++ b/Frontend/app/src/components/fornecedores/CatalogFileList.jsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { format } from 'date-fns';
+
+function CatalogFileList({ files = [], onReprocess }) {
+  if (!files || files.length === 0) {
+    return <p>Nenhum arquivo encontrado.</p>;
+  }
+
+  return (
+    <table className="catalog-file-table">
+      <thead>
+        <tr>
+          <th>Arquivo</th>
+          <th>Status</th>
+          <th>Enviado em</th>
+          {onReprocess && <th>Ações</th>}
+        </tr>
+      </thead>
+      <tbody>
+        {files.map((f) => (
+          <tr key={f.id}>
+            <td>{f.original_filename}</td>
+            <td>{f.status}</td>
+            <td>{format(new Date(f.created_at), 'dd/MM/yyyy HH:mm')}</td>
+            {onReprocess && (
+              <td>
+                <button onClick={() => onReprocess(f.id)}>Reprocessar</button>
+              </td>
+            )}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export default CatalogFileList;

--- a/Frontend/app/src/components/fornecedores/__tests__/EditFornecedorModal.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/EditFornecedorModal.test.jsx
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import EditFornecedorModal from '../EditFornecedorModal.jsx';
+
+jest.mock('../ImportCatalogWizard.jsx', () => () => <div>Wizard</div>);
+
+const filesMock = [
+  { id: 1, original_filename: 'file1.csv', status: 'IMPORTED', created_at: '2024-01-01T00:00:00Z' }
+];
+
+jest.mock('../../../services/fornecedorService', () => ({
+  __esModule: true,
+  default: {
+    getCatalogImportFiles: jest.fn(() => Promise.resolve(filesMock)),
+  },
+}));
+
+import fornecedorService from '../../../services/fornecedorService';
+
+test('loads and displays catalog files on import tab', async () => {
+  render(
+    <EditFornecedorModal
+      isOpen={true}
+      fornecedorData={{ id: 5, nome: 'Fornecedor X' }}
+      onClose={() => {}}
+      onSave={() => {}}
+      isLoading={false}
+    />
+  );
+  await userEvent.click(screen.getByText('Importar Catálogo'));
+  await waitFor(() => expect(fornecedorService.getCatalogImportFiles).toHaveBeenCalledWith({ fornecedor_id: 5 }));
+  expect(await screen.findByText('file1.csv')).toBeInTheDocument();
+});

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -159,6 +159,22 @@ export const finalizarImportacaoCatalogo = async (
   }
 };
 
+export const getCatalogImportFiles = async (params = {}) => {
+  try {
+    const response = await apiClient.get('/catalog-import-files/', { params });
+    return response.data;
+  } catch (error) {
+    console.error('Erro ao buscar arquivos de importação:', JSON.stringify(error.response?.data || error.message || error));
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    } else if (error.request) {
+      throw new Error('Nenhuma resposta do servidor ao buscar arquivos de importação.');
+    } else {
+      throw new Error(error.message || 'Erro ao configurar requisição para buscar arquivos de importação.');
+    }
+  }
+};
+
 export default {
   getFornecedores,
   getFornecedorById,
@@ -168,4 +184,5 @@ export default {
   previewCatalogo,
   importCatalogo,
   finalizarImportacaoCatalogo,
+  getCatalogImportFiles,
 };


### PR DESCRIPTION
## Summary
- support listing catalog import files via fornecedorService
- display previous imports inside EditFornecedorModal
- add CatalogFileList component
- test EditFornecedorModal tab behavior

## Testing
- `npm install --legacy-peer-deps`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684ac690ed74832f833bc5a9d9a0aca6