### PR TITLE
Fix duplicate page_count argument

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -585,7 +585,6 @@ async def upload_produto_image(  # Nome da função mantido como no arquivo do u
 async def importar_catalogo_preview(
     file: UploadFile = File(...),
     fornecedor_id: Optional[int] = Form(None),
-    page_count: int = Query(1, ge=1),
     page_count: int = Query(1, ge=1, description="Número de páginas de preview do PDF"),
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user),


### PR DESCRIPTION
## Summary
- remove duplicate `page_count` argument in `importar_catalogo_preview` with description

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684acbba32c4832fa535166c2c4694c7