### PR TITLE
Fix JS syntax and update test

### DIFF
--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -206,6 +206,9 @@ export const selecionarRegiaoPdf = async (
       throw error.response.data;
     }
     throw new Error(error.message || 'Falha ao solicitar região do PDF');
+  }
+};
+
 export const selecionarRegiao = async (fileId, page, bbox) => {
   try {
     const response = await apiClient.post('/produtos/selecionar-regiao/', {


### PR DESCRIPTION
## Summary
- close missing braces in `fornecedorService`
- fill out `test_status_endpoint_returns_progress` so it compiles

## Testing
- `./scripts/run_tests.sh` *(fails: 15 failed, 37 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684ae1715900832f944956681a1dd555