### PR TITLE
Update README about AUTO_CREATE_TABLES

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ python run_backend.py       # Inicia o backend (http://localhost:8000)
 > **Importante:** as migrações do Alembic **devem** ser executadas antes de iniciar o backend.
 > Em ambientes de desenvolvimento é possível definir `AUTO_CREATE_TABLES=true` no `.env`
 > para que as tabelas sejam criadas automaticamente no startup.
+> Mesmo com `AUTO_CREATE_TABLES=true`, novas migrações (como campos extras) exigem `alembic upgrade head`.
 
 Após a primeira execução, o backend cria automaticamente um usuário administrador
 e um **produto de exemplo**. Utilize as credenciais definidas em `.env` para


### PR DESCRIPTION
## Summary
- clarify behavior of `AUTO_CREATE_TABLES` in backend setup

## Testing
- `./scripts/run_tests.sh` *(fails: 15 failed, 37 passed, 1 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_684ae9969924832f94d53599011016f3