### PR TITLE
Add links for catalog files

### DIFF
--- a/Frontend/app/src/components/fornecedores/CatalogFileList.jsx
+++ b/Frontend/app/src/components/fornecedores/CatalogFileList.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { format } from 'date-fns';
+import getBackendBaseUrl from '../../utils/backend.js';
 
 function CatalogFileList({ files = [], onReprocess }) {
+  const backendBaseUrl = getBackendBaseUrl();
   if (!files || files.length === 0) {
     return <p>Nenhum arquivo encontrado.</p>;
   }
@@ -13,6 +15,7 @@ function CatalogFileList({ files = [], onReprocess }) {
           <th>Arquivo</th>
           <th>Status</th>
           <th>Enviado em</th>
+          <th>Processado</th>
           {onReprocess && <th>Ações</th>}
         </tr>
       </thead>
@@ -22,6 +25,15 @@ function CatalogFileList({ files = [], onReprocess }) {
             <td>{f.original_filename}</td>
             <td>{f.status}</td>
             <td>{format(new Date(f.created_at), 'dd/MM/yyyy HH:mm')}</td>
+            <td>
+              <a
+                href={`${backendBaseUrl}/static/uploads/catalogs/${f.stored_filename}`}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {f.stored_filename}
+              </a>
+            </td>
             {onReprocess && (
               <td>
                 <button onClick={() => onReprocess(f.id)}>Reprocessar</button>

--- a/Frontend/app/src/components/fornecedores/__tests__/CatalogFileList.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/CatalogFileList.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import CatalogFileList from '../CatalogFileList.jsx';
+
+jest.mock('../../../utils/backend.js', () => ({
+  __esModule: true,
+  default: () => 'http://backend',
+  getBackendBaseUrl: () => 'http://backend'
+}));
+
+const files = [
+  {
+    id: 1,
+    original_filename: 'file1.csv',
+    stored_filename: 'stored1.csv',
+    status: 'IMPORTED',
+    created_at: '2024-01-01T00:00:00Z'
+  },
+  {
+    id: 2,
+    original_filename: 'file2.csv',
+    stored_filename: 'stored2.csv',
+    status: 'IMPORTED',
+    created_at: '2024-01-02T00:00:00Z'
+  }
+];
+
+test('renders link to stored file for each entry', () => {
+  render(<CatalogFileList files={files} />);
+  const links = screen.getAllByRole('link');
+  expect(links).toHaveLength(files.length);
+  expect(links[0]).toHaveAttribute(
+    'href',
+    'http://backend/static/uploads/catalogs/stored1.csv'
+  );
+});

--- a/Frontend/app/src/utils/backend.js
+++ b/Frontend/app/src/utils/backend.js
@@ -1,0 +1,6 @@
+export function getBackendBaseUrl() {
+  const apiUrl = process.env.VITE_API_BASE_URL || '/api/v1';
+  return apiUrl.replace(/\/api\/v1\/?$/, '');
+}
+
+export default getBackendBaseUrl;


### PR DESCRIPTION
## Summary
- compute backend base url
- link stored catalog files in CatalogFileList
- test CatalogFileList links

## Testing
- `pytest` *(fails: pydantic validation errors during collection)*
- `npm test` *(fails: PdfRegionSelector test parse error)*

------
https://chatgpt.com/codex/tasks/task_e_684af8fab5c4832fbf1c384e4a9e280a