### PR TITLE
Fix backend baseUrl helper for browser

### DIFF
--- a/Frontend/app/src/utils/backend.js
+++ b/Frontend/app/src/utils/backend.js
@@ -1,5 +1,9 @@
 export function getBackendBaseUrl() {
-  const apiUrl = process.env.VITE_API_BASE_URL || '/api/v1';
+  const metaEnv = typeof import.meta !== 'undefined' ? import.meta.env : undefined;
+  const apiUrl =
+    (metaEnv && metaEnv.VITE_API_BASE_URL) ||
+    (typeof process !== 'undefined' && process.env && process.env.VITE_API_BASE_URL) ||
+    '/api/v1';
   return apiUrl.replace(/\/api\/v1\/?$/, '');
 }
 


### PR DESCRIPTION
## Summary
- support browser environment in `getBackendBaseUrl`

## Testing
- `npm --prefix Frontend/app install` *(fails: ERESOLVE)*
- `npm --prefix Frontend/app test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: jose)*

------
https://chatgpt.com/codex/tasks/task_e_684aecdc5268832f944425bb8dd59731