### PR TITLE
Add catalog file management actions

### DIFF
--- a/Frontend/app/src/components/fornecedores/CatalogFileList.jsx
+++ b/Frontend/app/src/components/fornecedores/CatalogFileList.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { format } from 'date-fns';
 import getBackendBaseUrl from '../../utils/backend.js';
 
-function CatalogFileList({ files = [], onReprocess }) {
+function CatalogFileList({ files = [], onReprocess, onDelete }) {
   const backendBaseUrl = getBackendBaseUrl();
   if (!files || files.length === 0) {
     return <p>Nenhum arquivo encontrado.</p>;
@@ -16,7 +16,7 @@ function CatalogFileList({ files = [], onReprocess }) {
           <th>Status</th>
           <th>Enviado em</th>
           <th>Processado</th>
-          {onReprocess && <th>Ações</th>}
+          {(onReprocess || onDelete) && <th>Ações</th>}
         </tr>
       </thead>
       <tbody>
@@ -34,9 +34,19 @@ function CatalogFileList({ files = [], onReprocess }) {
                 {f.stored_filename}
               </a>
             </td>
-            {onReprocess && (
+            {(onReprocess || onDelete) && (
               <td>
-                <button onClick={() => onReprocess(f.id)}>Reprocessar</button>
+                {onReprocess && (
+                  <button onClick={() => onReprocess(f.id)}>Reprocessar</button>
+                )}
+                {onDelete && (
+                  <button
+                    onClick={() => onDelete(f.id)}
+                    style={{ marginLeft: '0.5em' }}
+                  >
+                    Excluir
+                  </button>
+                )}
               </td>
             )}
           </tr>

--- a/Frontend/app/src/components/fornecedores/__tests__/CatalogFileList.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/CatalogFileList.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
 import CatalogFileList from '../CatalogFileList.jsx';
 
 jest.mock('../../../utils/backend.js', () => ({
@@ -33,4 +34,18 @@ test('renders link to stored file for each entry', () => {
     'href',
     'http://backend/static/uploads/catalogs/stored1.csv'
   );
+});
+
+test('calls handlers when buttons clicked', async () => {
+  const onDelete = jest.fn();
+  const onReprocess = jest.fn();
+  render(
+    <CatalogFileList files={files} onDelete={onDelete} onReprocess={onReprocess} />
+  );
+  const reprocessBtn = screen.getAllByText('Reprocessar')[0];
+  const deleteBtn = screen.getAllByText('Excluir')[0];
+  await userEvent.click(reprocessBtn);
+  await userEvent.click(deleteBtn);
+  expect(onReprocess).toHaveBeenCalledWith(files[0].id);
+  expect(onDelete).toHaveBeenCalledWith(files[0].id);
 });

--- a/Frontend/app/src/components/fornecedores/__tests__/EditFornecedorModal.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/EditFornecedorModal.test.jsx
@@ -5,6 +5,12 @@ import EditFornecedorModal from '../EditFornecedorModal.jsx';
 
 jest.mock('../ImportCatalogWizard.jsx', () => () => <div>Wizard</div>);
 
+jest.mock('../../../utils/backend.js', () => ({
+  __esModule: true,
+  default: () => 'http://backend',
+  getBackendBaseUrl: () => 'http://backend'
+}));
+
 const filesMock = [
   { id: 1, original_filename: 'file1.csv', status: 'IMPORTED', created_at: '2024-01-01T00:00:00Z' }
 ];
@@ -13,6 +19,8 @@ jest.mock('../../../services/fornecedorService', () => ({
   __esModule: true,
   default: {
     getCatalogImportFiles: jest.fn(() => Promise.resolve(filesMock)),
+    deleteCatalogFile: jest.fn(() => Promise.resolve({})),
+    reprocessCatalogFile: jest.fn(() => Promise.resolve({})),
   },
 }));
 
@@ -31,4 +39,23 @@ test('loads and displays catalog files on Arquivos tab', async () => {
   await userEvent.click(screen.getByText('Arquivos'));
   await waitFor(() => expect(fornecedorService.getCatalogImportFiles).toHaveBeenCalledWith({ fornecedor_id: 5 }));
   expect(await screen.findByText('file1.csv')).toBeInTheDocument();
+});
+
+test('calls delete and reprocess when buttons clicked', async () => {
+  render(
+    <EditFornecedorModal
+      isOpen={true}
+      fornecedorData={{ id: 5, nome: 'Fornecedor X' }}
+      onClose={() => {}}
+      onSave={() => {}}
+      isLoading={false}
+    />
+  );
+  await userEvent.click(screen.getByText('Arquivos'));
+  const reprocessBtn = await screen.findByText('Reprocessar');
+  const deleteBtn = await screen.findByText('Excluir');
+  await userEvent.click(reprocessBtn);
+  await userEvent.click(deleteBtn);
+  expect(fornecedorService.reprocessCatalogFile).toHaveBeenCalledWith(1);
+  expect(fornecedorService.deleteCatalogFile).toHaveBeenCalledWith(1);
 });

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -178,6 +178,42 @@ export const getCatalogImportFiles = async (params = {}) => {
   }
 };
 
+export const deleteCatalogFile = async (fileId) => {
+  try {
+    const response = await apiClient.delete(
+      `/produtos/catalog-import-files/${fileId}/`
+    );
+    return response.data;
+  } catch (error) {
+    console.error(
+      `Erro ao excluir arquivo ${fileId}:`,
+      JSON.stringify(error.response?.data || error.message || error)
+    );
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao excluir arquivo');
+  }
+};
+
+export const reprocessCatalogFile = async (fileId) => {
+  try {
+    const response = await apiClient.post(
+      `/produtos/catalog-import-files/${fileId}/reprocess/`
+    );
+    return response.data;
+  } catch (error) {
+    console.error(
+      `Erro ao reprocessar arquivo ${fileId}:`,
+      JSON.stringify(error.response?.data || error.message || error)
+    );
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao reprocessar arquivo');
+  }
+};
+
 export const getImportacaoStatus = async (fileId) => {
   try {
     const response = await apiClient.get(`/produtos/importar-catalogo-status/${fileId}/`);
@@ -236,6 +272,8 @@ export default {
   importCatalogo,
   finalizarImportacaoCatalogo,
   getCatalogImportFiles,
+  deleteCatalogFile,
+  reprocessCatalogFile,
   getImportacaoStatus,
   selecionarRegiaoPdf,
   selecionarRegiao,


### PR DESCRIPTION
## Summary
- allow CatalogFileList to show delete and reprocess buttons
- refresh files list via new handlers in EditFornecedorModal
- open import wizard from the files tab
- add deleteCatalogFile and reprocessCatalogFile service helpers
- test delete and reprocess interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684b029ece98832fa890c098fc9758f2