### PR TITLE
Update docs for new endpoints and file controls

### DIFF
--- a/README Backend.md
+++ b/README Backend.md
@@ -226,6 +226,13 @@
 * `get_product(product_id: int, db: Session)`: Busca produto pelo ID.
 * `update_product(product_id: int, update: ProdutoUpdate, db: Session)`: Atualiza produto.
 * `delete_product(product_id: int, db: Session)`: Remove produto.
+* `list_catalog_import_files(fornecedor_id: Optional[int], skip: int = 0, limit: int = 100, db: Session)`: Lista arquivos de importação de catálogos do usuário.
+* `importar_catalogo_preview(file: UploadFile, fornecedor_id: Optional[int], page_count: int, db: Session)`: Envia um arquivo e retorna cabeçalhos, amostras e `file_id` para processamento posterior.
+* `importar_catalogo_fornecedor(fornecedor_id: int, file: UploadFile, mapeamento_colunas_usuario: Optional[str], db: Session)`: Importa catálogo e cria produtos imediatamente.
+* `importar_catalogo_finalizar(file_id: int, product_type_id: int, fornecedor_id: int, mapping: Optional[dict], db: Session)`: Processa em background um arquivo já enviado.
+* `importar_catalogo_status(file_id: int, db: Session)`: Consulta o status do processamento do catálogo.
+* `selecionar_regiao_pdf(req: PdfRegionRequest, db: Session)`: Extrai texto de uma região específica de um PDF.
+* `selecionar_regiao(file_id: int, page: int, bbox: List[float], db: Session)`: Processa região selecionada e retorna produtos detectados.
 
 ## Backend/routers/social\_auth.py
 

--- a/README Frontend.md
+++ b/README Frontend.md
@@ -55,6 +55,10 @@
 
 * `PaginationControls({ currentPage, totalPages, onPageChange, isLoading, itemsPerPage, onItemsPerPageChange, totalItems })`: Componente de paginação. Recebe props para controlar página atual, total de itens e ações de navegação (próxima, anterior).
 
+## Frontend/app/src/common/PdfRegionSelector.jsx
+
+* `PdfRegionSelector({ file, onSelect })`: Permite desenhar uma região em um PDF e envia as coordenadas ao callback.
+
 ---
 
 ## Frontend/app/src/components/product_types/AttributeTemplateList.jsx
@@ -67,7 +71,7 @@
 
 ## Frontend/app/src/components/fornecedores/EditFornecedorModal.jsx
 
-* `EditFornecedorModal({ isOpen, onClose, fornecedorData, onSave, isLoading })`: Modal para editar dados de um fornecedor. Recebe props para controlar abertura, fornecedor ativo e callback de salvar. Na aba **Importar Catálogo**, o botão abre o `ImportCatalogWizard`.
+* `EditFornecedorModal({ isOpen, onClose, fornecedorData, onSave, isLoading })`: Modal para editar dados de um fornecedor. Conta agora com a aba **Arquivos**, que lista catálogos enviados e permite reprocessá-los. Na aba **Importar Catálogo**, o botão abre o `ImportCatalogWizard`.
 
 ## Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
 
@@ -75,7 +79,11 @@
   1. **Pré-visualização e seleção do tipo** – upload do arquivo, exibição de amostras e escolha do tipo de produto.
   2. **Mapeamento de colunas** – associa colunas da planilha a campos padrão e atributos dinâmicos. Permite criar um novo tipo de produto caso não exista.
   3. **Confirmação** – revisão final e importação.
-  O wizard mostra linhas de amostra e miniaturas antes do envio definitivo, garantindo que as colunas estejam corretas.
+O wizard mostra linhas de amostra e miniaturas antes do envio definitivo, garantindo que as colunas estejam corretas.
+
+## Frontend/app/src/components/fornecedores/CatalogFileList.jsx
+
+* `CatalogFileList({ files = [], onReprocess })`: Exibe tabela com arquivos importados, mostrando link de download e botão opcional de reprocessar.
 
 ## Frontend/app/src/components/fornecedores/FornecedorTable.jsx
 
@@ -136,6 +144,10 @@
 ## Frontend/app/src/components/produtos/shared/AttributeField.jsx
 
 * `AttributeField({ attributeTemplate, value, onChange, disabled })`: Componente para campo de atributo dinâmico em formulários de produto. Renderiza campo de input/select conforme tipo do atributo. Dispara callback ao alterar valor.
+
+### Instruções de gerenciamento de arquivos
+
+Na aba **Arquivos** do `EditFornecedorModal` é possível visualizar catálogos já enviados. Clique no nome para baixar o arquivo ou use **Reprocessar** para importá-lo novamente. Durante o assistente de importação, o `PdfRegionSelector` ajuda a escolher a região do PDF contendo a tabela de produtos.
 
 ---
 


### PR DESCRIPTION
## Summary
- document catalog import and PDF region endpoints in backend README
- explain new CatalogFileList and PDF region selector in frontend docs
- add user instructions for accessing uploaded files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684b02a058e8832f9d02bcc3f09d6fe2