### PR TITLE
Add reprocess & delete endpoints for catalog files

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -51,6 +51,19 @@ async def save_uploaded_catalog(
         fornecedor_id=fornecedor_id,
     )
 
+
+def delete_catalog_file(stored_filename: str) -> None:
+    """Remove a stored catalog file from disk if it exists."""
+    directory = Path(settings.UPLOAD_DIRECTORY) / "catalogs"
+    if not directory.is_absolute():
+        directory = Path(__file__).resolve().parent.parent / directory
+    path = directory / stored_filename
+    try:
+        if path.exists():
+            path.unlink()
+    except Exception:
+        logger.exception("Erro ao remover arquivo %s", stored_filename)
+
 def _limpar_valor_extraido(valor: Any) -> Optional[str]:
     """Helper para limpar strings ou converter outros tipos para string, retornando None se vazio."""
     if valor is None:


### PR DESCRIPTION
## Summary
- enable removing catalog files on disk
- add routes to delete and reprocess catalog-import-files
- test the new behaviour

## Testing
- `pytest tests/test_catalog_import_file.py::test_delete_catalog_import_file_removes_file_and_record -q`
- `pytest tests/test_catalog_import_file.py::test_reprocess_catalog_import_file_creates_again -q`
- `pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_684b029d3588832faabdc6a8d4e2f3b4