### PR TITLE
Allow selecting PDF pages for catalog import

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -54,6 +54,7 @@ async def _tarefa_processar_catalogo(
     product_type_id: int,
     fornecedor_id: int,
     mapping: Optional[Dict[str, str]] = None,
+    pages: Optional[List[int]] = None,
 ):
     """Processa o arquivo salvo em background e cria os produtos."""
     db: Optional[Session] = None
@@ -93,6 +94,7 @@ async def _tarefa_processar_catalogo(
                 content,
                 mapeamento_colunas_usuario=mapping,
                 product_type_id=product_type_id,
+                pages=pages,
             )
         else:
             catalog_file.status = "FAILED"
@@ -313,6 +315,7 @@ async def reprocess_catalog_import_file(
         product_type_id=product_type_id,
         fornecedor_id=fornecedor_id,
         mapping=mapping,
+        pages=pages,
     )
 
     return {"status": "PROCESSING", "file_id": file_id}
@@ -799,6 +802,7 @@ async def importar_catalogo_finalizar(
     product_type_id: int = Body(..., embed=True),
     fornecedor_id: int = Body(..., embed=True),
     mapping: Optional[Dict[str, str]] = Body(None),
+    pages: Optional[List[int]] = Body(None),
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user),
 ):
@@ -847,6 +851,7 @@ async def importar_catalogo_finalizar(
             content,
             mapeamento_colunas_usuario=mapping,
             product_type_id=product_type_id,
+            pages=pages,
         )
     else:
         raise HTTPException(
@@ -861,6 +866,7 @@ async def importar_catalogo_finalizar(
         product_type_id=product_type_id,
         fornecedor_id=fornecedor_id,
         mapping=mapping,
+        pages=pages,
     )
 
     return {"status": "PROCESSING", "file_id": file_id}

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -235,6 +235,7 @@ async def processar_arquivo_pdf(
     mapeamento_colunas_usuario: Optional[Dict[str, str]] = None,
     usar_llm: bool = True,
     product_type_id: Optional[int] = None,
+    pages: Optional[List[int]] = None,
 ) -> List[Dict[str, Any]]:
     produtos_extraidos: List[Dict[str, Any]] = []
     log_pdf: List[str] = []
@@ -242,6 +243,9 @@ async def processar_arquivo_pdf(
         with pdfplumber.open(io.BytesIO(conteudo_arquivo)) as pdf:
             log_pdf.append(f"PDF com {len(pdf.pages)} páginas.")
             for i, page in enumerate(pdf.pages):
+                page_num = i + 1
+                if pages and page_num not in pages:
+                    continue
                 # Tenta extrair tabelas da página
                 # Configurações para extração de tabela podem ser ajustadas
                 tables = page.extract_tables(table_settings={
@@ -277,6 +281,9 @@ async def processar_arquivo_pdf(
                     "Nenhum produto extraído de tabelas. Extraindo texto de todas as páginas."
                 )
                 for i, page in enumerate(pdf.pages):
+                    page_num = i + 1
+                    if pages and page_num not in pages:
+                        continue
                     page_text = page.extract_text(x_tolerance=2, y_tolerance=2)
                     if page_text and page_text.strip():
                         log_pdf.append(f"Página {i+1}: Texto extraído.")

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -37,6 +37,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   const [regionProducts, setRegionProducts] = useState(null);
   const [isRegionModalOpen, setIsRegionModalOpen] = useState(false);
   const [pdfUrl, setPdfUrl] = useState(null);
+  const [selectedPages, setSelectedPages] = useState(new Set());
 
   const { productTypes, addProductType } = useProductTypes();
 
@@ -63,6 +64,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       }
       setCurrentPreviewPage(0);
       setPdfUrl(null);
+      setSelectedPages(new Set());
     }
   }, [isOpen]);
 
@@ -95,6 +97,11 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
         numPages: data.numPages,
         tablePages: data.tablePages || [],
       });
+      if (data.numPages) {
+        setSelectedPages(new Set(Array.from({ length: data.numPages }, (_, i) => i + 1)));
+      } else {
+        setSelectedPages(new Set());
+      }
       setFileId(data.fileId);
       setSampleRows(data.sampleRows || []);
       setCurrentPreviewPage(0);
@@ -136,6 +143,18 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     } finally {
       setLoading(false);
     }
+  };
+
+  const toggleSelectedPage = (page) => {
+    setSelectedPages((prev) => {
+      const next = new Set(prev);
+      if (next.has(page)) {
+        next.delete(page);
+      } else {
+        next.add(page);
+      }
+      return next;
+    });
   };
 
   const handleContinueAfterTypeSelect = () => {
@@ -191,7 +210,8 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
         fornecedorId,
         mapping,
         sampleRows,
-        selectedType.id
+        selectedType.id,
+        selectedPages
       );
       setMessage('Processando...');
       setStep(4);
@@ -274,11 +294,19 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
                 Próxima
               </button>
             </div>
-            <img
-              src={`data:image/png;base64,${preview.previewImages[currentPreviewPage]}`}
-              alt={`Página ${currentPreviewPage + 1}`}
-              style={{ maxWidth: '100%', marginBottom: '1em' }}
-            />
+            <div style={{ position: 'relative', display: 'inline-block' }}>
+              <input
+                type="checkbox"
+                checked={selectedPages.has(currentPreviewPage + 1)}
+                onChange={() => toggleSelectedPage(currentPreviewPage + 1)}
+                style={{ position: 'absolute', top: 10, left: 10, zIndex: 1 }}
+              />
+              <img
+                src={`data:image/png;base64,${preview.previewImages[currentPreviewPage]}`}
+                alt={`Página ${currentPreviewPage + 1}`}
+                style={{ maxWidth: '100%', marginBottom: '1em' }}
+              />
+            </div>
             <button type="button" onClick={() => setIsRegionModalOpen(true)} className="btn-small">
               Selecionar Região
             </button>

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -54,6 +54,7 @@ test('shows preview rows and sends productTypeId on confirm', async () => {
     expect.any(Object),
     expect.any(Array),
     1,
+    expect.any(Set),
   );
   expect(fornecedorService.getImportacaoStatus).toHaveBeenCalled();
   expect(await screen.findByText('Importação concluída com sucesso')).toBeInTheDocument();
@@ -96,6 +97,30 @@ test('confirms import even when fileId is missing', async () => {
     expect.any(Object),
     expect.any(Array),
     1,
+    expect.any(Set),
   );
+});
+
+test('sends only selected pages', async () => {
+  fornecedorService.previewCatalogo.mockResolvedValueOnce({
+    fileId: 'f1',
+    headers: ['Nome'],
+    sampleRows: [{ Nome: 'Item' }],
+    previewImages: ['a', 'b'],
+    numPages: 2,
+  });
+  render(<ImportCatalogWizard isOpen={true} onClose={() => {}} fornecedorId={1} />);
+  const fileInput = document.querySelector('input[type="file"]');
+  const file = new File(['a'], 'test.pdf', { type: 'application/pdf' });
+  await userEvent.upload(fileInput, file);
+  await userEvent.click(screen.getByText('Gerar Preview'));
+  await userEvent.click(screen.getByText('Próxima'));
+  await userEvent.click(screen.getByRole('checkbox'));
+  await userEvent.click(screen.getByText('Anterior'));
+  await userEvent.selectOptions(screen.getByRole('combobox'), '1');
+  await userEvent.click(screen.getByText('Continuar'));
+  await userEvent.click(screen.getByText('Confirmar Importação'));
+  const pages = fornecedorService.finalizarImportacaoCatalogo.mock.calls[0][5];
+  expect(Array.from(pages)).toEqual([1]);
 });
 });

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -135,6 +135,7 @@ export const finalizarImportacaoCatalogo = async (
   mapping = null,
   rows = null,
   productTypeId = null,
+  pages = null,
 ) => {
   try {
     const payload = { file_id: fileId, fornecedor_id: fornecedorId };
@@ -144,6 +145,9 @@ export const finalizarImportacaoCatalogo = async (
     }
     if (rows) {
       payload.rows = rows;
+    }
+    if (pages) {
+      payload.pages = Array.from(pages);
     }
     const response = await apiClient.post(
       `/produtos/importar-catalogo-finalizar/${fileId}/`,

--- a/tests/test_pdf_no_tables.py
+++ b/tests/test_pdf_no_tables.py
@@ -38,3 +38,14 @@ def test_processar_pdf_sem_tabelas_extrai_texto():
     assert res[0]["dados_brutos_adicionais"]["texto_completo_pagina_1"].startswith("Primeira")
     assert res[1]["dados_brutos_adicionais"]["texto_completo_pagina_2"].startswith("Segunda")
 
+
+def test_processar_pdf_pages_param():
+    pdf_bytes = _create_pdf(["A", "B", "C"])
+    res = asyncio.run(
+        file_processing_service.processar_arquivo_pdf(pdf_bytes, usar_llm=False, pages=[1, 3])
+    )
+    textos = [list(r["dados_brutos_adicionais"].values())[0] for r in res]
+    assert len(res) == 2
+    assert textos[0].startswith("A")
+    assert textos[1].startswith("C")
+


### PR DESCRIPTION
## Summary
- let frontend track selected PDF pages
- overlay checkbox to choose pages in ImportCatalogWizard
- send selected pages to backend during catalog import
- update backend to process only chosen pages
- test PDF page filtering

## Testing
- `npm test --silent`
- `pytest -q` *(fails: pydantic validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_684beaf65b78832fbd8a30864dc6dc43