### PR TITLE
Remove selecionarRegiaoPdf helper

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -507,19 +507,6 @@ class FileProcessResponse(BaseModel):
     size_bytes: Optional[int] = None
 
 
-class PdfRegionRequest(BaseModel):
-    file_id: int
-    page: int
-    x0: float
-    y0: float
-    x1: float
-    y1: float
-
-
-class PdfRegionResponse(PdfRegionRequest):
-    text: str
-
-
 class SocialLoginConfig(BaseModel):
     """Indica quais provedores de login social estão configurados."""
     google_enabled: bool
@@ -541,5 +528,4 @@ RegistroHistoricoResponse.model_rebuild()
 CatalogImportFileResponse.model_rebuild()
 UserActivity.model_rebuild()
 SocialLoginConfig.model_rebuild()
-PdfRegionResponse.model_rebuild()
 

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -227,23 +227,6 @@ export const getImportacaoStatus = async (fileId) => {
   }
 };
 
-export const selecionarRegiaoPdf = async (
-  fileId,
-  page,
-  bbox,
-) => {
-  try {
-    const payload = { file_id: fileId, page, ...bbox };
-    const response = await apiClient.post('/produtos/selecionar-regiao/', payload);
-    return response.data;
-  } catch (error) {
-    console.error('Erro ao selecionar região do PDF:', JSON.stringify(error.response?.data || error.message || error));
-    if (error.response && error.response.data) {
-      throw error.response.data;
-    }
-    throw new Error(error.message || 'Falha ao solicitar região do PDF');
-  }
-};
 
 export const selecionarRegiao = async (fileId, page, bbox) => {
   try {
@@ -275,6 +258,5 @@ export default {
   deleteCatalogFile,
   reprocessCatalogFile,
   getImportacaoStatus,
-  selecionarRegiaoPdf,
   selecionarRegiao,
 };

--- a/README Backend.md
+++ b/README Backend.md
@@ -231,8 +231,7 @@
 * `importar_catalogo_fornecedor(fornecedor_id: int, file: UploadFile, mapeamento_colunas_usuario: Optional[str], db: Session)`: Importa catálogo e cria produtos imediatamente.
 * `importar_catalogo_finalizar(file_id: int, product_type_id: int, fornecedor_id: int, mapping: Optional[dict], db: Session)`: Processa em background um arquivo já enviado.
 * `importar_catalogo_status(file_id: int, db: Session)`: Consulta o status do processamento do catálogo.
-* `selecionar_regiao_pdf(req: PdfRegionRequest, db: Session)`: Extrai texto de uma região específica de um PDF.
-* `selecionar_regiao(file_id: int, page: int, bbox: List[float], db: Session)`: Processa região selecionada e retorna produtos detectados.
+* `selecionar_regiao(file_id: int, page: int, bbox: List[float], db: Session)`: Processa região selecionada de um PDF e retorna produtos detectados.
 
 ## Backend/routers/social\_auth.py
 

--- a/tests/test_select_region.py
+++ b/tests/test_select_region.py
@@ -69,7 +69,7 @@ def get_admin_headers():
     return {"Authorization": f"Bearer {token}"}
 
 
-def test_selecionar_regiao_returns_text():
+def test_selecionar_regiao_returns_empty_products():
     headers = get_admin_headers()
     pdf_bytes = _create_pdf()
     uploads = Path(__file__).resolve().parents[1] / "Backend" / "static" / "uploads" / "catalogs"
@@ -89,14 +89,15 @@ def test_selecionar_regiao_returns_text():
         db.refresh(record)
         file_id = record.id
 
-    payload = {"file_id": file_id, "page": 1, "x0": 90, "y0": 80, "x1": 200, "y1": 100}
+    payload = {"file_id": file_id, "page": 1, "bbox": [90, 80, 200, 100]}
     resp = client.post("/api/v1/produtos/selecionar-regiao/", json=payload, headers=headers)
     assert resp.status_code == 200
-    assert "Hello" in resp.json()["text"]
+    data = resp.json()
+    assert data["produtos"] == []
 
 
 def test_selecionar_regiao_file_not_found():
     headers = get_admin_headers()
-    payload = {"file_id": 999, "page": 1, "x0": 0, "y0": 0, "x1": 10, "y1": 10}
+    payload = {"file_id": 999, "page": 1, "bbox": [0, 0, 10, 10]}
     resp = client.post("/api/v1/produtos/selecionar-regiao/", json=payload, headers=headers)
     assert resp.status_code == 404


### PR DESCRIPTION
## Summary
- drop selecionarRegiaoPdf from frontend service and exports
- remove PDF region extraction endpoint and related schemas
- keep selecionarRegiao endpoint expecting `{file_id, page, bbox}`
- update docs
- update tests that referenced the removed function

## Testing
- `pytest -q` *(fails: email-validator and other packages missing)*

------
https://chatgpt.com/codex/tasks/task_e_684beb04cc58832fa57a561a6d3be8bc