### PR TITLE
Remove rows argument from finalize import

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -190,7 +190,6 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
         fileId,
         fornecedorId,
         mapping,
-        sampleRows,
         selectedType.id
       );
       setMessage('Processando...');

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -52,7 +52,6 @@ test('shows preview rows and sends productTypeId on confirm', async () => {
     'f1',
     1,
     expect.any(Object),
-    expect.any(Array),
     1,
   );
   expect(fornecedorService.getImportacaoStatus).toHaveBeenCalled();
@@ -94,7 +93,6 @@ test('confirms import even when fileId is missing', async () => {
     null,
     1,
     expect.any(Object),
-    expect.any(Array),
     1,
   );
 });

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -133,7 +133,6 @@ export const finalizarImportacaoCatalogo = async (
   fileId,
   fornecedorId,
   mapping = null,
-  rows = null,
   productTypeId = null,
 ) => {
   try {
@@ -141,9 +140,6 @@ export const finalizarImportacaoCatalogo = async (
     if (productTypeId) payload.product_type_id = productTypeId;
     if (mapping) {
       payload.mapping = mapping;
-    }
-    if (rows) {
-      payload.rows = rows;
     }
     const response = await apiClient.post(
       `/produtos/importar-catalogo-finalizar/${fileId}/`,


### PR DESCRIPTION
## Summary
- drop `rows` parameter from `finalizarImportacaoCatalogo`
- update `ImportCatalogWizard` call site
- fix tests for new signature

## Testing
- `./scripts/run_tests.sh` *(fails: 16 failed, 38 passed)*
- `cd Frontend/app && npm test`

------
https://chatgpt.com/codex/tasks/task_e_684beb117de8832f82efa0bea0162ea6