### PR TITLE
Add start_page option for PDF previews

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -659,6 +659,7 @@ async def importar_catalogo_preview(
     file: UploadFile = File(...),
     fornecedor_id: Optional[int] = Form(None),
     page_count: int = Query(1, ge=1, description="Número de páginas de preview do PDF"),
+    start_page: int = Query(1, ge=1, description="Página inicial do preview do PDF"),
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user),
 ):
@@ -682,7 +683,7 @@ async def importar_catalogo_preview(
 
     if ext == ".pdf":
         preview_images = await file_processing_service.pdf_pages_to_images(
-            content, max_pages=page_count
+            content, max_pages=page_count, start_page=start_page
         )
         preview["preview_images"] = preview_images
 

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -435,14 +435,24 @@ async def gerar_preview(conteudo_arquivo: bytes, ext: str, max_rows: int = 5) ->
     raise ValueError("Formato de arquivo não suportado para preview")
 
 
-async def pdf_pages_to_images(conteudo_arquivo: bytes, max_pages: int = 1) -> List[str]:
-    """Converte páginas de um PDF em strings base64 de imagens PNG."""
+async def pdf_pages_to_images(
+    conteudo_arquivo: bytes, max_pages: int = 1, start_page: int = 1
+) -> List[str]:
+    """Converte páginas de um PDF em strings base64 de imagens PNG.
+
+    :param conteudo_arquivo: conteúdo bruto do PDF
+    :param max_pages: quantidade de páginas a converter
+    :param start_page: página inicial (1-indexada)
+    """
     import base64
     from pdf2image import convert_from_bytes
 
     imagens_base64: List[str] = []
     try:
-        pages = convert_from_bytes(conteudo_arquivo, first_page=1, last_page=max_pages)
+        end_page = start_page + max_pages - 1
+        pages = convert_from_bytes(
+            conteudo_arquivo, first_page=start_page, last_page=end_page
+        )
         for img in pages:
             with io.BytesIO() as buf:
                 img.save(buf, format="PNG")

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -85,11 +85,15 @@ export const deleteFornecedor = async (fornecedorId) => {
   }
 };
 
-export const previewCatalogo = async (file, pageCount = 1) => {
+export const previewCatalogo = async (file, pageCount = 1, startPage = 1) => {
   try {
     const formData = new FormData();
     formData.append('file', file);
-    const response = await apiClient.post('/produtos/importar-catalogo-preview/', formData, { params: { page_count: pageCount } });
+    const response = await apiClient.post(
+      '/produtos/importar-catalogo-preview/',
+      formData,
+      { params: { page_count: pageCount, start_page: startPage } },
+    );
     const { file_id, headers, sample_rows, preview_images, num_pages, table_pages } = response.data;
     return {
       fileId: file_id,

--- a/README Backend.md
+++ b/README Backend.md
@@ -227,7 +227,7 @@
 * `update_product(product_id: int, update: ProdutoUpdate, db: Session)`: Atualiza produto.
 * `delete_product(product_id: int, db: Session)`: Remove produto.
 * `list_catalog_import_files(fornecedor_id: Optional[int], skip: int = 0, limit: int = 100, db: Session)`: Lista arquivos de importação de catálogos do usuário.
-* `importar_catalogo_preview(file: UploadFile, fornecedor_id: Optional[int], page_count: int, db: Session)`: Envia um arquivo e retorna cabeçalhos, amostras e `file_id` para processamento posterior.
+* `importar_catalogo_preview(file: UploadFile, fornecedor_id: Optional[int], page_count: int, start_page: int, db: Session)`: Envia um arquivo e retorna cabeçalhos, amostras e `file_id` para processamento posterior. O parâmetro `start_page` define a página inicial usada para gerar as imagens de preview do PDF.
 * `importar_catalogo_fornecedor(fornecedor_id: int, file: UploadFile, mapeamento_colunas_usuario: Optional[str], db: Session)`: Importa catálogo e cria produtos imediatamente.
 * `importar_catalogo_finalizar(file_id: int, product_type_id: int, fornecedor_id: int, mapping: Optional[dict], db: Session)`: Processa em background um arquivo já enviado.
 * `importar_catalogo_status(file_id: int, db: Session)`: Consulta o status do processamento do catálogo.

--- a/tests/test_pdf_pages_to_images.py
+++ b/tests/test_pdf_pages_to_images.py
@@ -10,16 +10,12 @@ except ImportError:  # pragma: no cover - install at runtime
     subprocess.check_call([sys.executable, "-m", "pip", "install", "reportlab"])
     from reportlab.pdfgen import canvas
 
-from Backend.services.file_processing_service import pdf_pages_to_images
 import pytest
 
+from Backend.services.file_processing_service import pdf_pages_to_images
 
-def _create_pdf(pages: int = 1):
-    buf = io.BytesIO()
-    c = canvas.Canvas(buf)
-    for i in range(pages):
-        c.drawString(100, 750, f"Page {i+1}")
-def _create_pdf(pages=1):
+
+def _create_pdf(pages: int = 1) -> bytes:
     buf = io.BytesIO()
     c = canvas.Canvas(buf)
     for i in range(pages):
@@ -42,8 +38,14 @@ async def test_pdf_pages_to_images_basic():
 
 @pytest.mark.asyncio
 async def test_pdf_pages_to_images_respects_max_pages():
-    pdf_bytes = _create_pdf(3)
-async def test_pdf_pages_respects_max_pages():
     pdf_bytes = _create_pdf(pages=3)
     images = await pdf_pages_to_images(pdf_bytes, max_pages=2)
     assert len(images) == 2
+
+
+@pytest.mark.asyncio
+async def test_pdf_pages_to_images_start_page():
+    pdf_bytes = _create_pdf(pages=5)
+    first_page_img = await pdf_pages_to_images(pdf_bytes, max_pages=1, start_page=1)
+    third_page_img = await pdf_pages_to_images(pdf_bytes, max_pages=1, start_page=3)
+    assert first_page_img[0] != third_page_img[0]


### PR DESCRIPTION
## Summary
- add `start_page` parameter to `pdf_pages_to_images`
- expose `start_page` in catalog preview endpoint
- allow frontend `previewCatalogo` to pass `start_page`
- document new option in backend README
- test PDF preview starting from different pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684beb193368832fa7989ac1580c27be