### PR TITLE
Fix ImportCatalogWizard syntax

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -211,10 +211,8 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
         fileId,
         fornecedorId,
         mapping,
-        selectedType.id
-        sampleRows,
         selectedType.id,
-        selectedPages
+        selectedPages,
       );
       setMessage('Processando...');
       setStep(4);
@@ -302,14 +300,6 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
               alt={`Página ${currentPreviewPage + 1}`}
               style={{ maxWidth: '100%', marginBottom: '1em' }}
             />
-            <button
-              type="button"
-              onClick={() => {
-                setRegionPage(currentPreviewPage + 1);
-                setIsRegionModalOpen(true);
-              }}
-              className="btn-small"
-            >
             <div style={{ position: 'relative', display: 'inline-block' }}>
               <input
                 type="checkbox"
@@ -323,7 +313,14 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
                 style={{ maxWidth: '100%', marginBottom: '1em' }}
               />
             </div>
-            <button type="button" onClick={() => setIsRegionModalOpen(true)} className="btn-small">
+            <button
+              type="button"
+              onClick={() => {
+                setRegionPage(currentPreviewPage + 1);
+                setIsRegionModalOpen(true);
+              }}
+              className="btn-small"
+            >
               Selecionar Região
             </button>
             {preview.tablePages && preview.tablePages.length > 0 && (

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -146,9 +146,6 @@ export const finalizarImportacaoCatalogo = async (
     if (mapping) {
       payload.mapping = mapping;
     }
-    if (rows) {
-      payload.rows = rows;
-    }
     if (pages) {
       payload.pages = Array.from(pages);
     }


### PR DESCRIPTION
## Summary
- remove stray button wrapper and fix call to finalizarImportacaoCatalogo
- clean up finalizarImportacaoCatalogo service implementation

## Testing
- `npm test --silent`
- `pytest -q` *(fails: ImportError: cannot import name '_ElementStringResult' from 'lxml.etree')*

------
https://chatgpt.com/codex/tasks/task_e_684bf625a5f0832fa4d18f806004cc2a