### PR TITLE
Refactor PDF preview logic

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -383,46 +383,16 @@ async def preview_arquivo_csv(conteudo_arquivo: bytes, max_rows: int = 5) -> Dic
 
 
 async def preview_arquivo_pdf(conteudo_arquivo: bytes, max_rows: int = 5) -> Dict[str, Any]:
-    """Tenta extrair cabeçalhos e linhas de amostra de tabelas em um PDF."""
+    """Retorna somente informações básicas do PDF sem tentar extrair dados."""
     try:
         with pdfplumber.open(io.BytesIO(conteudo_arquivo)) as pdf:
             num_pages = len(pdf.pages)
-            table_pages: List[int] = []
-            headers: List[str] = []
-            sample_rows: List[Dict[str, Any]] = []
-            for idx, page in enumerate(pdf.pages):
-                tables = page.extract_tables(
-                    table_settings={"vertical_strategy": "lines", "horizontal_strategy": "lines"}
-                )
-                if tables:
-                    table_pages.append(idx + 1)
-                    if not headers:
-                        primeira_tabela = tables[0]
-                        if len(primeira_tabela) < 2:
-                            continue
-                        headers_raw = primeira_tabela[0]
-                        headers = [
-                            str(h).strip() if h is not None else f"coluna_vazia_{h_idx}"
-                            for h_idx, h in enumerate(headers_raw)
-                        ]
-                        for row in primeira_tabela[1 : max_rows + 1]:
-                            if len(row) != len(headers):
-                                continue
-                            sample_rows.append({headers[i]: row[i] for i in range(len(headers))})
-            if headers:
-                return {
-                    "headers": headers,
-                    "sample_rows": sample_rows,
-                    "num_pages": num_pages,
-                    "table_pages": table_pages,
-                }
-            return {
-                "headers": [],
-                "sample_rows": [],
-                "num_pages": num_pages,
-                "table_pages": table_pages,
-                "message": "Nenhuma tabela encontrada no PDF",
-            }
+        return {
+            "headers": [],
+            "sample_rows": [],
+            "num_pages": num_pages,
+            "table_pages": [],
+        }
     except Exception as e:
         logger.error("Erro ao gerar preview de arquivo PDF: %s", e)
         return {"error": f"Falha ao ler arquivo PDF: {str(e)}"}

--- a/README Backend.md
+++ b/README Backend.md
@@ -231,7 +231,7 @@
 * `update_product(product_id: int, update: ProdutoUpdate, db: Session)`: Atualiza produto.
 * `delete_product(product_id: int, db: Session)`: Remove produto.
 * `list_catalog_import_files(fornecedor_id: Optional[int], skip: int = 0, limit: int = 100, db: Session)`: Lista arquivos de importação de catálogos do usuário.
-* `importar_catalogo_preview(file: UploadFile, fornecedor_id: Optional[int], page_count: int, start_page: int, db: Session)`: Envia um arquivo e retorna cabeçalhos, amostras e `file_id` para processamento posterior. O parâmetro `start_page` define a página inicial usada para gerar as imagens de preview do PDF.
+* `importar_catalogo_preview(file: UploadFile, fornecedor_id: Optional[int], page_count: int, start_page: int, db: Session)`: Envia um arquivo e retorna apenas o número de páginas e imagens para visualização, sem extrair cabeçalhos ou amostras. O parâmetro `start_page` define a página inicial usada para gerar as imagens de preview do PDF.
 * `importar_catalogo_fornecedor(fornecedor_id: int, file: UploadFile, mapeamento_colunas_usuario: Optional[str], db: Session)`: Importa catálogo e cria produtos imediatamente.
 * `importar_catalogo_finalizar(file_id: int, product_type_id: int, fornecedor_id: int, mapping: Optional[dict], db: Session)`: Processa em background um arquivo já enviado.
 * `importar_catalogo_status(file_id: int, db: Session)`: Consulta o status do processamento do catálogo.

--- a/tests/test_file_processing_service.py
+++ b/tests/test_file_processing_service.py
@@ -58,3 +58,5 @@ async def test_preview_arquivo_pdf_returns_page_info():
     res = await file_processing_service.preview_arquivo_pdf(pdf_bytes)
     assert res.get("num_pages") == 2
     assert res.get("table_pages") == [] or isinstance(res.get("table_pages"), list)
+    assert res.get("headers") == []
+    assert res.get("sample_rows") == []


### PR DESCRIPTION
## Summary
- simplify PDF preview to only return page count and images
- document new preview behavior
- adjust preview tests accordingly

## Testing
- `pytest tests/test_file_processing_service.py::test_preview_arquivo_pdf_returns_page_info -q` *(fails: ImportError: cannot import name '_ElementStringResult' from 'lxml.etree')*

------
https://chatgpt.com/codex/tasks/task_e_684c2b753a5c832fb2a35a6aed2cd601