### PR TITLE
Improve test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -455,16 +455,18 @@ Esses identificadores serão anexados a todos os produtos extraídos do arquivo.
 
 ## 🧪 Testes
 
-Os testes do backend dependem das bibliotecas listadas em `requirements-backend.txt`,
-que incluem pacotes como **SQLAlchemy** e as dependências `pytest` e
-`pytest-asyncio`. Instale-as com:
+Os testes do backend dependem **de todas** as bibliotecas listadas em
+`requirements-backend.txt`. Elas incluem desde o **SQLAlchemy** até o
+próprio `pytest` (e `pytest-asyncio`).
+Instale **todas** essas dependências antes de executar qualquer teste,
+com o comando:
 
 ```sh
 pip install -r requirements-backend.txt
 ```
 
 Em seguida execute o `pytest` manualmente ou utilize o script de conveniência abaixo,
-que realiza a instalação das dependências e roda os testes:
+que já realiza essa instalação automaticamente antes de rodar os testes:
 
 ```sh
 ./scripts/run_tests.sh

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,7 +1,6 @@
 #!/bin/sh
 set -e
 pip install -r requirements-backend.txt
-pip install pytest pytest-asyncio
 export FIRST_SUPERUSER_EMAIL="admin@example.com"
 export FIRST_SUPERUSER_PASSWORD="adminpass"
 export ADMIN_EMAIL="admin@example.com"


### PR DESCRIPTION
## Summary
- clarify that all packages from `requirements-backend.txt` must be installed before running tests
- simplify `run_tests.sh` to install dependencies once

## Testing
- `./scripts/run_tests.sh` *(fails: 13 failed, 43 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684c33aad168832fb60268b45dd4d3b7