### PR TITLE
Add start page option on catalog import wizard

### DIFF
--- a/README Frontend.md
+++ b/README Frontend.md
@@ -80,7 +80,7 @@
 ## Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
 
 * `ImportCatalogWizard({ isOpen, onClose, fornecedorId })`: Assistente em três passos para importar catálogos.
-  1. **Pré-visualização e seleção do tipo** – upload do arquivo, exibição de amostras e escolha do tipo de produto.
+  1. **Pré-visualização e seleção do tipo** – upload do arquivo, exibição de amostras e escolha do tipo de produto. Agora é possível definir a **Página inicial** para filtrar as páginas a serem importadas.
   2. **Mapeamento de colunas** – associa colunas da planilha a campos padrão e atributos dinâmicos. Permite criar um novo tipo de produto caso não exista.
   3. **Confirmação** – revisão final e importação.
 O wizard mostra linhas de amostra e miniaturas antes do envio definitivo, garantindo que as colunas estejam corretas.


### PR DESCRIPTION
## Summary
- add `startPage` state for ImportCatalogWizard
- select pages starting from the chosen page
- expose numeric input "Página inicial" in preview step
- document the new option in README

## Testing
- `npm run lint` *(fails: numerous pre-existing lint errors)*
- `npm test`
- `pytest Backend/tests`

------
https://chatgpt.com/codex/tasks/task_e_684c389c43e4832f8b3024238c66f5b3