### PR TITLE
Fix JSX table closing issue

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -387,13 +387,6 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
             )}
           </div>
         )}
-        {sampleRows.length > 0 && (
-          <table className="preview-table">
-          {preview.tablePages && preview.tablePages.length > 0 && (
-            <p>Páginas com tabelas: {preview.tablePages.join(', ')}</p>
-          )}
-        </div>
-      )}
       {preview.numPages > 1 && (
         <div className="form-group">
           <label htmlFor="start-page-input">Página inicial:</label>


### PR DESCRIPTION
## Summary
- fix invalid JSX in ImportCatalogWizard

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_684c3c444be8832f9f77092e44798851