### PR TITLE
Add POPPLER_PATH support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,6 +63,8 @@ FACEBOOK_REDIRECT_URI="http://localhost:8000/api/v1/auth/facebook/callback"
 FRONTEND_URL="http://localhost:5173"
 VITE_API_BASE_URL="http://localhost:8000/api/v1"
 UPLOAD_DIRECTORY="static/uploads"
+# Path to poppler binaries (required on Windows for PDF preview)
+POPPLER_PATH=""
 OPENAI_API_KEY=""
 GOOGLE_GEMINI_API_KEY=""
 GOOGLE_CSE_API_KEY=""

--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -85,6 +85,7 @@ class Settings(BaseSettings):
 
     FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:5173")
     UPLOAD_DIRECTORY: str = os.getenv("UPLOAD_DIRECTORY", "static/uploads")
+    POPPLER_PATH: Optional[str] = os.getenv("POPPLER_PATH")
 
     OPENAI_API_KEY: Optional[str] = os.getenv("OPENAI_API_KEY")
     GOOGLE_GEMINI_API_KEY: Optional[str] = os.getenv("GOOGLE_GEMINI_API_KEY")

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -427,8 +427,11 @@ async def pdf_pages_to_images(
     imagens_base64: List[str] = []
     try:
         end_page = start_page + max_pages - 1
+        kwargs = {}
+        if settings.POPPLER_PATH:
+            kwargs["poppler_path"] = settings.POPPLER_PATH
         pages = convert_from_bytes(
-            conteudo_arquivo, first_page=start_page, last_page=end_page
+            conteudo_arquivo, first_page=start_page, last_page=end_page, **kwargs
         )
         for img in pages:
             with io.BytesIO() as buf:

--- a/README.md
+++ b/README.md
@@ -274,6 +274,8 @@ Principais variáveis obrigatórias:
 - `ADMIN_EMAIL` e `ADMIN_PASSWORD`
 - `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM` e `MAIL_SERVER`
 
+Em ambientes Windows, defina também `POPPLER_PATH` apontando para os binários do Poppler para que a conversão de PDFs funcione.
+
 
 ### 6. **Testes**
 
@@ -347,6 +349,8 @@ RAISE_ON_MISSING_EMAIL_CONFIG=True  # gera erro se a configuração de email est
 
 # Frontend
 FRONTEND_URL="http://localhost:5173"
+# Path to poppler binaries (required on Windows)
+POPPLER_PATH=""
 
 # OAuth2 (Google/Facebook)
 GOOGLE_CLIENT_ID="..."


### PR DESCRIPTION
## Summary
- add optional `POPPLER_PATH` env var to settings
- use that path when converting PDF pages to images
- document variable in `.env.example` and README

## Testing
- `scripts/run_tests.sh` *(fails: 18 failed)*

------
https://chatgpt.com/codex/tasks/task_e_684c3cc410ac832fb2b453c8feae66a4