### PR TITLE
Add Windows poppler instructions

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -5,6 +5,7 @@ import csv
 import io  # Para ler o conteúdo do arquivo em memória
 import chardet
 import base64
+import os
 from typing import List, Dict, Any, Union, Optional
 from pathlib import Path
 from uuid import uuid4
@@ -420,15 +421,23 @@ async def pdf_pages_to_images(
     :param conteudo_arquivo: conteúdo bruto do PDF
     :param max_pages: quantidade de páginas a converter
     :param start_page: página inicial (1-indexada)
+    
+    Se o executável ``pdftoppm`` não estiver no ``PATH``, defina a variável de
+    ambiente ``POPPLER_PATH`` apontando para o diretório onde ele está
+    localizado.
     """
     import base64
     from pdf2image import convert_from_bytes
 
     imagens_base64: List[str] = []
     try:
+        poppler_dir = os.getenv("POPPLER_PATH")
         end_page = start_page + max_pages - 1
         pages = convert_from_bytes(
-            conteudo_arquivo, first_page=start_page, last_page=end_page
+            conteudo_arquivo,
+            first_page=start_page,
+            last_page=end_page,
+            poppler_path=poppler_dir,
         )
         for img in pages:
             with io.BytesIO() as buf:

--- a/README Backend.md
+++ b/README Backend.md
@@ -26,6 +26,11 @@
 
 * Para gerar previews de PDF é necessário instalar o pacote `poppler-utils` (ex.: `apt install poppler-utils`). Sem ele o backend não conseguirá converter PDFs em imagens, e o preview de PDF não será gerado.
 
+### Poppler no Windows
+
+Para usuários do Windows, instale o Poppler via Chocolatey (`choco install poppler`) ou baixe os binários em <https://github.com/oschwartz10612/poppler-windows/releases>.
+Após a instalação, adicione o diretório que contém `pdftoppm.exe` ao `PATH` ou defina a variável `POPPLER_PATH`. A função `pdf_pages_to_images` lê essa variável se o executável não estiver no `PATH`.
+
 ---
 
 ## Backend/**init**.py

--- a/README Frontend.md
+++ b/README Frontend.md
@@ -9,6 +9,11 @@
 
 * A geração de previews de PDF depende do pacote `poppler-utils` instalado no sistema (por exemplo, `apt install poppler-utils`). Sem ele o backend não consegue converter PDFs em imagens, e o frontend não exibirá a pré-visualização do arquivo.
 
+### Poppler no Windows
+
+Em ambientes Windows é possível instalar o Poppler pelo Chocolatey (`choco install poppler`) ou baixar os binários de <https://github.com/oschwartz10612/poppler-windows/releases>.
+Após instalar, inclua o diretório com `pdftoppm.exe` no `PATH` ou defina `POPPLER_PATH`. A função `pdf_pages_to_images` usa essa variável quando o executável não está no `PATH`.
+
 ## Frontend/app/eslint.config.js
 
 * **Configuração**: Arquivo de configuração do ESLint para garantir o padrão e a qualidade do código JavaScript/React.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,14 @@ CatalogAI-0525-Dev/
 * Chaves de API: OpenAI, Google Search, serviço de e-mail (SMTP)
 * Copie o arquivo `.env.example` para `.env` e ajuste os valores
 
+#### Poppler no Windows
+
+Para Windows, instale o Poppler usando o Chocolatey (`choco install poppler`) ou
+baixe os binários em <https://github.com/oschwartz10612/poppler-windows/releases>.
+Inclua o diretório que contém `pdftoppm.exe` no `PATH` ou defina a variável
+`POPPLER_PATH` apontando para esse diretório. A função `pdf_pages_to_images`
+usa essa variável para localizar o executável caso ele não esteja no `PATH`.
+
 ---
 
 ### 2. **Clonar o Projeto**


### PR DESCRIPTION
## Summary
- document how to install Poppler on Windows and update PDF utility docs
- allow `pdf_pages_to_images` to read `POPPLER_PATH`

## Testing
- `pip install -r requirements-full.txt`
- `pytest -q` *(fails: ImportError: cannot import name '_ElementStringResult' from 'lxml.etree')*

------
https://chatgpt.com/codex/tasks/task_e_684c3ccb2750832fbccc053d7dd20886