### PR TITLE
Fix pdf pages conversion bug

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -431,17 +431,16 @@ async def pdf_pages_to_images(
 
     imagens_base64: List[str] = []
     try:
-        poppler_dir = os.getenv("POPPLER_PATH")
+        poppler_dir = settings.POPPLER_PATH or os.getenv("POPPLER_PATH")
         end_page = start_page + max_pages - 1
         kwargs = {}
-        if settings.POPPLER_PATH:
-            kwargs["poppler_path"] = settings.POPPLER_PATH
+        if poppler_dir:
+            kwargs["poppler_path"] = poppler_dir
         pages = convert_from_bytes(
             conteudo_arquivo,
             first_page=start_page,
             last_page=end_page,
-            poppler_path=poppler_dir,
-            conteudo_arquivo, first_page=start_page, last_page=end_page, **kwargs
+            **kwargs,
         )
         for img in pages:
             with io.BytesIO() as buf:


### PR DESCRIPTION
## Summary
- fix positional argument bug in `pdf_pages_to_images`

## Testing
- `pytest -q` *(fails: 13 failed, 43 passed)*

------
https://chatgpt.com/codex/tasks/task_e_684c45f358e8832fb2d0b1e820cf83ad