### PR TITLE
Enhance PDF preview API

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -325,13 +325,10 @@ class ProdutoBatchDeleteRequest(BaseModel):
 
 class ImportPreviewResponse(BaseModel):
     file_id: int
-    headers: List[str]
-    sample_rows: List[Dict[str, Any]]
-    preview_images: Optional[List[str]] = None
-    num_pages: Optional[int] = None
-    table_pages: Optional[List[int]] = None
-    message: Optional[str] = None
-    error: Optional[str] = None
+    num_pages: int
+    table_pages: List[int]
+    sample_rows: Dict[int, str]
+    preview_images: List[Dict[str, Any]]
 
 
 class ImportCatalogoResponse(BaseModel):

--- a/tests/test_catalog_import_file.py
+++ b/tests/test_catalog_import_file.py
@@ -290,9 +290,9 @@ def test_preview_pdf_respects_page_count():
     with TestingSessionLocal() as db:
         fornec_id = db.query(models.Fornecedor.id).first()[0]
     resp = client.post(
-        "/api/v1/produtos/importar-catalogo-preview/?page_count=2",
+        "/api/v1/produtos/importar-catalogo-preview/",
         files=files,
-        data={"fornecedor_id": fornec_id},
+        data={"fornecedor_id": fornec_id, "page_count": 2},
         headers=headers,
     )
     file_id = resp.json()["file_id"]
@@ -318,6 +318,7 @@ def test_preview_pdf_respects_page_count():
     data = resp.json()
     assert "preview_images" in data
     assert len(data["preview_images"]) == 2
+    assert all("page" in img for img in data["preview_images"])
 
 
 def test_region_selection_endpoint():

--- a/tests/test_file_processing_service.py
+++ b/tests/test_file_processing_service.py
@@ -55,8 +55,8 @@ async def test_preview_arquivo_pdf_returns_page_info():
     c.save()
     pdf_bytes = buf.getvalue()
 
-    res = await file_processing_service.preview_arquivo_pdf(pdf_bytes)
+    res = await file_processing_service.preview_arquivo_pdf(pdf_bytes, ".pdf")
     assert res.get("num_pages") == 2
-    assert res.get("table_pages") == [] or isinstance(res.get("table_pages"), list)
-    assert res.get("headers") == []
-    assert res.get("sample_rows") == []
+    assert isinstance(res.get("table_pages"), list)
+    assert len(res["preview_images"]) == 2
+    assert 1 in res["sample_rows"]

--- a/tests/test_preview_pdf.py
+++ b/tests/test_preview_pdf.py
@@ -1,0 +1,48 @@
+import io
+import subprocess
+import sys
+
+import pytest
+
+try:
+    from reportlab.pdfgen import canvas
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, PageBreak, Paragraph
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import getSampleStyleSheet
+except ImportError:
+    subprocess.check_call([sys.executable, "-m", "pip", "install", "reportlab"])
+    from reportlab.pdfgen import canvas
+    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, PageBreak, Paragraph
+    from reportlab.lib import colors
+    from reportlab.lib.pagesizes import letter
+    from reportlab.lib.styles import getSampleStyleSheet
+
+from Backend.services.file_processing_service import preview_arquivo_pdf
+
+
+def _create_pdf_with_table():
+    buf = io.BytesIO()
+    doc = SimpleDocTemplate(buf, pagesize=letter)
+    styles = getSampleStyleSheet()
+    story = [Paragraph("Page 1 text", styles["Normal"]), PageBreak()]
+    table = Table([["A", "B"], ["1", "2"]])
+    table.setStyle(TableStyle([('GRID', (0, 0), (-1, -1), 1, colors.black)]))
+    story.append(table)
+    story.append(PageBreak())
+    story.append(Paragraph("Last page", styles["Normal"]))
+    doc.build(story)
+    buf.seek(0)
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_preview_pdf_extracts_all():
+    pdf_bytes = _create_pdf_with_table()
+    res = await preview_arquivo_pdf(pdf_bytes, ".pdf")
+    assert res["num_pages"] == 3
+    assert 2 in res["table_pages"]
+    assert len(res["preview_images"]) == 3
+    assert {img["page"] for img in res["preview_images"]} == {1, 2, 3}
+    assert len(res["sample_rows"]) == 3
+    assert all(isinstance(v, str) for v in res["sample_rows"].values())


### PR DESCRIPTION
## Summary
- update `preview_arquivo_pdf` to generate page thumbnails, text snippets and detect tables
- adjust router to accept `start_page` and `page_count` via form fields
- update `ImportPreviewResponse` schema for new preview format
- update existing tests and add new `test_preview_pdf`

## Testing
- `pip install -q -r requirements-backend.txt`
- `pytest -q` *(fails: test suite errors)*

------
https://chatgpt.com/codex/tasks/task_e_684c4f29b0a0832f981bb9529145bd4a