### PR TITLE
Forçar Poppler path e normalizar preview response

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -324,11 +324,11 @@ class ProdutoBatchDeleteRequest(BaseModel):
 
 
 class ImportPreviewResponse(BaseModel):
-    file_id: int
     num_pages: int
     table_pages: List[int]
     sample_rows: Dict[int, str]
     preview_images: List[Dict[str, Any]]
+    error: Optional[str] = None
 
 
 class ImportCatalogoResponse(BaseModel):


### PR DESCRIPTION
## Summary
- define POPPLER_PATH constante e use na geração de miniaturas
- simplificar endpoint de preview e incluir tratamento de erro
- atualizar schema ImportPreviewResponse com campo `error`

## Testing
- `python run_backend.py --port 8001 --reload False` *(fails: address already in use)*
- `python run_backend.py --port 8001 --reload False` *(server started; killed)*
- `python run_backend.py --port 8001 --reload False` *(server started)*
- `curl` request to preview endpoint returned 401


------
https://chatgpt.com/codex/tasks/task_e_684c5abc36f4832f851ced574971ff10