### PR TITLE
Refactor poppler path handling

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -7,9 +7,6 @@ import chardet
 import base64
 import os
 from pdf2image import convert_from_bytes
-import io, base64
-# Ajuste para o seu ambiente:
-POPPLER_PATH = r"/usr/bin"
 from typing import List, Dict, Any, Union, Optional
 from pathlib import Path
 from uuid import uuid4
@@ -463,12 +460,15 @@ async def pdf_pages_to_images(
     """
     imagens_base64: List[str] = []
     try:
+        poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
+        kwargs = {"poppler_path": poppler_dir} if poppler_dir else {}
+
         images = convert_from_bytes(
             conteudo_arquivo,
-            poppler_path=POPPLER_PATH,
             first_page=start_page,
             last_page=start_page + max_pages - 1,
             fmt="png",
+            **kwargs,
         )
         for img in images:
             with io.BytesIO() as buf:


### PR DESCRIPTION
## Summary
- refactor `pdf_pages_to_images` to mirror preview behaviour for poppler
- remove unused `POPPLER_PATH` constant

## Testing
- `pdftoppm -h | head`
- `pytest tests/test_pdf_pages_to_images.py tests/test_file_processing_service.py::test_pdf_pages_to_images_returns_base64 -q`

------
https://chatgpt.com/codex/tasks/task_e_684c7965c0f8832fb182a0a8c907b396