### PR TITLE
Fix previewCatalogo form data

### DIFF
--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -89,10 +89,11 @@ export const previewCatalogo = async (file, pageCount = 1, startPage = 1) => {
   try {
     const formData = new FormData();
     formData.append('file', file);
+    formData.append('page_count', pageCount);
+    formData.append('start_page', startPage);
     const response = await apiClient.post(
       '/produtos/importar-catalogo-preview/',
       formData,
-      { params: { page_count: pageCount, start_page: startPage } },
     );
     const { file_id, headers, sample_rows, preview_images, num_pages, table_pages } = response.data;
     return {


### PR DESCRIPTION
## Summary
- update fornecedorService previewCatalogo to include `start_page` and `page_count` in the FormData

## Testing
- `pytest -q tests/test_catalog_import_file.py` *(fails: Backend.sche...)*

------
https://chatgpt.com/codex/tasks/task_e_685019a58294832f8316640a3f4d9846