### PR TITLE
Add file_id to catalog preview response

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -329,6 +329,7 @@ class ImportPreviewResponse(BaseModel):
     sample_rows: Dict[int, str]
     preview_images: List[Dict[str, Any]]
     error: Optional[str] = None
+    file_id: Optional[int] = None
 
 
 class ImportCatalogoResponse(BaseModel):


### PR DESCRIPTION
## Summary
- extend `ImportPreviewResponse` with optional `file_id`
- save uploaded catalog when generating preview and include `file_id` in response

## Testing
- `pytest tests/test_catalog_import_file.py::test_preview_saves_file_and_record -q`
- `pytest -q` *(fails: 22 failed, 35 passed, 26 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_685019aa7d08832fb1f5107ff01a4600