### PR TITLE
Add fornecedor_id support for catalog preview

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -324,6 +324,7 @@ class ProdutoBatchDeleteRequest(BaseModel):
 
 
 class ImportPreviewResponse(BaseModel):
+    file_id: int
     num_pages: int
     table_pages: List[int]
     sample_rows: Dict[int, str]

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -105,9 +105,16 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       let data = await fornecedorService.previewCatalogo(
         file,
         INITIAL_PREVIEW_PAGE_COUNT,
+        1,
+        fornecedorId,
       );
       if (data.numPages && data.numPages > INITIAL_PREVIEW_PAGE_COUNT) {
-        data = await fornecedorService.previewCatalogo(file, data.numPages);
+        data = await fornecedorService.previewCatalogo(
+          file,
+          data.numPages,
+          1,
+          fornecedorId,
+        );
       }
       setPreview({
         headers: data.headers,

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -94,13 +94,14 @@ export const previewCatalogo = async (
   try {
     const formData = new FormData();
     formData.append('file', file);
+    formData.append('page_count', pageCount);
+    formData.append('start_page', startPage);
     if (fornecedorId) {
       formData.append('fornecedor_id', fornecedorId);
     }
     const response = await apiClient.post(
       '/produtos/importar-catalogo-preview/',
       formData,
-      { params: { page_count: pageCount, start_page: startPage } },
     );
     const { file_id, headers, sample_rows, preview_images, num_pages, table_pages } = response.data;
     return {

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -85,10 +85,18 @@ export const deleteFornecedor = async (fornecedorId) => {
   }
 };
 
-export const previewCatalogo = async (file, pageCount = 1, startPage = 1) => {
+export const previewCatalogo = async (
+  file,
+  pageCount = 1,
+  startPage = 1,
+  fornecedorId = null,
+) => {
   try {
     const formData = new FormData();
     formData.append('file', file);
+    if (fornecedorId) {
+      formData.append('fornecedor_id', fornecedorId);
+    }
     const response = await apiClient.post(
       '/produtos/importar-catalogo-preview/',
       formData,


### PR DESCRIPTION
## Summary
- allow optional `fornecedor_id` in preview endpoint
- save supplier id with `CatalogImportFile`
- expose new parameter in frontend service and wizard
- add file_id to `ImportPreviewResponse`

## Testing
- `pytest tests/test_catalog_import_file.py::test_preview_saves_file_and_record -q`

------
https://chatgpt.com/codex/tasks/task_e_685019b7d758832fbb475741940799ea