### PR TITLE
Fix catalog preview parameter duplication

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -330,7 +330,6 @@ class ImportPreviewResponse(BaseModel):
     sample_rows: Dict[int, str]
     preview_images: List[Dict[str, Any]]
     error: Optional[str] = None
-    file_id: Optional[int] = None
 
 
 class ImportCatalogoResponse(BaseModel):


### PR DESCRIPTION
## Summary
- fix duplicated fornecedor_id argument in `importar_catalogo_preview`
- remove duplicated `file_id` attribute in `ImportPreviewResponse`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, sqlalchemy, jose, httpx)*

------
https://chatgpt.com/codex/tasks/task_e_68502071c810832fa631cb68d183f3e2