### PR TITLE
Fix PDF.js import path

### DIFF
--- a/Frontend/app/src/components/common/PdfRegionSelector.jsx
+++ b/Frontend/app/src/components/common/PdfRegionSelector.jsx
@@ -1,10 +1,12 @@
 import React, { useRef, useEffect, useState } from 'react';
-import * as pdfjs from 'pdfjs-dist/build/pdf';
+// Using the "legacy" build of pdfjs works better with bundlers such as Vite
+import * as pdfjs from 'pdfjs-dist/legacy/build/pdf';
 
 if (pdfjs.GlobalWorkerOptions) {
   // Use bundled worker for both browser and test environments
   // eslint-disable-next-line global-require
-  pdfjs.GlobalWorkerOptions.workerSrc = require('pdfjs-dist/build/pdf.worker.js');
+  // The worker file also lives in the legacy folder
+  pdfjs.GlobalWorkerOptions.workerSrc = require('pdfjs-dist/legacy/build/pdf.worker.js');
 }
 
 function PdfRegionSelector({ file, onSelect, initialPage = 1 }) {

--- a/Frontend/app/src/components/common/__tests__/PdfRegionSelector.test.jsx
+++ b/Frontend/app/src/components/common/__tests__/PdfRegionSelector.test.jsx
@@ -3,7 +3,8 @@ import { act } from 'react-dom/test-utils';
 import '@testing-library/jest-dom';
 import PdfRegionSelector from '../PdfRegionSelector.jsx';
 
-jest.mock('pdfjs-dist/build/pdf', () => ({
+// Mock the legacy build used in the component
+jest.mock('pdfjs-dist/legacy/build/pdf', () => ({
   GlobalWorkerOptions: { workerSrc: '' },
   getDocument: jest.fn(() => ({
     promise: Promise.resolve({


### PR DESCRIPTION
## Summary
- resolve pdfjs import path for Vite bundling
- update tests to use the legacy pdfjs build

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68503fabe3a4832f8f9e76a352d11898