### PR TITLE
Fix pdfjs import path for PdfRegionSelector

### DIFF
--- a/Frontend/app/src/components/common/PdfRegionSelector.jsx
+++ b/Frontend/app/src/components/common/PdfRegionSelector.jsx
@@ -1,10 +1,11 @@
 import React, { useRef, useEffect, useState } from 'react';
-import * as pdfjs from 'pdfjs-dist/build/pdf';
+// Use the legacy build of pdfjs which provides an ES module compatible bundle.
+import * as pdfjs from 'pdfjs-dist/legacy/build/pdf';
 
 if (pdfjs.GlobalWorkerOptions) {
   // Use bundled worker for both browser and test environments
   // eslint-disable-next-line global-require
-  pdfjs.GlobalWorkerOptions.workerSrc = require('pdfjs-dist/build/pdf.worker.js');
+  pdfjs.GlobalWorkerOptions.workerSrc = require('pdfjs-dist/legacy/build/pdf.worker.js');
 }
 
 function PdfRegionSelector({ file, onSelect, initialPage = 1 }) {

--- a/Frontend/app/src/components/common/__tests__/PdfRegionSelector.test.jsx
+++ b/Frontend/app/src/components/common/__tests__/PdfRegionSelector.test.jsx
@@ -3,7 +3,7 @@ import { act } from 'react-dom/test-utils';
 import '@testing-library/jest-dom';
 import PdfRegionSelector from '../PdfRegionSelector.jsx';
 
-jest.mock('pdfjs-dist/build/pdf', () => ({
+jest.mock('pdfjs-dist/legacy/build/pdf', () => ({
   GlobalWorkerOptions: { workerSrc: '' },
   getDocument: jest.fn(() => ({
     promise: Promise.resolve({


### PR DESCRIPTION
## Summary
- update PdfRegionSelector to use pdfjs-dist legacy build
- update tests to mock the new import path

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850517ea8f4832fae584c2630ca9b02