### PR TITLE
Add column mapping modal

### DIFF
--- a/Frontend/app/src/components/common/ColumnMappingModal.jsx
+++ b/Frontend/app/src/components/common/ColumnMappingModal.jsx
@@ -1,0 +1,85 @@
+import React, { useState, useEffect } from 'react';
+import Modal from './Modal.jsx';
+
+function ColumnMappingModal({
+  isOpen,
+  onClose,
+  headers = [],
+  rows = [],
+  fieldOptions = [],
+  onConfirm,
+}) {
+  const [mapping, setMapping] = useState({});
+
+  useEffect(() => {
+    if (isOpen) setMapping({});
+  }, [isOpen]);
+
+  const handleChange = (header, value) => {
+    setMapping((prev) => ({ ...prev, [header]: value }));
+  };
+
+  const handleConfirm = () => {
+    if (onConfirm) onConfirm(mapping);
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title="Mapear Colunas">
+      <table className="mapping-table">
+        <thead>
+          <tr>
+            <th>Coluna</th>
+            <th>Campo</th>
+          </tr>
+        </thead>
+        <tbody>
+          {headers.map((h) => (
+            <tr key={h}>
+              <td>{h}</td>
+              <td>
+                <select
+                  value={mapping[h] || ''}
+                  onChange={(e) => handleChange(h, e.target.value)}
+                >
+                  <option value="">Ignorar</option>
+                  {fieldOptions.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {rows.length > 0 && (
+        <table className="preview-table">
+          <thead>
+            <tr>
+              {headers.map((h) => (
+                <th key={h}>{h}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((row, idx) => (
+              <tr key={idx}>
+                {headers.map((h) => (
+                  <td key={h}>{row[h]}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+      <div className="modal-actions">
+        <button onClick={handleConfirm}>Confirmar mapeamento</button>
+      </div>
+    </Modal>
+  );
+}
+
+export default ColumnMappingModal;

--- a/Frontend/app/src/components/common/__tests__/ColumnMappingModal.test.jsx
+++ b/Frontend/app/src/components/common/__tests__/ColumnMappingModal.test.jsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import ColumnMappingModal from '../ColumnMappingModal.jsx';
+
+test('calls onConfirm with mapping object', async () => {
+  const headers = ['Coluna A', 'Coluna B'];
+  const rows = [
+    { 'Coluna A': 'a1', 'Coluna B': 'b1' },
+    { 'Coluna A': 'a2', 'Coluna B': 'b2' },
+  ];
+  const options = [
+    { value: 'nome_produto', label: 'Nome Produto' },
+    { value: 'preco', label: 'Preço' },
+  ];
+  const onConfirm = jest.fn();
+  render(
+    <ColumnMappingModal
+      isOpen={true}
+      onClose={() => {}}
+      headers={headers}
+      rows={rows}
+      fieldOptions={options}
+      onConfirm={onConfirm}
+    />,
+  );
+
+  await userEvent.selectOptions(
+    screen.getAllByRole('combobox')[0],
+    'nome_produto',
+  );
+  await userEvent.selectOptions(screen.getAllByRole('combobox')[1], 'preco');
+
+  await userEvent.click(screen.getByText('Confirmar mapeamento'));
+
+  expect(onConfirm).toHaveBeenCalledWith({
+    'Coluna A': 'nome_produto',
+    'Coluna B': 'preco',
+  });
+});


### PR DESCRIPTION
## Summary
- add ColumnMappingModal component for mapping extracted columns to fields
- test ColumnMappingModal behavior

## Testing
- `./scripts/run_tests.sh` *(fails: KeyError and other test failures)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685095f02fc4832f94a2792c31b5a1f0