### PR TITLE
Add catalog import progress API and frontend updates

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -977,6 +977,32 @@ def importar_catalogo_status(
 
 
 @router.get(
+    "/importar-catalogo-status/{file_id}",
+    response_model=schemas.CatalogImportStatus,
+    include_in_schema=False,
+)
+def importar_catalogo_status_simple(
+    file_id: int,
+    db: Session = Depends(database.get_db),
+    current_user: models.User = Depends(auth_utils.get_current_active_user),
+):
+    """Versão simplificada do status de importação."""
+    record = (
+        db.query(models.CatalogImportFile)
+        .filter_by(id=file_id, user_id=current_user.id)
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="Arquivo não encontrado")
+    status = "DONE" if record.status == "IMPORTED" else "PROCESSING"
+    return {
+        "status": status,
+        "pages_total": record.total_pages or 0,
+        "pages_processed": record.pages_processed,
+    }
+
+
+@router.get(
     "/importar-catalogo-result/{file_id}/",
     response_model=schemas.CatalogImportResult,
 )

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -1,6 +1,6 @@
 # Backend/schemas.py
 
-from typing import List, Optional, Dict, Any, Union
+from typing import List, Optional, Dict, Any, Union, Literal
 from pydantic import BaseModel, EmailStr, HttpUrl, Field, field_validator, model_validator
 from datetime import datetime
 import json # Para validação de JSON string
@@ -430,6 +430,14 @@ class CatalogImportFileResponse(CatalogImportFileBase):
 
     class Config:
         from_attributes = True
+
+
+class CatalogImportStatus(BaseModel):
+    """Status simplificado de importação de catálogo."""
+
+    status: Literal["PROCESSING", "DONE"]
+    pages_total: int
+    pages_processed: int
 
 class CatalogImportFilePage(BaseModel):
     items: List[CatalogImportFileResponse]

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -28,6 +28,8 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   const [productTypeId, setProductTypeId] = useState('');
   const [loading, setLoading] = useState(false);
   const [message, setMessage] = useState('');
+  const [pagesTotal, setPagesTotal] = useState(0);
+  const [pagesProcessed, setPagesProcessed] = useState(0);
   const [selectedType, setSelectedType] = useState(null);
   const [isNewTypeModalOpen, setIsNewTypeModalOpen] = useState(false);
   const [newTypeName, setNewTypeName] = useState('');
@@ -60,6 +62,8 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       setMapping({});
       setProductTypeId('');
       setMessage('');
+      setPagesTotal(0);
+      setPagesProcessed(0);
       setLoading(false);
       setSelectedType(null);
       setNewTypeName('');
@@ -278,15 +282,17 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       setStep(4);
       const checkStatus = async () => {
         try {
-          const { status, pages_processed, total_pages } = await fornecedorService.getImportacaoStatus(fileId);
-          if (status === 'IMPORTED') {
+          const { status, pages_total, pages_processed } = await fornecedorService.getImportacaoStatus(fileId);
+          setPagesTotal(pages_total);
+          setPagesProcessed(pages_processed);
+          if (status === 'DONE') {
             const result = await fornecedorService.getImportacaoResult(fileId);
             setResultSummary(result);
             setMessage('Importação concluída');
             setStep(5);
             clearInterval(intervalRef.current);
-          } else if (status === 'PROCESSING' && total_pages) {
-            setMessage(`${pages_processed} de ${total_pages}`);
+          } else if (status === 'PROCESSING' && pages_total) {
+            setMessage(`${pages_processed} de ${pages_total}`);
           } else if (status !== 'PROCESSING') {
             setMessage('Falha na importação');
             clearInterval(intervalRef.current);
@@ -524,6 +530,14 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
 const renderStep4 = () => (
   <div>
     <p>{message || 'Processo finalizado.'}</p>
+    {pagesTotal > 0 && (
+      <>
+        <progress value={pagesProcessed} max={pagesTotal} style={{ width: '100%' }} />
+        <p>
+          {pagesProcessed} / {pagesTotal}
+        </p>
+      </>
+    )}
     <button onClick={onClose}>Fechar</button>
   </div>
 );

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -229,7 +229,9 @@ export const reprocessCatalogFile = async (fileId) => {
 
 export const getImportacaoStatus = async (fileId) => {
   try {
-    const response = await apiClient.get(`/produtos/importar-catalogo-status/${fileId}/`);
+    const response = await apiClient.get(
+      `/produtos/importar-catalogo-status/${fileId}`
+    );
     return response.data;
   } catch (error) {
     console.error(`Erro ao consultar status do arquivo ${fileId}:`, JSON.stringify(error.response?.data || error.message || error));


### PR DESCRIPTION
## Summary
- provide simplified `CatalogImportStatus` schema
- add new GET `/produtos/importar-catalogo-status/{file_id}` endpoint
- adjust service call and wizard UI to show real progress

## Testing
- `./scripts/run_tests.sh` *(fails: Unable to get page count. Is poppler installed?)*

------
https://chatgpt.com/codex/tasks/task_e_6850960a9814832f9e247d1faa2844a0