### PR TITLE
Optimize PDF preview

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -6,6 +6,7 @@ import io  # Para ler o conteúdo do arquivo em memória
 import chardet
 import base64
 import os
+import asyncio
 from pdf2image import convert_from_bytes
 from typing import List, Dict, Any, Union, Optional
 from pathlib import Path
@@ -66,6 +67,7 @@ def delete_catalog_file(stored_filename: str) -> None:
     except Exception:
         logger.exception("Erro ao remover arquivo %s", stored_filename)
 
+
 def _limpar_valor_extraido(valor: Any) -> Optional[str]:
     """Helper para limpar strings ou converter outros tipos para string, retornando None se vazio."""
     if valor is None:
@@ -73,7 +75,14 @@ def _limpar_valor_extraido(valor: Any) -> Optional[str]:
     try:
         s = str(valor).strip()
         # Considerar 'nan', 'None' (string), '' como nulos após strip
-        if s.lower() in ['', 'nan', 'none', '#n/a', 'na', '<na>']: # Adicionado #N/A, NA, <NA> comuns em planilhas
+        if s.lower() in [
+            "",
+            "nan",
+            "none",
+            "#n/a",
+            "na",
+            "<na>",
+        ]:  # Adicionado #N/A, NA, <NA> comuns em planilhas
             return None
         return s
     except:
@@ -81,8 +90,8 @@ def _limpar_valor_extraido(valor: Any) -> Optional[str]:
 
 
 def _processar_linha_padronizada(
-    linha_original: Dict[str, Any], 
-    mapeamento_colunas_usuario: Optional[Dict[str, str]] = None
+    linha_original: Dict[str, Any],
+    mapeamento_colunas_usuario: Optional[Dict[str, str]] = None,
 ) -> Optional[Dict[str, Any]]:
     """
     Tenta padronizar uma linha de dados extraída para campos comuns do Produto.
@@ -97,14 +106,36 @@ def _processar_linha_padronizada(
     # Mapeamento padrão (de nomes de coluna comuns em arquivos para nossos campos internos)
     # Chaves devem ser em minúsculo e sem espaços extra para matching.
     mapeamento_default = {
-        "nome": "nome_base", "produto": "nome_base", "item": "nome_base", "title": "nome_base", "título": "nome_base", "titulo": "nome_base",
-        "sku": "sku_original", "código": "sku_original", "codigo": "sku_original", "ref": "sku_original", "referência": "sku_original", "referencia": "sku_original",
-        "marca": "marca", "fabricante": "marca", "brand": "marca",
-        "categoria": "categoria_original", "category": "categoria_original",
-        "descrição": "descricao_original", "descricao": "descricao_original", "description": "descricao_original",
-        "ean": "ean_original", "gtin": "ean_original", "upc": "ean_original",
-        "preço": "preco_original", "preco": "preco_original", "price": "preco_original", "valor": "preco_original",
-        "url_imagem": "imagem_url_original", "imagem": "imagem_url_original", "image_url": "imagem_url_original",
+        "nome": "nome_base",
+        "produto": "nome_base",
+        "item": "nome_base",
+        "title": "nome_base",
+        "título": "nome_base",
+        "titulo": "nome_base",
+        "sku": "sku_original",
+        "código": "sku_original",
+        "codigo": "sku_original",
+        "ref": "sku_original",
+        "referência": "sku_original",
+        "referencia": "sku_original",
+        "marca": "marca",
+        "fabricante": "marca",
+        "brand": "marca",
+        "categoria": "categoria_original",
+        "category": "categoria_original",
+        "descrição": "descricao_original",
+        "descricao": "descricao_original",
+        "description": "descricao_original",
+        "ean": "ean_original",
+        "gtin": "ean_original",
+        "upc": "ean_original",
+        "preço": "preco_original",
+        "preco": "preco_original",
+        "price": "preco_original",
+        "valor": "preco_original",
+        "url_imagem": "imagem_url_original",
+        "imagem": "imagem_url_original",
+        "image_url": "imagem_url_original",
         # Adicionar mais mapeamentos comuns conforme necessário
     }
 
@@ -112,12 +143,14 @@ def _processar_linha_padronizada(
     mapeamento_final = mapeamento_default.copy()
     if mapeamento_colunas_usuario:
         # Normalizar chaves do mapeamento do usuário também
-        mapeamento_usuario_norm = {str(k).lower().strip(): v for k, v in mapeamento_colunas_usuario.items()}
+        mapeamento_usuario_norm = {
+            str(k).lower().strip(): v for k, v in mapeamento_colunas_usuario.items()
+        }
         mapeamento_final.update(mapeamento_usuario_norm)
 
     for nome_coluna_original, valor_original in linha_original.items():
         valor_limpo = _limpar_valor_extraido(valor_original)
-        if valor_limpo is None: # Ignora células completamente vazias/nulas
+        if valor_limpo is None:  # Ignora células completamente vazias/nulas
             continue
 
         nome_coluna_norm = str(nome_coluna_original).lower().strip()
@@ -133,23 +166,35 @@ def _processar_linha_padronizada(
         else:
             # Guarda campos não mapeados diretamente em dados_brutos_originais
             dados_brutos_nao_mapeados[str(nome_coluna_original).strip()] = valor_limpo
-            
+
     # Garante que 'nome_base' ou 'sku_original' exista, senão a linha é pouco útil
-    if not produto_dados_padronizados.get("nome_base") and not produto_dados_padronizados.get("sku_original"):
+    if not produto_dados_padronizados.get(
+        "nome_base"
+    ) and not produto_dados_padronizados.get("sku_original"):
         # Se não tem nome_base nem sku, mas tem outros dados, tenta pegar o primeiro valor não nulo como nome_base
         if dados_brutos_nao_mapeados:
-            primeiro_valor_util = next((v for v in dados_brutos_nao_mapeados.values() if v), None)
+            primeiro_valor_util = next(
+                (v for v in dados_brutos_nao_mapeados.values() if v), None
+            )
             if primeiro_valor_util:
-                 produto_dados_padronizados["nome_base"] = primeiro_valor_util
+                produto_dados_padronizados["nome_base"] = primeiro_valor_util
             else:  # Se realmente não há nada que possa ser um nome/identificador
-                return {"motivo_descarte": "Faltam nome_base e sku_original", "linha_original": linha_original}
+                return {
+                    "motivo_descarte": "Faltam nome_base e sku_original",
+                    "linha_original": linha_original,
+                }
         else:
-            return {"motivo_descarte": "Faltam nome_base e sku_original", "linha_original": linha_original}
+            return {
+                "motivo_descarte": "Faltam nome_base e sku_original",
+                "linha_original": linha_original,
+            }
 
     # Adiciona os campos não mapeados ao dicionário principal
     if dados_brutos_nao_mapeados:
-        produto_dados_padronizados["dados_brutos_adicionais"] = dados_brutos_nao_mapeados
-        
+        produto_dados_padronizados["dados_brutos_adicionais"] = (
+            dados_brutos_nao_mapeados
+        )
+
     return produto_dados_padronizados
 
 
@@ -196,6 +241,7 @@ async def processar_arquivo_csv(
         # Detectar encoding usando chardet para lidar com diferentes formatos
         try:
             import chardet  # Lazy import para evitar dependência desnecessária em outros caminhos
+
             detection = chardet.detect(conteudo_arquivo)
             encoding_detectada = (detection.get("encoding") or "utf-8").lower()
         except Exception:  # Falha na detecção: assume utf-8
@@ -205,7 +251,7 @@ async def processar_arquivo_csv(
             conteudo_str = conteudo_arquivo.decode("utf-8-sig", errors="replace")
         else:
             conteudo_str = conteudo_arquivo.decode(encoding_detectada, errors="replace")
-            
+
         # Detectar delimitador usando csv.Sniffer em uma amostra de linhas
         linhas = conteudo_str.splitlines()
         sample = "\n".join(linhas[:5]) if linhas else conteudo_str
@@ -214,15 +260,21 @@ async def processar_arquivo_csv(
             delimitador_provavel = dialect.delimiter
         except Exception:
             delimitador_provavel = ","
-            primeira_linha = conteudo_str.splitlines()[0] if conteudo_str.splitlines() else ""
+            primeira_linha = (
+                conteudo_str.splitlines()[0] if conteudo_str.splitlines() else ""
+            )
             if ";" in primeira_linha:
                 delimitador_provavel = ";"
             elif "\t" in primeira_linha:
                 delimitador_provavel = "\t"
 
-        leitor_csv = csv.DictReader(io.StringIO(conteudo_str), delimiter=delimitador_provavel)
+        leitor_csv = csv.DictReader(
+            io.StringIO(conteudo_str), delimiter=delimitador_provavel
+        )
         for linha_dict_raw in leitor_csv:
-            produto_padronizado = _processar_linha_padronizada(linha_dict_raw, mapeamento_colunas_usuario)
+            produto_padronizado = _processar_linha_padronizada(
+                linha_dict_raw, mapeamento_colunas_usuario
+            )
             if produto_padronizado:
                 if product_type_id is not None:
                     produto_padronizado["product_type_id"] = product_type_id
@@ -231,6 +283,7 @@ async def processar_arquivo_csv(
     except Exception as e:
         logger.error("Erro ao processar arquivo CSV: %s", e)
         return [{"erro_processamento_csv": f"Falha ao ler arquivo CSV: {str(e)}"}]
+
 
 async def processar_arquivo_pdf(
     conteudo_arquivo: bytes,
@@ -250,35 +303,57 @@ async def processar_arquivo_pdf(
                     continue
                 # Tenta extrair tabelas da página
                 # Configurações para extração de tabela podem ser ajustadas
-                tables = page.extract_tables(table_settings={
-                    "vertical_strategy": "lines", # ou "text"
-                    "horizontal_strategy": "lines", # ou "text"
-                })
+                tables = page.extract_tables(
+                    table_settings={
+                        "vertical_strategy": "lines",  # ou "text"
+                        "horizontal_strategy": "lines",  # ou "text"
+                    }
+                )
                 if tables:
                     log_pdf.append(f"Página {i+1}: Encontradas {len(tables)} tabelas.")
                     for table_num, table_data in enumerate(tables):
-                        if not table_data or len(table_data) < 2: # Precisa de cabeçalho e pelo menos uma linha de dados
-                            log_pdf.append(f"Página {i+1}, Tabela {table_num+1}: Tabela vazia ou sem dados suficientes.")
+                        if (
+                            not table_data or len(table_data) < 2
+                        ):  # Precisa de cabeçalho e pelo menos uma linha de dados
+                            log_pdf.append(
+                                f"Página {i+1}, Tabela {table_num+1}: Tabela vazia ou sem dados suficientes."
+                            )
                             continue
-                        
+
                         headers_raw = table_data[0]
-                        headers = [_limpar_valor_extraido(h) or f"coluna_vazia_{idx}" for idx, h in enumerate(headers_raw)]
-                        
+                        headers = [
+                            _limpar_valor_extraido(h) or f"coluna_vazia_{idx}"
+                            for idx, h in enumerate(headers_raw)
+                        ]
+
                         for row_idx, row_data in enumerate(table_data[1:]):
                             if len(row_data) != len(headers):
-                                log_pdf.append(f"Página {i+1}, Tabela {table_num+1}, Linha {row_idx+1}: Número de colunas ({len(row_data)}) não corresponde ao cabeçalho ({len(headers)}). Pulando.")
+                                log_pdf.append(
+                                    f"Página {i+1}, Tabela {table_num+1}, Linha {row_idx+1}: Número de colunas ({len(row_data)}) não corresponde ao cabeçalho ({len(headers)}). Pulando."
+                                )
                                 continue
 
-                            linha_dict_raw = {headers[col_idx]: cell_data for col_idx, cell_data in enumerate(row_data)}
-                            produto_padronizado = _processar_linha_padronizada(linha_dict_raw, mapeamento_colunas_usuario)
+                            linha_dict_raw = {
+                                headers[col_idx]: cell_data
+                                for col_idx, cell_data in enumerate(row_data)
+                            }
+                            produto_padronizado = _processar_linha_padronizada(
+                                linha_dict_raw, mapeamento_colunas_usuario
+                            )
                             if produto_padronizado:
                                 if product_type_id is not None:
-                                    produto_padronizado["product_type_id"] = product_type_id
+                                    produto_padronizado["product_type_id"] = (
+                                        product_type_id
+                                    )
                                 produtos_extraidos.append(produto_padronizado)
                 else:
-                    log_pdf.append(f"Página {i+1}: Nenhuma tabela encontrada com as configurações atuais.")
+                    log_pdf.append(
+                        f"Página {i+1}: Nenhuma tabela encontrada com as configurações atuais."
+                    )
 
-            if not produtos_extraidos and len(pdf.pages) > 0:  # Fallback se nenhuma tabela extraiu dados
+            if (
+                not produtos_extraidos and len(pdf.pages) > 0
+            ):  # Fallback se nenhuma tabela extraiu dados
                 log_pdf.append(
                     "Nenhum produto extraído de tabelas. Extraindo texto de todas as páginas."
                 )
@@ -292,26 +367,40 @@ async def processar_arquivo_pdf(
                         texto_chave = f"texto_completo_pagina_{i+1}"
                         if usar_llm:
                             try:
-                                dados_produto = await web_data_extractor_service.extrair_dados_produto_com_llm(page_text)
+                                dados_produto = await web_data_extractor_service.extrair_dados_produto_com_llm(
+                                    page_text
+                                )
                                 if isinstance(dados_produto, dict):
-                                    dados_produto["texto_bruto"] = page_text.strip()[:20000]
+                                    dados_produto["texto_bruto"] = page_text.strip()[
+                                        :20000
+                                    ]
                                     if product_type_id is not None:
-                                        dados_produto["product_type_id"] = product_type_id
+                                        dados_produto["product_type_id"] = (
+                                            product_type_id
+                                        )
                                     produtos_extraidos.append(dados_produto)
                                 else:
                                     item = {
                                         "nome_base": f"Texto da página {i+1}",
-                                        "dados_brutos_adicionais": {texto_chave: page_text.strip()[:20000]},
+                                        "dados_brutos_adicionais": {
+                                            texto_chave: page_text.strip()[:20000]
+                                        },
                                     }
                                     if product_type_id is not None:
                                         item["product_type_id"] = product_type_id
                                     produtos_extraidos.append(item)
-                                log_pdf.append(f"Página {i+1}: Texto processado com LLM.")
+                                log_pdf.append(
+                                    f"Página {i+1}: Texto processado com LLM."
+                                )
                             except Exception as llm_e:
-                                log_pdf.append(f"Página {i+1}: Erro ao extrair dados com LLM: {str(llm_e)}")
+                                log_pdf.append(
+                                    f"Página {i+1}: Erro ao extrair dados com LLM: {str(llm_e)}"
+                                )
                                 item = {
                                     "nome_base": f"Conteúdo Bruto da Página {i+1} do PDF",
-                                    "dados_brutos_adicionais": {texto_chave: page_text.strip()[:20000]},
+                                    "dados_brutos_adicionais": {
+                                        texto_chave: page_text.strip()[:20000]
+                                    },
                                 }
                                 if product_type_id is not None:
                                     item["product_type_id"] = product_type_id
@@ -319,27 +408,46 @@ async def processar_arquivo_pdf(
                         else:
                             item = {
                                 "nome_base": f"Conteúdo da Página {i+1}",
-                                "dados_brutos_adicionais": {texto_chave: page_text.strip()[:20000]},
+                                "dados_brutos_adicionais": {
+                                    texto_chave: page_text.strip()[:20000]
+                                },
                             }
                             if product_type_id is not None:
                                 item["product_type_id"] = product_type_id
                             produtos_extraidos.append(item)
-                            log_pdf.append(f"Página {i+1}: Texto armazenado sem uso do LLM.")
+                            log_pdf.append(
+                                f"Página {i+1}: Texto armazenado sem uso do LLM."
+                            )
                     else:
-                        log_pdf.append(f"Página {i+1}: Nenhum texto extraível encontrado.")
-            
-            if not produtos_extraidos: # Se ainda vazio
-                 return [{"erro_processamento_pdf": "Nenhum dado de produto pôde ser extraído do PDF.", "log_pdf": log_pdf}]
+                        log_pdf.append(
+                            f"Página {i+1}: Nenhum texto extraível encontrado."
+                        )
+
+            if not produtos_extraidos:  # Se ainda vazio
+                return [
+                    {
+                        "erro_processamento_pdf": "Nenhum dado de produto pôde ser extraído do PDF.",
+                        "log_pdf": log_pdf,
+                    }
+                ]
 
         return produtos_extraidos
     except Exception as e:
         import traceback
+
         log_pdf.append(f"Erro crítico ao processar arquivo PDF: {str(e)}")
         logger.error("Erro ao processar arquivo PDF: %s", traceback.format_exc())
-        return [{"erro_processamento_pdf": f"Falha crítica ao ler arquivo PDF: {str(e)}", "log_pdf": log_pdf}]
+        return [
+            {
+                "erro_processamento_pdf": f"Falha crítica ao ler arquivo PDF: {str(e)}",
+                "log_pdf": log_pdf,
+            }
+        ]
 
 
-async def preview_arquivo_excel(conteudo_arquivo: bytes, max_rows: int = 5) -> Dict[str, Any]:
+async def preview_arquivo_excel(
+    conteudo_arquivo: bytes, max_rows: int = 5
+) -> Dict[str, Any]:
     """Retorna cabeçalhos e linhas de amostra de um arquivo Excel."""
     try:
         df = pd.read_excel(io.BytesIO(conteudo_arquivo), sheet_name=0)
@@ -351,7 +459,9 @@ async def preview_arquivo_excel(conteudo_arquivo: bytes, max_rows: int = 5) -> D
         return {"error": f"Falha ao ler arquivo Excel: {str(e)}"}
 
 
-async def preview_arquivo_csv(conteudo_arquivo: bytes, max_rows: int = 5) -> Dict[str, Any]:
+async def preview_arquivo_csv(
+    conteudo_arquivo: bytes, max_rows: int = 5
+) -> Dict[str, Any]:
     """Retorna cabeçalhos e linhas de amostra de um arquivo CSV."""
     try:
         try:
@@ -365,7 +475,9 @@ async def preview_arquivo_csv(conteudo_arquivo: bytes, max_rows: int = 5) -> Dic
             delimitador = dialect.delimiter
         except Exception:
             delimitador = ","
-            primeira_linha = conteudo_str.splitlines()[0] if conteudo_str.splitlines() else ""
+            primeira_linha = (
+                conteudo_str.splitlines()[0] if conteudo_str.splitlines() else ""
+            )
             if ";" in primeira_linha:
                 delimitador = ";"
             elif "\t" in primeira_linha:
@@ -385,7 +497,7 @@ async def preview_arquivo_csv(conteudo_arquivo: bytes, max_rows: int = 5) -> Dic
 
 
 async def preview_arquivo_pdf(
-    conteudo_arquivo: bytes, ext: str, start_page: int = 1, page_count: int = 0
+    conteudo_arquivo: bytes, ext: str, start_page: int = 1, page_count: int = 1
 ) -> Dict[str, Any]:
     """Gera preview com miniaturas, texto e detecção de tabelas."""
 
@@ -406,24 +518,33 @@ async def preview_arquivo_pdf(
         poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
         kwargs = {"poppler_path": poppler_dir} if poppler_dir else {}
 
-        for p in range(start_page, end_page + 1):
-            page = reader.pages[p - 1]
+        loop = asyncio.get_running_loop()
 
+        def _process_page(page_number: int):
+            page = reader.pages[page_number - 1]
             tables = page.extract_tables()
-            if tables:
-                preview["table_pages"].append(p)
-
             text = page.extract_text() or ""
-            snippet = "\n".join(text.splitlines()[:3])
-            preview["sample_rows"][p] = snippet
-
             img = convert_from_bytes(
-                conteudo_arquivo, first_page=p, last_page=p, fmt="png", **kwargs
+                conteudo_arquivo,
+                first_page=page_number,
+                last_page=page_number,
+                fmt="png",
+                **kwargs,
             )[0]
             buf = io.BytesIO()
             img.save(buf, format="PNG")
             b64 = base64.b64encode(buf.getvalue()).decode()
-            preview["preview_images"].append({"page": p, "image": f"data:image/png;base64,{b64}"})
+            return tables, text, b64
+
+        for p in range(start_page, end_page + 1):
+            tables, text, b64 = await loop.run_in_executor(None, _process_page, p)
+            if tables:
+                preview["table_pages"].append(p)
+            snippet = "\n".join(text.splitlines()[:3])
+            preview["sample_rows"][p] = snippet
+            preview["preview_images"].append(
+                {"page": p, "image": f"data:image/png;base64,{b64}"}
+            )
 
         return preview
     except Exception as e:
@@ -431,9 +552,9 @@ async def preview_arquivo_pdf(
         return {"error": f"Falha ao ler arquivo PDF: {str(e)}"}
 
 
-
-
-async def gerar_preview(conteudo_arquivo: bytes, ext: str, max_rows: int = 5) -> Dict[str, Any]:
+async def gerar_preview(
+    conteudo_arquivo: bytes, ext: str, max_rows: int = 5
+) -> Dict[str, Any]:
     """Despacha para a função de preview correta com base na extensão."""
     ext = ext.lower()
     if ext in [".xlsx", ".xls"]:
@@ -441,7 +562,7 @@ async def gerar_preview(conteudo_arquivo: bytes, ext: str, max_rows: int = 5) ->
     if ext == ".csv":
         return await preview_arquivo_csv(conteudo_arquivo, max_rows)
     if ext == ".pdf":
-        return await preview_arquivo_pdf(conteudo_arquivo, ext, 1, 0)
+        return await preview_arquivo_pdf(conteudo_arquivo, ext, 1, 1)
     raise ValueError("Formato de arquivo não suportado para preview")
 
 
@@ -453,7 +574,7 @@ async def pdf_pages_to_images(
     :param conteudo_arquivo: conteúdo bruto do PDF
     :param max_pages: quantidade de páginas a converter
     :param start_page: página inicial (1-indexada)
-    
+
     Se o executável ``pdftoppm`` não estiver no ``PATH``, defina a variável de
     ambiente ``POPPLER_PATH`` apontando para o diretório onde ele está
     localizado.
@@ -479,7 +600,9 @@ async def pdf_pages_to_images(
     return imagens_base64
 
 
-async def extrair_pagina_pdf(conteudo_arquivo: bytes, page_number: int) -> Dict[str, Any]:
+async def extrair_pagina_pdf(
+    conteudo_arquivo: bytes, page_number: int
+) -> Dict[str, Any]:
     """Extrai imagem, texto e tabela de uma única página de um PDF."""
     try:
         with pdf_open(io.BytesIO(conteudo_arquivo)) as pdf:
@@ -488,14 +611,21 @@ async def extrair_pagina_pdf(conteudo_arquivo: bytes, page_number: int) -> Dict[
             page = pdf.pages[page_number - 1]
             text = page.extract_text(x_tolerance=2, y_tolerance=2) or ""
             tables = page.extract_tables(
-                table_settings={"vertical_strategy": "lines", "horizontal_strategy": "lines"}
+                table_settings={
+                    "vertical_strategy": "lines",
+                    "horizontal_strategy": "lines",
+                }
             )
             table = tables[0] if tables else None
 
         poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
         kwargs = {"poppler_path": poppler_dir} if poppler_dir else {}
         image = convert_from_bytes(
-            conteudo_arquivo, first_page=page_number, last_page=page_number, fmt="png", **kwargs
+            conteudo_arquivo,
+            first_page=page_number,
+            last_page=page_number,
+            fmt="png",
+            **kwargs,
         )[0]
         with io.BytesIO() as buf:
             image.save(buf, format="PNG")

--- a/tests/test_file_processing_service.py
+++ b/tests/test_file_processing_service.py
@@ -14,6 +14,7 @@ except ImportError:  # pragma: no cover - install at runtime
 
 from reportlab.pdfgen import canvas
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "data,encoding,esperado_nome,esperada_marca",
@@ -23,7 +24,9 @@ from reportlab.pdfgen import canvas
         ("nome_base\tmarca\nE\tF\n", "cp1252", "E", "F"),
     ],
 )
-async def test_processar_arquivo_csv_encodings(data, encoding, esperado_nome, esperada_marca):
+async def test_processar_arquivo_csv_encodings(
+    data, encoding, esperado_nome, esperada_marca
+):
     bytes_data = data.encode(encoding)
     resultado = await file_processing_service.processar_arquivo_csv(bytes_data)
     assert resultado
@@ -58,5 +61,5 @@ async def test_preview_arquivo_pdf_returns_page_info():
     res = await file_processing_service.preview_arquivo_pdf(pdf_bytes, ".pdf")
     assert res.get("num_pages") == 2
     assert isinstance(res.get("table_pages"), list)
-    assert len(res["preview_images"]) == 2
+    assert len(res["preview_images"]) == 1
     assert 1 in res["sample_rows"]

--- a/tests/test_preview_pdf.py
+++ b/tests/test_preview_pdf.py
@@ -6,14 +6,26 @@ import pytest
 
 try:
     from reportlab.pdfgen import canvas
-    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, PageBreak, Paragraph
+    from reportlab.platypus import (
+        SimpleDocTemplate,
+        Table,
+        TableStyle,
+        PageBreak,
+        Paragraph,
+    )
     from reportlab.lib import colors
     from reportlab.lib.pagesizes import letter
     from reportlab.lib.styles import getSampleStyleSheet
 except ImportError:
     subprocess.check_call([sys.executable, "-m", "pip", "install", "reportlab"])
     from reportlab.pdfgen import canvas
-    from reportlab.platypus import SimpleDocTemplate, Table, TableStyle, PageBreak, Paragraph
+    from reportlab.platypus import (
+        SimpleDocTemplate,
+        Table,
+        TableStyle,
+        PageBreak,
+        Paragraph,
+    )
     from reportlab.lib import colors
     from reportlab.lib.pagesizes import letter
     from reportlab.lib.styles import getSampleStyleSheet
@@ -27,7 +39,7 @@ def _create_pdf_with_table():
     styles = getSampleStyleSheet()
     story = [Paragraph("Page 1 text", styles["Normal"]), PageBreak()]
     table = Table([["A", "B"], ["1", "2"]])
-    table.setStyle(TableStyle([('GRID', (0, 0), (-1, -1), 1, colors.black)]))
+    table.setStyle(TableStyle([("GRID", (0, 0), (-1, -1), 1, colors.black)]))
     story.append(table)
     story.append(PageBreak())
     story.append(Paragraph("Last page", styles["Normal"]))
@@ -42,7 +54,7 @@ async def test_preview_pdf_extracts_all():
     res = await preview_arquivo_pdf(pdf_bytes, ".pdf")
     assert res["num_pages"] == 3
     assert 2 in res["table_pages"]
-    assert len(res["preview_images"]) == 3
-    assert {img["page"] for img in res["preview_images"]} == {1, 2, 3}
-    assert len(res["sample_rows"]) == 3
+    assert len(res["preview_images"]) == 1
+    assert {img["page"] for img in res["preview_images"]} == {1}
+    assert len(res["sample_rows"]) == 1
     assert all(isinstance(v, str) for v in res["sample_rows"].values())


### PR DESCRIPTION
## Summary
- process only the first page when generating PDF previews
- handle PDF preview conversion in an executor to avoid blocking
- adjust tests for new preview behavior

## Testing
- `pytest -q` *(fails: 23 failed, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6850a47babd8832f9324f5e65b864809