### PR TITLE
Add drag-and-drop support in catalog import

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -46,6 +46,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   const [isTextModalOpen, setIsTextModalOpen] = useState(false);
   const [textPreview, setTextPreview] = useState('');
   const [startPage, setStartPage] = useState(1);
+  const [dragOver, setDragOver] = useState(false);
 
   const { productTypes, addProductType } = useProductTypes();
 
@@ -101,6 +102,28 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     setFile(f);
     if (f && f.type === 'application/pdf') {
       setPdfUrl(URL.createObjectURL(f));
+    }
+  };
+
+  const onDragOver = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(true);
+  };
+
+  const onDragLeave = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(false);
+  };
+
+  const onDrop = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setDragOver(false);
+    if (e.dataTransfer.files && e.dataTransfer.files.length > 0) {
+      handleFileChange({ target: { files: e.dataTransfer.files } });
+      e.dataTransfer.clearData();
     }
   };
 
@@ -312,7 +335,18 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
 
   const renderStep1 = () => (
     <div>
-      <input type="file" accept=".csv,.xls,.xlsx,.pdf" onChange={handleFileChange} />
+      <div
+        className={`file-drop-area${dragOver ? ' drag-over' : ''}`}
+        onDragOver={onDragOver}
+        onDragLeave={onDragLeave}
+        onDrop={onDrop}
+      >
+        <input
+          type="file"
+          accept=".csv,.xls,.xlsx,.pdf"
+          onChange={handleFileChange}
+        />
+      </div>
       <button onClick={handleGeneratePreview} disabled={!file || loading}>
         {loading ? 'Enviando...' : 'Gerar Preview'}
       </button>


### PR DESCRIPTION
## Summary
- implement drag and drop handlers in `ImportCatalogWizard`
- wrap file input in a drop area and highlight on drag over

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: ERESOLVE could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6851592e9e14832f88e8986763b96d58