### PR TITLE
Improve accessibility for ImportCatalogWizard progress

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -694,10 +694,18 @@ const renderStep4 = () => (
     {pagesTotal > 0 && (
       <>
         <progress
+          role="progressbar"
           value={pagesProcessed}
           max={pagesTotal}
+          aria-valuenow={pagesProcessed}
+          aria-valuemin={0}
+          aria-valuemax={pagesTotal}
           style={{ width: '100%' }}
-        />
+        >
+          <span className="visually-hidden">
+            Progresso: {pagesProcessed} de {pagesTotal}
+          </span>
+        </progress>
         <p>
           Página {pagesProcessed} de {pagesTotal}
         </p>

--- a/Frontend/app/src/index.css
+++ b/Frontend/app/src/index.css
@@ -606,3 +606,15 @@ tr:hover {
 }
 .pagination-controls button { padding: 0.5em 1em; }
 .pagination-controls span { margin: 0 10px; font-size: 0.9em; color: #555;}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}


### PR DESCRIPTION
## Summary
- add ARIA attributes and hidden label to progress bar
- include `.visually-hidden` utility style for screen readers

## Testing
- `npm test --silent` *(fails: Jest encountered an unexpected token)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_68515dfac850832f81fb376bf2122a2c