### PR TITLE
Add indeterminate spinner while catalog pages load

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -691,7 +691,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
 
 const renderStep4 = () => (
   <div>
-    {pagesTotal > 0 && (
+    {pagesTotal > 0 ? (
       <>
         <progress
           value={pagesProcessed}
@@ -701,9 +701,14 @@ const renderStep4 = () => (
         <p>
           Página {pagesProcessed} de {pagesTotal}
         </p>
+        {message && !message.startsWith('Página') && <p>{message}</p>}
+      </>
+    ) : (
+      <>
+        <div className="loading-spinner" style={{ margin: '20px auto' }} />
+        {message && <p>{message}</p>}
       </>
     )}
-    {message && !message.startsWith('Página') && <p>{message}</p>}
     <button onClick={onClose}>Fechar</button>
   </div>
 );


### PR DESCRIPTION
## Summary
- show a spinner until the total number of pages is known

## Testing
- `npm test --silent` *(fails: jest not found)*
- `./scripts/run_tests.sh` *(fails: many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68515dfc6eb4832fbadfaea2306a33f2