### PR TITLE
Track updated products in catalog import

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -80,6 +80,8 @@ async def _tarefa_processar_catalogo(
         ext = file_path.suffix.lower()
         erros: List[Dict[str, Any]] = []
         produtos_create: List[schemas.ProdutoCreate] = []
+        created: List[models.Produto] = []
+        updated: List[Dict[str, Any]] = []
         if ext == ".pdf":
             import pdfplumber, io
             with pdfplumber.open(io.BytesIO(content)) as pdf:
@@ -89,7 +91,6 @@ async def _tarefa_processar_catalogo(
             db.commit()
             page_list = pages or list(range(1, total + 1))
 
-            created: List[models.Produto] = []
             for page in page_list:
                 produtos_data = await file_processing_service.processar_arquivo_pdf(
                     content,
@@ -124,8 +125,26 @@ async def _tarefa_processar_catalogo(
 
                 if produtos_create:
                     page_created, dup_errors = crud_produtos.create_produtos_bulk(db, produtos_create, user_id=user_id)
-                    erros.extend(dup_errors)
                     created.extend(page_created)
+                    for err in dup_errors:
+                        if err.get("duplicado"):
+                            linha = err.get("linha_original", {})
+                            sku = linha.get("sku")
+                            ean = linha.get("ean")
+                            query = db.query(models.Produto).filter(models.Produto.user_id == user_id)
+                            if sku:
+                                query = query.filter(models.Produto.sku == sku)
+                            elif ean:
+                                query = query.filter(models.Produto.ean == ean)
+                            existing = query.first()
+                            if existing:
+                                before = schemas.ProdutoResponse.model_validate(existing).model_dump()
+                                update_schema = schemas.ProdutoUpdate(**linha)
+                                updated_prod = crud_produtos.update_produto(db, existing, update_schema)
+                                after = schemas.ProdutoResponse.model_validate(updated_prod).model_dump()
+                                updated.append({"before": before, "after": after})
+                                continue
+                        erros.append(err)
                     for db_produto in page_created:
                         crud.create_registro_uso_ia(
                             db,
@@ -193,7 +212,25 @@ async def _tarefa_processar_catalogo(
                     erros.append({"motivo_descarte": f"Erro ao converter linha: {str(e)}", "linha_original": prod})
             if produtos_create:
                 created, dup_errors = crud_produtos.create_produtos_bulk(db, produtos_create, user_id=user_id)
-                erros.extend(dup_errors)
+                for err in dup_errors:
+                    if err.get("duplicado"):
+                        linha = err.get("linha_original", {})
+                        sku = linha.get("sku")
+                        ean = linha.get("ean")
+                        query = db.query(models.Produto).filter(models.Produto.user_id == user_id)
+                        if sku:
+                            query = query.filter(models.Produto.sku == sku)
+                        elif ean:
+                            query = query.filter(models.Produto.ean == ean)
+                        existing = query.first()
+                        if existing:
+                            before = schemas.ProdutoResponse.model_validate(existing).model_dump()
+                            update_schema = schemas.ProdutoUpdate(**linha)
+                            updated_prod = crud_produtos.update_produto(db, existing, update_schema)
+                            after = schemas.ProdutoResponse.model_validate(updated_prod).model_dump()
+                            updated.append({"before": before, "after": after})
+                            continue
+                    erros.append(err)
                 for db_produto in created:
                     crud.create_registro_uso_ia(
                         db,
@@ -213,7 +250,7 @@ async def _tarefa_processar_catalogo(
                             entity_id=db_produto.id,
                         ),
                     )
-            catalog_file.pages_processed = catalog_file.total_pages
+                catalog_file.pages_processed = catalog_file.total_pages
             db.commit()
 
         result_summary = {
@@ -221,7 +258,7 @@ async def _tarefa_processar_catalogo(
                 schemas.ProdutoResponse.model_validate(p).model_dump()
                 for p in created
             ],
-            "updated": [],
+            "updated": updated,
             "errors": erros,
         }
 

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -337,9 +337,16 @@ class ImportCatalogoResponse(BaseModel):
     erros: List[Dict[str, Any]]
 
 
+class UpdatedProductInfo(BaseModel):
+    """Representa um produto atualizado durante a importação."""
+
+    before: ProdutoResponse
+    after: ProdutoResponse
+
+
 class CatalogImportResult(BaseModel):
     created: List[ProdutoResponse]
-    updated: List[ProdutoResponse]
+    updated: List[UpdatedProductInfo]
     errors: List[Dict[str, Any]]
 
 
@@ -543,6 +550,7 @@ AttributeTemplateResponse.model_rebuild()
 ProductTypeResponse.model_rebuild()
 ProdutoResponse.model_rebuild()
 ImportCatalogoResponse.model_rebuild()
+UpdatedProductInfo.model_rebuild()
 CatalogImportResult.model_rebuild()
 RegionExtractionResponse.model_rebuild()
 SinglePageExtractionResponse.model_rebuild()

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -734,8 +734,31 @@ const renderStep5 = () => {
         <div>
           <h5>Atualizados</h5>
           <ul>
-            {resultSummary.updated.map((p) => (
-              <li key={p.id}>{p.nome_base} ({p.sku || p.ean})</li>
+            {resultSummary.updated.map((u, idx) => (
+              <li key={u.after.id || idx}>
+                <strong>
+                  {u.after.nome_base} ({u.after.sku || u.after.ean})
+                </strong>
+                <ul>
+                  {u.before.nome_base !== u.after.nome_base && (
+                    <li>
+                      Nome: {u.before.nome_base || '—'} → {u.after.nome_base || '—'}
+                    </li>
+                  )}
+                  {u.before.sku !== u.after.sku && (
+                    <li>SKU: {u.before.sku || '—'} → {u.after.sku || '—'}</li>
+                  )}
+                  {u.before.ean !== u.after.ean && (
+                    <li>EAN: {u.before.ean || '—'} → {u.after.ean || '—'}</li>
+                  )}
+                  {u.before.descricao_original !== u.after.descricao_original && (
+                    <li>
+                      Descrição: {u.before.descricao_original || '—'} →{' '}
+                      {u.after.descricao_original || '—'}
+                    </li>
+                  )}
+                </ul>
+              </li>
             ))}
           </ul>
         </div>


### PR DESCRIPTION
## Summary
- extend `CatalogImportResult` with `UpdatedProductInfo`
- capture before/after data for updated products when importing catalogs
- show detailed differences for updated products in the import wizard UI

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: many tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_68515e09556c832fbec370a5693cda9c