### PR TITLE
Remove preprocessing from catalog finalize

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -917,35 +917,11 @@ async def importar_catalogo_finalizar(
         file_path = Path(__file__).resolve().parent.parent / file_path
     if not file_path.exists():
         raise HTTPException(status_code=404, detail="Arquivo não encontrado")
-    content = file_path.read_bytes()
-    ext = file_path.suffix.lower()
+
     if mapping is None:
         fornecedor = crud_fornecedores.get_fornecedor(db, fornecedor_id)
         if fornecedor and fornecedor.default_column_mapping:
             mapping = fornecedor.default_column_mapping
-    if ext in [".xlsx", ".xls"]:
-        produtos_data = await file_processing_service.processar_arquivo_excel(
-            content,
-            mapeamento_colunas_usuario=mapping,
-            product_type_id=product_type_id,
-        )
-    elif ext == ".csv":
-        produtos_data = await file_processing_service.processar_arquivo_csv(
-            content,
-            mapeamento_colunas_usuario=mapping,
-            product_type_id=product_type_id,
-        )
-    elif ext == ".pdf":
-        produtos_data = await file_processing_service.processar_arquivo_pdf(
-            content,
-            mapeamento_colunas_usuario=mapping,
-            product_type_id=product_type_id,
-            pages=pages,
-        )
-    else:
-        raise HTTPException(
-            status_code=400, detail="Formato de arquivo não suportado"
-        )
 
     background_tasks.add_task(
         _tarefa_processar_catalogo,


### PR DESCRIPTION
## Summary
- streamline `importar_catalogo_finalizar` so parsing happens only in the background task

## Testing
- `pytest Backend/tests/test_health.py -q`
- `pytest -q` *(fails: 23 failed, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68515df96e48832fa2f58ba491bb714e