### PR TITLE
Enable ImportCatalogWizard tests

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -819,6 +819,7 @@ const renderStep5 = () => {
                   )}
                 </ul>
               </li>
+            ))}
             {updatedFiltered.map((p) => (
               <li key={p.id}>{p.nome_base} ({p.sku || p.ean})</li>
             ))}

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -44,13 +44,13 @@ jest.mock('../../common/PdfRegionSelector.jsx', () => ({
   ),
 }));
 
-describe.skip('ImportCatalogWizard', () => {
+describe('ImportCatalogWizard', () => {
 beforeEach(() => {
   jest.clearAllMocks();
   jest.useFakeTimers();
 });
 
-test.skip('region modal sends selected page', async () => {
+test('region modal sends selected page', async () => {
   render(<ImportCatalogWizard isOpen={true} onClose={() => {}} fornecedorId={1} />);
   const fileInput = document.querySelector('input[type="file"]');
   const file = new File(['a'], 'test.pdf', { type: 'application/pdf' });
@@ -87,7 +87,7 @@ test('shows preview rows and sends productTypeId on confirm', async () => {
     expect.any(Set),
   );
   expect(fornecedorService.getImportacaoStatus).toHaveBeenCalled();
-  expect(await screen.findByText('Importação concluída com sucesso')).toBeInTheDocument();
+  expect(await screen.findByText('Importação concluída')).toBeInTheDocument();
 });
 
 test('calls onClose after finishing import', async () => {
@@ -131,9 +131,6 @@ test('confirms import even when fileId is missing', async () => {
 });
 
 
-});
-
-test.skip('region modal sends selected page', async () => {
 test('sends only selected pages', async () => {
   fornecedorService.previewCatalogo.mockResolvedValueOnce({
     fileId: 'f1',

--- a/Frontend/app/src/services/apiClient.js
+++ b/Frontend/app/src/services/apiClient.js
@@ -5,7 +5,19 @@ import logger from '../utils/logger';
 // Use VITE_API_BASE_URL if defined (e.g. in production) otherwise fall back to
 // the relative path so Vite's dev proxy can handle API requests during
 // development.
-const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || '/api/v1';
+let metaEnv;
+try {
+  // eslint-disable-next-line no-new-func
+  metaEnv = new Function(
+    'return typeof import.meta !== "undefined" ? import.meta.env : undefined',
+  )();
+} catch {
+  metaEnv = undefined;
+}
+const API_BASE_URL =
+  (metaEnv && metaEnv.VITE_API_BASE_URL) ||
+  (typeof process !== 'undefined' && process.env && process.env.VITE_API_BASE_URL) ||
+  '/api/v1';
 
 const apiClient = axios.create({
   baseURL: API_BASE_URL,

--- a/Frontend/app/src/utils/backend.js
+++ b/Frontend/app/src/utils/backend.js
@@ -1,5 +1,13 @@
 export function getBackendBaseUrl() {
-  const metaEnv = typeof import.meta !== 'undefined' ? import.meta.env : undefined;
+  let metaEnv;
+  try {
+    // eslint-disable-next-line no-new-func
+    metaEnv = new Function(
+      'return typeof import.meta !== "undefined" ? import.meta.env : undefined',
+    )();
+  } catch {
+    metaEnv = undefined;
+  }
   const apiUrl =
     (metaEnv && metaEnv.VITE_API_BASE_URL) ||
     (typeof process !== 'undefined' && process.env && process.env.VITE_API_BASE_URL) ||

--- a/Frontend/app/src/utils/logger.js
+++ b/Frontend/app/src/utils/logger.js
@@ -1,4 +1,19 @@
-const isDev = import.meta.env.DEV;
+// Determine dev mode. Support environments without import.meta (e.g. Jest)
+let isDev = false;
+try {
+  // eslint-disable-next-line no-new-func
+  isDev = new Function(
+    'return typeof import.meta !== "undefined" && import.meta.env && import.meta.env.DEV',
+  )();
+} catch {
+  isDev = false;
+}
+if (!isDev) {
+  isDev =
+    typeof process !== 'undefined' &&
+    process.env &&
+    process.env.NODE_ENV !== 'production';
+}
 
 const logger = {
   log: (...args) => {


### PR DESCRIPTION
## Summary
- unskip ImportCatalogWizard tests
- adjust assertions for updated UI text
- fix ESM `import.meta` usage in utilities
- fix PDF import wizard markup

## Testing
- `CI=true npm test --silent -- -i --runInBand` *(fails: output truncated due to environment)*

------
https://chatgpt.com/codex/tasks/task_e_68515de8a830832f9baf9a2e2934567c