### PR TITLE
Enable JPEG compression for PDF previews

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -541,31 +541,55 @@ async def preview_arquivo_pdf(
             first_page=start_page,
             last_page=end_page,
             fmt="png",
+            dpi=dpi,
             **kwargs,
         )
 
-        for idx, p in enumerate(range(start_page, end_page + 1)):
-            page = reader.pages[p - 1]
+        idx = 0
+        for p, page in enumerate(reader.pages, start=1):
             tables = page.extract_tables()
-            text = page.extract_text() or ""
-            img = convert_from_bytes(
-                conteudo_arquivo,
-                first_page=page_number,
-                last_page=page_number,
-                fmt="png",
-                dpi=dpi,
-                **kwargs,
-            )[0]
-            buf = io.BytesIO()
-            images[idx].save(buf, format="PNG")
-            b64 = base64.b64encode(buf.getvalue()).decode()
             if tables:
                 preview["table_pages"].append(p)
-            snippet = "\n".join(text.splitlines()[:3])
-            preview["sample_rows"][p] = snippet
-            preview["preview_images"].append(
-                {"page": p, "image": f"data:image/png;base64,{b64}"}
-            )
+
+            if start_page <= p <= end_page:
+                text = page.extract_text() or ""
+
+                png_buf = io.BytesIO()
+                images[idx].save(png_buf, format="PNG")
+                png_b64 = base64.b64encode(png_buf.getvalue())
+
+                jpeg_buf = io.BytesIO()
+                images[idx].convert("RGB").save(
+                    jpeg_buf,
+                    format="JPEG",
+                    optimize=True,
+                    quality=70,
+                )
+                jpeg_b64 = base64.b64encode(jpeg_buf.getvalue())
+
+                if len(jpeg_b64) >= len(png_b64):
+                    jpeg_buf = io.BytesIO()
+                    images[idx].convert("RGB").save(
+                        jpeg_buf,
+                        format="JPEG",
+                        optimize=True,
+                        quality=50,
+                    )
+                    jpeg_b64 = base64.b64encode(jpeg_buf.getvalue())
+
+                if len(jpeg_b64) < len(png_b64):
+                    b64 = jpeg_b64.decode()
+                    mime = "jpeg"
+                else:
+                    b64 = png_b64.decode()
+                    mime = "png"
+
+                snippet = "\n".join(text.splitlines()[:3])
+                preview["sample_rows"][p] = snippet
+                preview["preview_images"].append(
+                    {"page": p, "image": f"data:image/{mime};base64,{b64}"}
+                )
+                idx += 1
 
         return preview
     except Exception as e:

--- a/README Backend.md
+++ b/README Backend.md
@@ -31,6 +31,10 @@
 Para usuários do Windows, instale o Poppler via Chocolatey (`choco install poppler`) ou baixe os binários em <https://github.com/oschwartz10612/poppler-windows/releases>.
 Após a instalação, adicione o diretório que contém `pdftoppm.exe` ao `PATH` ou defina a variável `POPPLER_PATH`. A função `pdf_pages_to_images` lê essa variável se o executável não estiver no `PATH`.
 
+Para reduzir o tamanho das prévias, a função `preview_arquivo_pdf` salva cada página em JPEG
+com `optimize=True` e qualidade inicial 70. Se o resultado não for menor que a versão PNG,
+a qualidade é reduzida para 50.
+
 ---
 
 ## Backend/**init**.py


### PR DESCRIPTION
## Summary
- compress preview images as JPEG in `preview_arquivo_pdf`
- mention the compression step in backend docs

## Testing
- `pytest tests/test_preview_pdf.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6851676b90a8832fbe58f4562c60bebe