### PR TITLE
Fix catalog processing loop indentation

### DIFF
--- a/Backend/routers/produtos.py
+++ b/Backend/routers/produtos.py
@@ -223,8 +223,6 @@ async def _tarefa_processar_catalogo(
                 erros.extend(dup_errors)
                 created.extend(created_page)
                 updated.extend(updated_page)
-                for db_produto in created_page:
-                created, dup_errors = crud_produtos.create_produtos_bulk(db, produtos_create, user_id=user_id)
                 for err in dup_errors:
                     if err.get("duplicado"):
                         linha = err.get("linha_original", {})
@@ -244,7 +242,7 @@ async def _tarefa_processar_catalogo(
                             updated.append({"before": before, "after": after})
                             continue
                     erros.append(err)
-                for db_produto in created:
+                for db_produto in created_page:
                     crud.create_registro_uso_ia(
                         db,
                         schemas.RegistroUsoIACreate(


### PR DESCRIPTION
## Summary
- fix indentation in catalog import loop
- remove redundant bulk create call for product catalog processing

## Testing
- `python -m py_compile Backend/routers/produtos.py`


------
https://chatgpt.com/codex/tasks/task_e_6851689bb9a8832fad58ec1d993861ca