### PR TITLE
Fix pdfjs module path

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, lazy, Suspense } from 'react';
-import * as pdfjs from 'pdfjs-dist/legacy/build/pdf';
+import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.js';
 import Modal from '../common/Modal.jsx';
 
 if (pdfjs.GlobalWorkerOptions) {


### PR DESCRIPTION
## Summary
- fix Vite import path for pdfjs-dist

## Testing
- `npm run lint` *(fails: 159 errors)*
- `npm test -- -i` *(failed to capture results)*

------
https://chatgpt.com/codex/tasks/task_e_68516bdd4e58832fa58590f679b28cd1