### PR TITLE
Fix pdf worker import

### DIFF
--- a/Frontend/app/src/components/common/PdfRegionSelector.jsx
+++ b/Frontend/app/src/components/common/PdfRegionSelector.jsx
@@ -1,10 +1,9 @@
 import React, { useRef, useEffect, useState } from 'react';
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf';
+import workerSrc from 'pdfjs-dist/legacy/build/pdf.worker.js?url';
 
 if (pdfjs.GlobalWorkerOptions) {
-  // Use bundled worker for both browser and test environments
-  // eslint-disable-next-line global-require
-  pdfjs.GlobalWorkerOptions.workerSrc = require('pdfjs-dist/legacy/build/pdf.worker.js');
+  pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 }
 
 function PdfRegionSelector({ file, onSelect, initialPage = 1 }) {

--- a/Frontend/app/src/components/common/__tests__/PdfRegionSelector.test.jsx
+++ b/Frontend/app/src/components/common/__tests__/PdfRegionSelector.test.jsx
@@ -3,6 +3,8 @@ import { act } from 'react-dom/test-utils';
 import '@testing-library/jest-dom';
 import PdfRegionSelector from '../PdfRegionSelector.jsx';
 
+jest.mock('pdfjs-dist/legacy/build/pdf.worker.js?url', () => 'worker-src-stub', { virtual: true });
+
 jest.mock('pdfjs-dist/legacy/build/pdf', () => ({
   GlobalWorkerOptions: { workerSrc: '' },
   getDocument: jest.fn(() => ({

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect, useRef, lazy, Suspense } from 'react';
 import * as pdfjs from 'pdfjs-dist/legacy/build/pdf.js';
+import workerSrc from 'pdfjs-dist/legacy/build/pdf.worker.js?url';
 import Modal from '../common/Modal.jsx';
 
 if (pdfjs.GlobalWorkerOptions) {
-  // Use bundled worker for both browser and test environments
-  // eslint-disable-next-line global-require
-  pdfjs.GlobalWorkerOptions.workerSrc = require('pdfjs-dist/legacy/build/pdf.worker.js');
+  pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 }
 import fornecedorService from '../../services/fornecedorService';
 import { createProduto } from '../../services/productService';

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -3,6 +3,25 @@ import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import ImportCatalogWizard from '../ImportCatalogWizard.jsx';
 
+jest.mock('pdfjs-dist/legacy/build/pdf.worker.js?url', () => 'worker-src-stub', { virtual: true });
+jest.mock(
+  'pdfjs-dist/legacy/build/pdf.js',
+  () => ({
+    GlobalWorkerOptions: { workerSrc: '' },
+    getDocument: jest.fn(() => ({
+      promise: Promise.resolve({
+        getPage: jest.fn(() =>
+          Promise.resolve({
+            getViewport: () => ({ width: 100, height: 100 }),
+            render: () => ({ promise: Promise.resolve() }),
+          }),
+        ),
+      }),
+    })),
+  }),
+  { virtual: true },
+);
+
 jest.setTimeout(30000);
 
 global.URL.createObjectURL = jest.fn(() => 'blob:url');


### PR DESCRIPTION
## Summary
- use url version of pdf.worker.js and assign to `GlobalWorkerOptions.workerSrc`
- mock new worker import in Jest tests

## Testing
- `npm run lint` *(fails: could not resolve ESLint config)*
- `npm test` *(fails: ImportCatalogWizard tests time out)*

------
https://chatgpt.com/codex/tasks/task_e_6851863fe1a4832f84a2dad0fa0dddb1