### PR TITLE
Fix duplicate keys and pdfjs reference

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -6,10 +6,10 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = pdfjsWorker;
 
 import Modal from '../common/Modal.jsx';
 
-if (pdfjs.GlobalWorkerOptions) {
+if (pdfjsLib.GlobalWorkerOptions) {
   // Use bundled worker for both browser and test environments
   // eslint-disable-next-line global-require
-  pdfjs.GlobalWorkerOptions.workerSrc = require('pdfjs-dist/legacy/build/pdf.worker.js');
+  pdfjsLib.GlobalWorkerOptions.workerSrc = require('pdfjs-dist/legacy/build/pdf.worker.js');
 }
 import fornecedorService from '../../services/fornecedorService';
 import { createProduto } from '../../services/productService';
@@ -167,7 +167,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       reader.onload = async () => {
         try {
           const data = reader.result;
-          const doc = await pdfjs.getDocument({ data }).promise;
+          const doc = await pdfjsLib.getDocument({ data }).promise;
           const page = await doc.getPage(1);
           const viewport = page.getViewport({ scale: 1.5 });
           const canvas = document.createElement('canvas');

--- a/Frontend/app/src/pages/DashboardPage.jsx
+++ b/Frontend/app/src/pages/DashboardPage.jsx
@@ -219,7 +219,7 @@ function DashboardPage() {
                 <tbody>
                   {searchResults.length > 0 ? (
                     searchResults.map(item => (
-                      <tr key={item.id}>
+                      <tr key={`${item.type}-${item.id}`}>
                         <td>{item.type}</td>
                         <td className="bold-cell">{item.name}</td>
                         <td>-</td>


### PR DESCRIPTION
## Summary
- avoid duplicate keys in dashboard search results
- fix undefined pdfjs in ImportCatalogWizard by using pdfjsLib

## Testing
- `npm test --silent --prefix Frontend/app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685194799398832f8912cc41c749062f