### PR TITLE
Improve suggestion handling in React components

### DIFF
--- a/Frontend/app/src/components/ProductEditModal.jsx
+++ b/Frontend/app/src/components/ProductEditModal.jsx
@@ -393,8 +393,11 @@ const ProductEditModal = ({ isOpen, onClose, product, onProductUpdated }) => {
 
         try {
             const suggestionsData = await productService.getAtributoSuggestions(product.id);
-            if (suggestionsData && suggestionsData.sugestoes_atributos && suggestionsData.sugestoes_atributos.length > 0) {
-                const newSuggestions = suggestionsData.sugestoes_atributos.reduce((acc, item) => {
+            const sugestoes = Array.isArray(suggestionsData?.sugestoes_atributos)
+                ? suggestionsData.sugestoes_atributos
+                : [];
+            if (sugestoes.length > 0) {
+                const newSuggestions = sugestoes.reduce((acc, item) => {
                     acc[item.chave_atributo] = item.valor_sugerido;
                     return acc;
                 }, {});

--- a/Frontend/app/src/components/__tests__/ProductEditModal.test.jsx
+++ b/Frontend/app/src/components/__tests__/ProductEditModal.test.jsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import ProductEditModal from '../ProductEditModal.jsx';
+
+jest.mock('../../services/productService', () => ({
+  __esModule: true,
+  default: {
+    getProdutoById: jest.fn(() => Promise.resolve({
+      id: 1,
+      nome_base: 'Produto',
+      fornecedor_id: 1,
+      product_type_id: 1,
+    })),
+    getAtributoSuggestions: jest.fn(() => Promise.resolve({})),
+  },
+}));
+
+jest.mock('../../services/fornecedorService', () => ({
+  __esModule: true,
+  default: {
+    getFornecedores: jest.fn(() => Promise.resolve({ items: [] })),
+    getFornecedorById: jest.fn(() => Promise.resolve({ id: 1, nome: 'F' })),
+  },
+}));
+
+jest.mock('../../contexts/ProductTypeContext', () => ({
+  useProductTypes: () => ({ productTypes: [], addProductType: jest.fn() }),
+}));
+
+jest.mock('../../contexts/AuthContext', () => ({
+  useAuth: () => ({ isAuthenticated: true }),
+}));
+
+// Simple render helper
+const renderModal = () =>
+  render(<ProductEditModal isOpen={true} onClose={() => {}} product={{ id: 1 }} />);
+
+test('fetchGeminiSuggestions does not crash when API returns empty object', async () => {
+  renderModal();
+  // Switch to suggestions tab
+  await userEvent.click(screen.getByRole('button', { name: /sugestões ia/i }));
+  const btn = screen.getByRole('button', { name: /buscar sugestões \(gemini\)/i });
+  await userEvent.click(btn);
+  expect(btn).not.toBeDisabled();
+});

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -223,8 +223,9 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
           fornecedorId,
         );
       }
+      const headers = Array.isArray(data.headers) ? data.headers : [];
       setPreview({
-        headers: data.headers,
+        headers,
         previewImages: data.previewImages || [],
         numPages: data.numPages,
         tablePages: data.tablePages || [],
@@ -233,7 +234,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       console.log('Preview latency:', latency);
       setPreviewLatency(latency);
       setMapping(
-        data.headers.reduce((acc, h) => {
+        headers.reduce((acc, h) => {
           acc[h] = '';
           return acc;
         }, {})

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -183,4 +183,23 @@ test('sends only selected pages', async () => {
   const pages = fornecedorService.finalizarImportacaoCatalogo.mock.calls[0][5];
   expect(Array.from(pages)).toEqual([1]);
 });
+
+test('handles missing headers gracefully', async () => {
+  fornecedorService.previewCatalogo.mockResolvedValueOnce({
+    fileId: 'f1',
+    sampleRows: [],
+    previewImages: [],
+    numPages: 1,
+  });
+
+  render(<ImportCatalogWizard isOpen={true} onClose={() => {}} fornecedorId={1} />);
+  const fileInput = document.querySelector('input[type="file"]');
+  const file = new File(['a'], 'test.csv', { type: 'text/csv' });
+  await userEvent.upload(fileInput, file);
+  await userEvent.click(screen.getByText('Gerar Preview'));
+  await userEvent.selectOptions(screen.getByRole('combobox'), '1');
+  await userEvent.click(screen.getByText('Continuar'));
+  const confirmBtn = await screen.findByText('Confirmar Importação');
+  expect(confirmBtn).toBeDisabled();
+});
 });


### PR DESCRIPTION
## Summary
- guard against undefined Gemini suggestions in `ProductEditModal`
- defensively assign headers in `ImportCatalogWizard`
- add regression tests for missing headers in `ImportCatalogWizard`
- add test covering empty suggestions in `ProductEditModal`

## Testing
- `npm run lint`
- `./scripts/run_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68519934ec40832fa6663d50aef8978a