### PR TITLE
Fix mapping headers for ImportCatalogWizard

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -218,7 +218,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
           fornecedorId,
         );
       }
-      const headers = Array.isArray(data.headers) ? data.headers : [];
+      const headers = Array.isArray(data?.headers) ? data.headers : [];
       setPreview({
         headers,
         previewImages: data.previewImages || [],


### PR DESCRIPTION
## Summary
- guard against undefined headers in ImportCatalogWizard

## Testing
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6851d69ed414832fb7934b339b50c49d