### PR TITLE
Limit PDF preview processing range

### DIFF
--- a/tests/test_file_processing_service.py
+++ b/tests/test_file_processing_service.py
@@ -60,6 +60,6 @@ async def test_preview_arquivo_pdf_returns_page_info():
 
     res = await file_processing_service.preview_arquivo_pdf(pdf_bytes, ".pdf")
     assert res.get("num_pages") == 2
-    assert isinstance(res.get("table_pages"), list)
+    assert res.get("table_pages") == []
     assert len(res["preview_images"]) == 1
     assert 1 in res["sample_rows"]

--- a/tests/test_preview_pdf.py
+++ b/tests/test_preview_pdf.py
@@ -53,7 +53,7 @@ async def test_preview_pdf_extracts_all():
     pdf_bytes = _create_pdf_with_table()
     res = await preview_arquivo_pdf(pdf_bytes, ".pdf")
     assert res["num_pages"] == 3
-    assert 2 in res["table_pages"]
+    assert res["table_pages"] == []
     assert len(res["preview_images"]) == 1
     assert {img["page"] for img in res["preview_images"]} == {1}
     assert len(res["sample_rows"]) == 1


### PR DESCRIPTION
## Summary
- restrict `preview_arquivo_pdf` to scan only the requested page range
- update docs accordingly
- adapt tests for new behaviour

## Testing
- `pytest -q tests/test_preview_pdf.py tests/test_file_processing_service.py`

------
https://chatgpt.com/codex/tasks/task_e_68520dbfd730832fb9ebc6bc676855af