### PR TITLE
Add paginated PDF preview

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -59,6 +59,8 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   const [dragOver, setDragOver] = useState(false);
   const [previewLatency, setPreviewLatency] = useState(null);
   const fileInputRef = useRef(null);
+  const [totalPages, setTotalPages] = useState(0);
+  const [loadedPages, setLoadedPages] = useState(0);
 
   const { productTypes, addProductType } = useProductTypes();
 
@@ -204,19 +206,30 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     setLoading(true);
     const t0 = performance.now();
     try {
-      let data = await fornecedorService.previewCatalogo(
-        file,
-        INITIAL_PREVIEW_PAGE_COUNT,
-        1,
-        fornecedorId,
-      );
-      if (data.numPages && data.numPages > INITIAL_PREVIEW_PAGE_COUNT) {
+      let data;
+      const isPdf =
+        file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
+      if (isPdf) {
+        data = await fornecedorService.previewPdf(file, 0, 20);
+        setTotalPages(data.totalPages || data.total_pages || 0);
+        setLoadedPages((data.pages || data.previewImages || []).length);
+      } else {
         data = await fornecedorService.previewCatalogo(
           file,
-          data.numPages,
+          INITIAL_PREVIEW_PAGE_COUNT,
           1,
           fornecedorId,
         );
+        if (data.numPages && data.numPages > INITIAL_PREVIEW_PAGE_COUNT) {
+          data = await fornecedorService.previewCatalogo(
+            file,
+            data.numPages,
+            1,
+            fornecedorId,
+          );
+        }
+        setTotalPages(data.numPages || 0);
+        setLoadedPages((data.previewImages || []).length);
       }
       const headers = Array.isArray(data?.headers) ? data.headers : [];
       setPreview({
@@ -299,6 +312,29 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       setIsTextModalOpen(true);
     } catch (err) {
       alert(err.detail || err.message || 'Erro ao pré-visualizar texto');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleLoadMore = async () => {
+    if (!file) return;
+    setLoading(true);
+    try {
+      const data = await fornecedorService.previewPdf(file, loadedPages, 20);
+      setPreview((prev) => ({
+        ...prev,
+        previewImages: [
+          ...(prev.previewImages || []),
+          ...(data.pages || data.previewImages || []),
+        ],
+      }));
+      setLoadedPages((prev) => prev + (data.pages ? data.pages.length : (data.previewImages || []).length));
+      if (data.totalPages || data.total_pages) {
+        setTotalPages(data.totalPages || data.total_pages);
+      }
+    } catch (err) {
+      alert(err.detail || err.message || 'Erro ao carregar mais páginas');
     } finally {
       setLoading(false);
     }
@@ -601,6 +637,11 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
             </button>
             {preview.tablePages && preview.tablePages.length > 0 && (
               <p>Páginas com tabelas: {preview.tablePages.join(', ')}</p>
+            )}
+            {loadedPages < totalPages && (
+              <button type="button" onClick={handleLoadMore} className="btn-small">
+                Carregar mais
+              </button>
             )}
           </div>
         )}

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -121,6 +121,26 @@ export const previewCatalogo = async (
   }
 };
 
+export const previewPdf = async (file, offset = 0, limit = 20) => {
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('offset', offset);
+    formData.append('limit', limit);
+    const response = await apiClient.post('/produtos/preview-pdf/', formData);
+    return response.data;
+  } catch (error) {
+    console.error(
+      'Erro ao pré-visualizar PDF:',
+      JSON.stringify(error.response?.data || error.message || error),
+    );
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao solicitar preview do PDF');
+  }
+};
+
 export const importCatalogo = async (fornecedorId, file, mapping = null) => {
   try {
     const formData = new FormData();
@@ -287,5 +307,6 @@ export default {
   reprocessCatalogFile,
   getImportacaoStatus,
   getImportacaoResult,
+  previewPdf,
   selecionarRegiao,
 };


### PR DESCRIPTION
## Summary
- add `totalPages` and `loadedPages` states to ImportCatalogWizard
- load the initial PDF preview with `previewPdf`
- allow fetching additional pages with `handleLoadMore`
- show a **Carregar mais** button when more pages are available
- expose new `previewPdf` function in `fornecedorService`

## Testing
- `npm test` *(fails: jest not found)*
- `pytest` *(fails: ModuleNotFoundError for jose)*


------
https://chatgpt.com/codex/tasks/task_e_6852be717944832f83f0880d0f1dfe23