### PR TITLE
Add previewPdf service

### DIFF
--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -255,6 +255,17 @@ export const getImportacaoResult = async (fileId) => {
   }
 };
 
+export const previewPdf = async (fornecedorId, file, offset = 0, limit = 20) => {
+  const formData = new FormData();
+  formData.append('file', file);
+  const resp = await apiClient.post(
+    `/fornecedores/${fornecedorId}/preview-pdf?offset=${offset}&limit=${limit}`,
+    formData,
+    { headers: { 'Content-Type': 'multipart/form-data' } }
+  );
+  return resp.data;
+};
+
 
 export const selecionarRegiao = async (fileId, page, bbox) => {
   try {
@@ -287,5 +298,6 @@ export default {
   reprocessCatalogFile,
   getImportacaoStatus,
   getImportacaoResult,
+  previewPdf,
   selecionarRegiao,
 };


### PR DESCRIPTION
## Summary
- support PDF previews for suppliers in frontend

## Testing
- `./scripts/run_tests.sh` *(fails: could not install fastapi)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852be71d9ac832fb3a196520754d88f