### PR TITLE
Handle PDF preview generation

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -47,6 +47,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   const [regionProducts, setRegionProducts] = useState(null);
   const [isRegionModalOpen, setIsRegionModalOpen] = useState(false);
   const [pdfUrl, setPdfUrl] = useState(null);
+  const [isPdfFile, setIsPdfFile] = useState(false);
   const [firstPageThumb, setFirstPageThumb] = useState(null);
   const [selectedPages, setSelectedPages] = useState(new Set());
   const [resultSummary, setResultSummary] = useState(null);
@@ -104,6 +105,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       setCurrentPreviewPage(0);
       setRegionPage(1);
       setPdfUrl(null);
+      setIsPdfFile(false);
       setFirstPageThumb(null);
       setSelectedPages(new Set());
       setStartPage(1);
@@ -152,6 +154,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     setFirstPageThumb(null);
     const isPdf =
       valid.type === 'application/pdf' || valid.name.toLowerCase().endsWith('.pdf');
+    setIsPdfFile(isPdf);
     if (isPdf) {
       const url = URL.createObjectURL(valid);
       setPdfUrl(url);
@@ -204,14 +207,15 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     setLoading(true);
     const t0 = performance.now();
     try {
-      let data = await fornecedorService.previewCatalogo(
+      const previewFn = isPdfFile ? fornecedorService.previewPdf : fornecedorService.previewCatalogo;
+      let data = await previewFn(
         file,
         INITIAL_PREVIEW_PAGE_COUNT,
         1,
         fornecedorId,
       );
       if (data.numPages && data.numPages > INITIAL_PREVIEW_PAGE_COUNT) {
-        data = await fornecedorService.previewCatalogo(
+        data = await previewFn(
           file,
           data.numPages,
           1,

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -47,6 +47,13 @@ jest.mock('../../../services/fornecedorService', () => ({
       previewImages: ['abc'],
       numPages: 2,
     })),
+    previewPdf: jest.fn(() => Promise.resolve({
+      fileId: 'f1',
+      headers: ['Nome'],
+      sampleRows: [{ Nome: 'Item' }],
+      previewImages: ['abc'],
+      numPages: 2,
+    })),
     selecionarRegiao: jest.fn(() => Promise.resolve({ produtos: [] })),
     finalizarImportacaoCatalogo: jest.fn(() => Promise.resolve({ status: 'PROCESSING', file_id: 'f1' })),
     getImportacaoStatus: jest.fn(() => Promise.resolve({ status: 'IMPORTED' })),
@@ -75,6 +82,7 @@ test('region modal sends selected page', async () => {
   const file = new File(['a'], 'test.pdf', { type: 'application/pdf' });
   await userEvent.upload(fileInput, file);
   await userEvent.click(screen.getByText('Gerar Preview'));
+  expect(fornecedorService.previewPdf).toHaveBeenCalled();
   const regionButton = await screen.findByText('Selecionar Região');
   await userEvent.click(regionButton);
   const modal = document.querySelector('.modal-content');
@@ -151,7 +159,7 @@ test('confirms import even when fileId is missing', async () => {
 
 
 test('sends only selected pages', async () => {
-  fornecedorService.previewCatalogo.mockResolvedValueOnce({
+  fornecedorService.previewPdf.mockResolvedValueOnce({
     fileId: 'f1',
     headers: ['Nome'],
     sampleRows: [{ Nome: 'Item' }],
@@ -163,6 +171,7 @@ test('sends only selected pages', async () => {
   const file = new File(['a'], 'test.pdf', { type: 'application/pdf' });
   await userEvent.upload(fileInput, file);
   await userEvent.click(screen.getByText('Gerar Preview'));
+  expect(fornecedorService.previewPdf).toHaveBeenCalled();
   const btn = await screen.findByText('Selecionar Região');
   await userEvent.click(btn);
   const modal = document.querySelector('.modal-content');

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -121,6 +121,42 @@ export const previewCatalogo = async (
   }
 };
 
+export const previewPdf = async (
+  file,
+  pageCount = 1,
+  startPage = 1,
+  fornecedorId = null,
+) => {
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('page_count', pageCount);
+    formData.append('start_page', startPage);
+    if (fornecedorId) {
+      formData.append('fornecedor_id', fornecedorId);
+    }
+    const response = await apiClient.post(
+      '/produtos/importar-catalogo-preview/',
+      formData,
+    );
+    const { file_id, headers, sample_rows, preview_images, num_pages, table_pages } = response.data;
+    return {
+      fileId: file_id,
+      headers,
+      sampleRows: sample_rows,
+      previewImages: preview_images,
+      numPages: num_pages,
+      tablePages: table_pages,
+    };
+  } catch (error) {
+    console.error('Erro ao gerar preview do PDF:', JSON.stringify(error.response?.data || error.message || error));
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao solicitar preview do PDF');
+  }
+};
+
 export const importCatalogo = async (fornecedorId, file, mapping = null) => {
   try {
     const formData = new FormData();
@@ -280,6 +316,7 @@ export default {
   updateFornecedor,
   deleteFornecedor,
   previewCatalogo,
+  previewPdf,
   importCatalogo,
   finalizarImportacaoCatalogo,
   getCatalogImportFiles,


### PR DESCRIPTION
## Summary
- support previewing PDF uploads in ImportCatalogWizard
- add `previewPdf` service method
- adjust unit tests for PDF preview path

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: jose)*

------
https://chatgpt.com/codex/tasks/task_e_6852be72b7a0832fab293e93a861383f