### PR TITLE
Add offset/limit pdf preview tests

### DIFF
--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -184,6 +184,45 @@ test('sends only selected pages', async () => {
   expect(Array.from(pages)).toEqual([1]);
 });
 
+test('loads more pages with correct offset', async () => {
+  fornecedorService.previewCatalogo.mockResolvedValueOnce({
+    fileId: 'f1',
+    headers: ['Nome'],
+    sampleRows: [{ Nome: 'Item' }],
+    previewImages: Array(2).fill('a'),
+    numPages: 4,
+  });
+  fornecedorService.previewCatalogo.mockResolvedValueOnce({
+    fileId: 'f1',
+    headers: ['Nome'],
+    sampleRows: [{ Nome: 'Item' }],
+    previewImages: Array(2).fill('b'),
+    numPages: 4,
+  });
+
+  render(<ImportCatalogWizard isOpen={true} onClose={() => {}} fornecedorId={1} />);
+  const fileInput = document.querySelector('input[type="file"]');
+  const file = new File(['a'], 'test.pdf', { type: 'application/pdf' });
+  await userEvent.upload(fileInput, file);
+  await userEvent.click(screen.getByText('Gerar Preview'));
+
+  expect(fornecedorService.previewCatalogo).toHaveBeenCalledWith(
+    file,
+    20,
+    1,
+    1,
+  );
+
+  await userEvent.click(screen.getByText('Próxima'));
+
+  expect(fornecedorService.previewCatalogo).toHaveBeenLastCalledWith(
+    file,
+    20,
+    3,
+    1,
+  );
+});
+
 test('handles missing headers gracefully', async () => {
   fornecedorService.previewCatalogo.mockResolvedValueOnce({
     fileId: 'f1',

--- a/tests/test_preview_pdf.py
+++ b/tests/test_preview_pdf.py
@@ -33,6 +33,18 @@ except ImportError:
 from Backend.services.file_processing_service import preview_arquivo_pdf
 
 
+def _create_pdf(pages: int = 1) -> bytes:
+    buf = io.BytesIO()
+    c = canvas.Canvas(buf)
+    for i in range(pages):
+        c.drawString(100, 750, f"Page {i + 1}")
+        if i < pages - 1:
+            c.showPage()
+    c.save()
+    buf.seek(0)
+    return buf.getvalue()
+
+
 def _create_pdf_with_table():
     buf = io.BytesIO()
     doc = SimpleDocTemplate(buf, pagesize=letter)
@@ -58,3 +70,12 @@ async def test_preview_pdf_extracts_all():
     assert {img["page"] for img in res["preview_images"]} == {1}
     assert len(res["sample_rows"]) == 1
     assert all(isinstance(v, str) for v in res["sample_rows"].values())
+
+
+@pytest.mark.asyncio
+async def test_preview_pdf_offset_and_limit():
+    pdf_bytes = _create_pdf(pages=5)
+    res = await preview_arquivo_pdf(pdf_bytes, ".pdf", start_page=2, page_count=2)
+    assert res["num_pages"] == 5
+    assert len(res["preview_images"]) == 2
+    assert {img["page"] for img in res["preview_images"]} == {2, 3}


### PR DESCRIPTION
## Summary
- test preview with offset/limit
- extend ImportCatalogWizard tests to assert offset when loading more pages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_6852be737944832fbe9d31a70e508b0a