### PR TITLE
Fix preview syntax errors

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -47,7 +47,6 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
   const [regionProducts, setRegionProducts] = useState(null);
   const [isRegionModalOpen, setIsRegionModalOpen] = useState(false);
   const [pdfUrl, setPdfUrl] = useState(null);
-  const [isPdfFile, setIsPdfFile] = useState(false);
   const [firstPageThumb, setFirstPageThumb] = useState(null);
   const [selectedPages, setSelectedPages] = useState(new Set());
   const [resultSummary, setResultSummary] = useState(null);
@@ -107,7 +106,6 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       setCurrentPreviewPage(0);
       setRegionPage(1);
       setPdfUrl(null);
-      setIsPdfFile(false);
       setFirstPageThumb(null);
       setSelectedPages(new Set());
       setStartPage(1);
@@ -156,7 +154,6 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     setFirstPageThumb(null);
     const isPdf =
       valid.type === 'application/pdf' || valid.name.toLowerCase().endsWith('.pdf');
-    setIsPdfFile(isPdf);
     if (isPdf) {
       const url = URL.createObjectURL(valid);
       setPdfUrl(url);
@@ -209,15 +206,6 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     setLoading(true);
     const t0 = performance.now();
     try {
-      const previewFn = isPdfFile ? fornecedorService.previewPdf : fornecedorService.previewCatalogo;
-      let data = await previewFn(
-        file,
-        INITIAL_PREVIEW_PAGE_COUNT,
-        1,
-        fornecedorId,
-      );
-      if (data.numPages && data.numPages > INITIAL_PREVIEW_PAGE_COUNT) {
-        data = await previewFn(
       let data;
       const isPdf =
         file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -121,36 +121,6 @@ export const previewCatalogo = async (
   }
 };
 
-
-export const previewPdf = async (
-  file,
-  pageCount = 1,
-  startPage = 1,
-  fornecedorId = null,
-) => {
-  try {
-    const formData = new FormData();
-    formData.append('file', file);
-    formData.append('page_count', pageCount);
-    formData.append('start_page', startPage);
-    if (fornecedorId) {
-      formData.append('fornecedor_id', fornecedorId);
-    }
-    const response = await apiClient.post(
-      '/produtos/importar-catalogo-preview/',
-      formData,
-    );
-    const { file_id, headers, sample_rows, preview_images, num_pages, table_pages } = response.data;
-    return {
-      fileId: file_id,
-      headers,
-      sampleRows: sample_rows,
-      previewImages: preview_images,
-      numPages: num_pages,
-      tablePages: table_pages,
-    };
-  } catch (error) {
-    console.error('Erro ao gerar preview do PDF:', JSON.stringify(error.response?.data || error.message || error));
 export const previewPdf = async (file, offset = 0, limit = 20) => {
   try {
     const formData = new FormData();
@@ -305,17 +275,6 @@ export const getImportacaoResult = async (fileId) => {
   }
 };
 
-export const previewPdf = async (fornecedorId, file, offset = 0, limit = 20) => {
-  const formData = new FormData();
-  formData.append('file', file);
-  const resp = await apiClient.post(
-    `/fornecedores/${fornecedorId}/preview-pdf?offset=${offset}&limit=${limit}`,
-    formData,
-    { headers: { 'Content-Type': 'multipart/form-data' } }
-  );
-  return resp.data;
-};
-
 
 export const selecionarRegiao = async (fileId, page, bbox) => {
   try {
@@ -341,7 +300,6 @@ export default {
   updateFornecedor,
   deleteFornecedor,
   previewCatalogo,
-  previewPdf,
   importCatalogo,
   finalizarImportacaoCatalogo,
   getCatalogImportFiles,


### PR DESCRIPTION
## Summary
- revert fornecedorService preview functions to correct version
- restore ImportCatalogWizard preview logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852c1a930d8832f96b7e9d05e03a420