### PR TITLE
Update PDF preview endpoint

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -210,7 +210,7 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
       const isPdf =
         file.type === 'application/pdf' || file.name.toLowerCase().endsWith('.pdf');
       if (isPdf) {
-        data = await fornecedorService.previewPdf(file, 0, 20);
+        data = await fornecedorService.previewPdf(file, 0, 20, fornecedorId);
         setTotalPages(data.totalPages || data.total_pages || 0);
         setLoadedPages((data.pages || data.previewImages || []).length);
       } else {
@@ -321,7 +321,12 @@ function ImportCatalogWizard({ isOpen, onClose, fornecedorId }) {
     if (!file) return;
     setLoading(true);
     try {
-      const data = await fornecedorService.previewPdf(file, loadedPages, 20);
+      const data = await fornecedorService.previewPdf(
+        file,
+        loadedPages,
+        20,
+        fornecedorId,
+      );
       setPreview((prev) => ({
         ...prev,
         previewImages: [

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -82,7 +82,7 @@ test('region modal sends selected page', async () => {
   const file = new File(['a'], 'test.pdf', { type: 'application/pdf' });
   await userEvent.upload(fileInput, file);
   await userEvent.click(screen.getByText('Gerar Preview'));
-  expect(fornecedorService.previewPdf).toHaveBeenCalled();
+  expect(fornecedorService.previewPdf).toHaveBeenCalledWith(file, 0, 20, 1);
   const regionButton = await screen.findByText('Selecionar Região');
   await userEvent.click(regionButton);
   const modal = document.querySelector('.modal-content');
@@ -171,7 +171,7 @@ test('sends only selected pages', async () => {
   const file = new File(['a'], 'test.pdf', { type: 'application/pdf' });
   await userEvent.upload(fileInput, file);
   await userEvent.click(screen.getByText('Gerar Preview'));
-  expect(fornecedorService.previewPdf).toHaveBeenCalled();
+  expect(fornecedorService.previewPdf).toHaveBeenCalledWith(file, 0, 20, 1);
   const btn = await screen.findByText('Selecionar Região');
   await userEvent.click(btn);
   const modal = document.querySelector('.modal-content');

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -121,13 +121,21 @@ export const previewCatalogo = async (
   }
 };
 
-export const previewPdf = async (file, offset = 0, limit = 20) => {
+export const previewPdf = async (
+  file,
+  offset = 0,
+  limit = 20,
+  fornecedorId,
+) => {
   try {
     const formData = new FormData();
     formData.append('file', file);
     formData.append('offset', offset);
     formData.append('limit', limit);
-    const response = await apiClient.post('/produtos/preview-pdf/', formData);
+    const response = await apiClient.post(
+      `/fornecedores/${fornecedorId}/preview-pdf`,
+      formData,
+    );
     return response.data;
   } catch (error) {
     console.error(

--- a/README.md
+++ b/README.md
@@ -462,6 +462,11 @@ Ao finalizar a importação de um arquivo previamente enviado com
 tanto o `product_type_id` quanto o `fornecedor_id` no corpo da requisição.
 Esses identificadores serão anexados a todos os produtos extraídos do arquivo.
 
+Para gerar um preview das páginas de um PDF antes da importação utilize
+`POST /fornecedores/{fornecedor_id}/preview-pdf` enviando o arquivo em
+`multipart/form-data` e, opcionalmente, os parâmetros `offset` e `limit` para
+paginação.
+
 ---
 
 ## 🧪 Testes


### PR DESCRIPTION
## Summary
- send fornecedorId when previewing PDFs
- update ImportCatalogWizard calls
- adapt tests for new API signature
- document PDF preview endpoint in README

## Testing
- `scripts/run_tests.sh` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.2)*

------
https://chatgpt.com/codex/tasks/task_e_6852c51ab798832f82d0299fe72b2fcf