### PR TITLE
Update previewPdf in fornecedor service

### DIFF
--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -122,19 +122,18 @@ export const previewCatalogo = async (
 };
 
 export const previewPdf = async (
+  fornecedorId,
   file,
   offset = 0,
   limit = 20,
-  fornecedorId,
 ) => {
   try {
     const formData = new FormData();
     formData.append('file', file);
-    formData.append('offset', offset);
-    formData.append('limit', limit);
     const response = await apiClient.post(
-      `/fornecedores/${fornecedorId}/preview-pdf`,
+      `/fornecedores/${fornecedorId}/preview-pdf?offset=${offset}&limit=${limit}`,
       formData,
+      { headers: { 'Content-Type': 'multipart/form-data' } },
     );
     return response.data;
   } catch (error) {


### PR DESCRIPTION
## Summary
- modify `previewPdf` signature to accept fornecedorId first
- build the form with just the PDF file
- send offset/limit as query parameters
- include multipart header in request

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_6852ca4f2648832f8f09ccff5d754b23