### PR TITLE
Update EditFornecedorModal wizard props

### DIFF
--- a/Frontend/app/src/components/fornecedores/EditFornecedorModal.jsx
+++ b/Frontend/app/src/components/fornecedores/EditFornecedorModal.jsx
@@ -180,9 +180,8 @@ function EditFornecedorModal({ isOpen, onClose, fornecedorData, onSave, isLoadin
           </div>
         )}
         <ImportCatalogWizard
-          isOpen={isImportWizardOpen}
+          fornecedor={fornecedorData}
           onClose={() => setIsImportWizardOpen(false)}
-          fornecedorId={fornecedorData.id}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- pass `fornecedor` prop to `ImportCatalogWizard`
- drop deprecated `isOpen` and `fornecedorId` props

## Testing
- `./scripts/run_tests.sh` *(fails: Could not download dependencies)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fd691f38832f8f122c03b65aac78