### PR TITLE
Update ImportCatalogWizard test to new props

### DIFF
--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -49,7 +49,7 @@ describe('ImportCatalogWizard', () => {
       .mockResolvedValueOnce({ pages: ['a', 'b'], totalPages: 3 })
       .mockResolvedValueOnce({ pages: ['c'], totalPages: 3 });
 
-    render(<ImportCatalogWizard isOpen={true} onClose={() => {}} fornecedorId={1} />);
+    render(<ImportCatalogWizard onClose={() => {}} fornecedor={{ id: 1 }} />);
 
     const fileInput = document.querySelector('input[type="file"]');
     const file = new File(['a'], 'test.pdf', { type: 'application/pdf' });
@@ -59,7 +59,7 @@ describe('ImportCatalogWizard', () => {
     expect(fornecedorService.previewPdf).toHaveBeenCalledWith(1, file, 0, 20);
     await screen.findByAltText('Página 1');
 
-    await userEvent.click(screen.getByText('Carregar mais'));
+    await userEvent.click(screen.getByText('Carregar mais páginas'));
     expect(fornecedorService.previewPdf).toHaveBeenLastCalledWith(1, file, 2, 20);
   });
 });


### PR DESCRIPTION
## Summary
- update ImportCatalogWizard test to use `fornecedor` prop and remove `isOpen`
- verify previewPdf calls after clicking "Carregar mais páginas"

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852fd698e84832fb0ca9bcfc1bb78d8