### PR TITLE
Add catalog region preview API

### DIFF
--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -549,6 +549,15 @@ class RegionExtractionRequest(BaseModel):
     import_file_id: int
     page_number: int
     region: List[float]
+
+class CatalogRegionPreviewRequest(BaseModel):
+    file_id: str
+    page_number: int
+    region: Optional[List[float]] = None
+
+class CatalogPreview(BaseModel):
+    columns: List[str]
+    data: List[Dict[str, Any]]
     
 # --- Rebuilds Finais ---
 UserResponse.model_rebuild()
@@ -569,3 +578,4 @@ CatalogImportFileResponse.model_rebuild()
 UserActivity.model_rebuild()
 SocialLoginConfig.model_rebuild()
 PdfPreviewResponse.model_rebuild()
+CatalogPreview.model_rebuild()


### PR DESCRIPTION
## Summary
- enable previewing selected catalog regions via `/fornecedores/preview-catalog-region`
- support `CatalogRegionPreviewRequest` and `CatalogPreview` schemas

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6853e62da288832f812bdd9755d6d609