### PR TITLE
Add pdf preview error state

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -1,6 +1,6 @@
 // Caminho: Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
 
-import React, { useState } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import * as fornecedorService from '../../services/fornecedorService';
 import LoadingPopup from '../common/LoadingPopup';
 import PdfRegionSelector from '../common/PdfRegionSelector';
@@ -12,6 +12,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
     const [loading, setLoading] = useState(false);
     const [loadingMessage, setLoadingMessage] = useState('');
     const [error, setError] = useState('');
+    const [pdfPreviewError, setPdfPreviewError] = useState(null);
 
     // Estados para a nossa lógica de pré-visualização paginada
     const [previewImages, setPreviewImages] = useState([]);


### PR DESCRIPTION
## Summary
- add `pdfPreviewError` state for ImportCatalogWizard
- extend React import to include `useEffect` and `useCallback`

## Testing
- `./scripts/run_tests.sh` *(fails: Could not find a version that satisfies the requirement fastapi==0.110.2)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e903af10832fa7077b6f85f05e5c