### PR TITLE
Add error handling for PdfRegionSelector preview

### DIFF
--- a/Frontend/app/src/components/common/PdfRegionSelector.jsx
+++ b/Frontend/app/src/components/common/PdfRegionSelector.jsx
@@ -6,7 +6,7 @@ if (pdfjs.GlobalWorkerOptions) {
   pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 }
 
-function PdfRegionSelector({ file, onSelect, initialPage = 1 }) {
+function PdfRegionSelector({ file, onSelect, initialPage = 1, onError = () => {} }) {
   const canvasRef = useRef(null);
   const pdfDocumentRef = useRef(null);
   const [pageNum, setPageNum] = useState(initialPage);
@@ -25,23 +25,27 @@ function PdfRegionSelector({ file, onSelect, initialPage = 1 }) {
 
     const load = async () => {
       if (!file) return;
-      task = pdfjs.getDocument({ data: file });
-      doc = await task.promise;
-      if (cancelled) {
-        doc.destroy();
-        return;
+      try {
+        task = pdfjs.getDocument({ data: file });
+        doc = await task.promise;
+        if (cancelled) {
+          doc.destroy();
+          return;
+        }
+        if (pdfDocumentRef.current) {
+          await pdfDocumentRef.current.destroy();
+        }
+        pdfDocumentRef.current = doc;
+        const page = await doc.getPage(pageNum);
+        const viewport = page.getViewport({ scale: 1.5 });
+        const canvas = canvasRef.current;
+        const ctx = canvas.getContext('2d');
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        await page.render({ canvasContext: ctx, viewport }).promise;
+      } catch (err) {
+        onError(err);
       }
-      if (pdfDocumentRef.current) {
-        await pdfDocumentRef.current.destroy();
-      }
-      pdfDocumentRef.current = doc;
-      const page = await doc.getPage(pageNum);
-      const viewport = page.getViewport({ scale: 1.5 });
-      const canvas = canvasRef.current;
-      const ctx = canvas.getContext('2d');
-      canvas.width = viewport.width;
-      canvas.height = viewport.height;
-      await page.render({ canvasContext: ctx, viewport }).promise;
     };
 
     load();
@@ -58,13 +62,17 @@ function PdfRegionSelector({ file, onSelect, initialPage = 1 }) {
     const renderPage = async () => {
       const doc = pdfDocumentRef.current;
       if (!doc) return;
-      const page = await doc.getPage(pageNum);
-      const viewport = page.getViewport({ scale: 1.5 });
-      const canvas = canvasRef.current;
-      const ctx = canvas.getContext('2d');
-      canvas.width = viewport.width;
-      canvas.height = viewport.height;
-      await page.render({ canvasContext: ctx, viewport }).promise;
+      try {
+        const page = await doc.getPage(pageNum);
+        const viewport = page.getViewport({ scale: 1.5 });
+        const canvas = canvasRef.current;
+        const ctx = canvas.getContext('2d');
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        await page.render({ canvasContext: ctx, viewport }).promise;
+      } catch (err) {
+        onError(err);
+      }
     };
     renderPage();
   }, [pageNum]);

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -12,6 +12,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
     const [loading, setLoading] = useState(false);
     const [loadingMessage, setLoadingMessage] = useState('');
     const [error, setError] = useState('');
+    const [pdfPreviewError, setPdfPreviewError] = useState('');
 
     // Estados para a nossa lógica de pré-visualização paginada
     const [previewImages, setPreviewImages] = useState([]);
@@ -30,6 +31,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         if (file && file.type === 'application/pdf') {
             setSelectedFile(file);
             setError('');
+            setPdfPreviewError('');
             setPreviewImages([]);
             setTotalPages(0);
             setLoadedPages(0);
@@ -45,6 +47,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         setLoading(true);
         setLoadingMessage('A gerar pré-visualização inicial...');
         setError('');
+        setPdfPreviewError('');
         try {
             const response = await fornecedorService.previewPdf(fornecedor.id, selectedFile);
 
@@ -71,6 +74,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         setLoading(true);
         setLoadingMessage('A carregar mais páginas...');
         setError('');
+        setPdfPreviewError('');
         try {
             const response = await fornecedorService.previewPdf(
                 fornecedor.id,
@@ -111,10 +115,18 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         }
     };
 
+    const handlePreviewError = (error) => {
+        console.error('Falha ao carregar a pré-visualização do PDF:', error);
+        setPdfPreviewError('Não foi possível carregar a pré-visualização do PDF. O arquivo pode estar corrompido ou em um formato não suportado. Por favor, tente com outro arquivo.');
+    };
+
     return (
         <div className="wizard-container">
             {loading && <LoadingPopup message={loadingMessage} isOpen={loading} />}
             {error && <p style={{ color: 'red', fontWeight: 'bold', border: '1px solid red', padding: '10px', marginTop: '10px' }}>{error}</p>}
+            {pdfPreviewError && (
+                <p style={{ color: 'red', fontWeight: 'bold', border: '1px solid red', padding: '10px', marginTop: '10px' }}>{pdfPreviewError}</p>
+            )}
             
             {step === 1 && (
                 <div>
@@ -133,6 +145,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
                     <PdfRegionSelector
                         imageUrls={previewImages}
                         onSelect={handleRegionSelect}
+                        onError={handlePreviewError}
                     />
                     
                     {loadedPages > 0 && (


### PR DESCRIPTION
## Summary
- manage PDF preview errors inside `ImportCatalogWizard`
- allow `PdfRegionSelector` to report errors via new `onError` prop

## Testing
- `npm test` *(fails: `jest` not found)*
- `./scripts/run_tests.sh` *(fails to install dependencies due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6853e90e5e20832f9656a427da3c4f66