### PR TITLE
Handle PDF preview errors

### DIFF
--- a/Frontend/app/src/components/common/PdfRegionSelector.jsx
+++ b/Frontend/app/src/components/common/PdfRegionSelector.jsx
@@ -6,7 +6,7 @@ if (pdfjs.GlobalWorkerOptions) {
   pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 }
 
-function PdfRegionSelector({ file, onSelect, initialPage = 1 }) {
+function PdfRegionSelector({ file, onSelect, initialPage = 1, onLoadError = () => {} }) {
   const canvasRef = useRef(null);
   const pdfDocumentRef = useRef(null);
   const [pageNum, setPageNum] = useState(initialPage);
@@ -25,23 +25,27 @@ function PdfRegionSelector({ file, onSelect, initialPage = 1 }) {
 
     const load = async () => {
       if (!file) return;
-      task = pdfjs.getDocument({ data: file });
-      doc = await task.promise;
-      if (cancelled) {
-        doc.destroy();
-        return;
+      try {
+        task = pdfjs.getDocument({ data: file });
+        doc = await task.promise;
+        if (cancelled) {
+          doc.destroy();
+          return;
+        }
+        if (pdfDocumentRef.current) {
+          await pdfDocumentRef.current.destroy();
+        }
+        pdfDocumentRef.current = doc;
+        const page = await doc.getPage(pageNum);
+        const viewport = page.getViewport({ scale: 1.5 });
+        const canvas = canvasRef.current;
+        const ctx = canvas.getContext('2d');
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        await page.render({ canvasContext: ctx, viewport }).promise;
+      } catch (e) {
+        onLoadError(e);
       }
-      if (pdfDocumentRef.current) {
-        await pdfDocumentRef.current.destroy();
-      }
-      pdfDocumentRef.current = doc;
-      const page = await doc.getPage(pageNum);
-      const viewport = page.getViewport({ scale: 1.5 });
-      const canvas = canvasRef.current;
-      const ctx = canvas.getContext('2d');
-      canvas.width = viewport.width;
-      canvas.height = viewport.height;
-      await page.render({ canvasContext: ctx, viewport }).promise;
     };
 
     load();
@@ -58,13 +62,17 @@ function PdfRegionSelector({ file, onSelect, initialPage = 1 }) {
     const renderPage = async () => {
       const doc = pdfDocumentRef.current;
       if (!doc) return;
-      const page = await doc.getPage(pageNum);
-      const viewport = page.getViewport({ scale: 1.5 });
-      const canvas = canvasRef.current;
-      const ctx = canvas.getContext('2d');
-      canvas.width = viewport.width;
-      canvas.height = viewport.height;
-      await page.render({ canvasContext: ctx, viewport }).promise;
+      try {
+        const page = await doc.getPage(pageNum);
+        const viewport = page.getViewport({ scale: 1.5 });
+        const canvas = canvasRef.current;
+        const ctx = canvas.getContext('2d');
+        canvas.width = viewport.width;
+        canvas.height = viewport.height;
+        await page.render({ canvasContext: ctx, viewport }).promise;
+      } catch (e) {
+        onLoadError(e);
+      }
     };
     renderPage();
   }, [pageNum]);

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -12,6 +12,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
     const [loading, setLoading] = useState(false);
     const [loadingMessage, setLoadingMessage] = useState('');
     const [error, setError] = useState('');
+    const [pdfPreviewError, setPdfPreviewError] = useState('');
 
     // Estados para a nossa lógica de pré-visualização paginada
     const [previewImages, setPreviewImages] = useState([]);
@@ -30,6 +31,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         if (file && file.type === 'application/pdf') {
             setSelectedFile(file);
             setError('');
+            setPdfPreviewError('');
             setPreviewImages([]);
             setTotalPages(0);
             setLoadedPages(0);
@@ -45,6 +47,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         setLoading(true);
         setLoadingMessage('A gerar pré-visualização inicial...');
         setError('');
+        setPdfPreviewError('');
         try {
             const response = await fornecedorService.previewPdf(fornecedor.id, selectedFile);
 
@@ -89,6 +92,12 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         }
     };
 
+    const handlePreviewError = (err) => {
+        console.error('Erro ao carregar PDF para seleção de região:', err);
+        const msg = err?.message || 'Falha ao carregar visualização do PDF.';
+        setPdfPreviewError(msg);
+    };
+
     const handleRegionSelect = async (selection) => {
         // selection deve conter { page: number, bbox: [x0, y0, x1, y1] }
         if (!uploadedFile) return;
@@ -130,10 +139,19 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
             {step === 2 && (
                 <div>
                     <h3>Passo 2: Selecione a Região da Tabela</h3>
-                    <PdfRegionSelector
-                        imageUrls={previewImages}
-                        onSelect={handleRegionSelect}
-                    />
+                    {pdfPreviewError ? (
+                        <div style={{ color: 'red', textAlign: 'center' }}>
+                            <p>Erro ao carregar PDF</p>
+                            <p>{pdfPreviewError}</p>
+                            <button onClick={() => setStep(1)}>Voltar</button>
+                        </div>
+                    ) : (
+                        <PdfRegionSelector
+                            imageUrls={previewImages}
+                            onSelect={handleRegionSelect}
+                            onLoadError={handlePreviewError}
+                        />
+                    )}
                     
                     {loadedPages > 0 && (
                         <div style={{ textAlign: 'center', marginTop: '1rem' }}>


### PR DESCRIPTION
## Summary
- handle PDF load/render errors inside `PdfRegionSelector`
- surface preview load errors in `ImportCatalogWizard`

## Testing
- `scripts/run_tests.sh` *(fails: Could not install fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6853e9157a5c832f83c158452a0f91f0