### PR TITLE
Fix PdfRegionSelector load error handling

### DIFF
--- a/Frontend/app/src/components/common/PdfRegionSelector.jsx
+++ b/Frontend/app/src/components/common/PdfRegionSelector.jsx
@@ -6,7 +6,7 @@ if (pdfjs.GlobalWorkerOptions) {
   pdfjs.GlobalWorkerOptions.workerSrc = workerSrc;
 }
 
-function PdfRegionSelector({ file, onSelect, initialPage = 1, onLoadError = () => {} }) {
+function PdfRegionSelector({ file, onSelect, initialPage = 1, onLoadError }) {
   const canvasRef = useRef(null);
   const pdfDocumentRef = useRef(null);
   const [pageNum, setPageNum] = useState(initialPage);
@@ -28,25 +28,6 @@ function PdfRegionSelector({ file, onSelect, initialPage = 1, onLoadError = () =
       try {
         task = pdfjs.getDocument({ data: file });
         doc = await task.promise;
-        if (cancelled) {
-          doc.destroy();
-          return;
-        }
-        if (pdfDocumentRef.current) {
-          await pdfDocumentRef.current.destroy();
-        }
-        pdfDocumentRef.current = doc;
-        const page = await doc.getPage(pageNum);
-        const viewport = page.getViewport({ scale: 1.5 });
-        const canvas = canvasRef.current;
-        const ctx = canvas.getContext('2d');
-        canvas.width = viewport.width;
-        canvas.height = viewport.height;
-        await page.render({ canvasContext: ctx, viewport }).promise;
-      } catch (err) {
-        onError(err);
-      } catch (e) {
-        onLoadError(e);
       } catch (err) {
         if (!cancelled && onLoadError) onLoadError(err);
         return;
@@ -55,6 +36,17 @@ function PdfRegionSelector({ file, onSelect, initialPage = 1, onLoadError = () =
         doc.destroy();
         return;
       }
+      if (pdfDocumentRef.current) {
+        await pdfDocumentRef.current.destroy();
+      }
+      pdfDocumentRef.current = doc;
+      const page = await doc.getPage(pageNum);
+      const viewport = page.getViewport({ scale: 1.5 });
+      const canvas = canvasRef.current;
+      const ctx = canvas.getContext('2d');
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+      await page.render({ canvasContext: ctx, viewport }).promise;
     };
 
     load();
@@ -71,19 +63,13 @@ function PdfRegionSelector({ file, onSelect, initialPage = 1, onLoadError = () =
     const renderPage = async () => {
       const doc = pdfDocumentRef.current;
       if (!doc) return;
-      try {
-        const page = await doc.getPage(pageNum);
-        const viewport = page.getViewport({ scale: 1.5 });
-        const canvas = canvasRef.current;
-        const ctx = canvas.getContext('2d');
-        canvas.width = viewport.width;
-        canvas.height = viewport.height;
-        await page.render({ canvasContext: ctx, viewport }).promise;
-      } catch (err) {
-        onError(err);
-      } catch (e) {
-        onLoadError(e);
-      }
+      const page = await doc.getPage(pageNum);
+      const viewport = page.getViewport({ scale: 1.5 });
+      const canvas = canvasRef.current;
+      const ctx = canvas.getContext('2d');
+      canvas.width = viewport.width;
+      canvas.height = viewport.height;
+      await page.render({ canvasContext: ctx, viewport }).promise;
     };
     renderPage();
   }, [pageNum]);

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -148,11 +148,6 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
             {step === 2 && (
                 <div>
                     <h3>Passo 2: Selecione a Região da Tabela</h3>
-                    <PdfRegionSelector
-                        imageUrls={previewImages}
-                        onSelect={handleRegionSelect}
-                        onError={handlePreviewError}
-                    />
                     {pdfPreviewError ? (
                         <div style={{ color: 'red', textAlign: 'center' }}>
                             <p>Erro ao carregar PDF</p>


### PR DESCRIPTION
## Summary
- fix PdfRegionSelector catch block and accept `onLoadError`
- simplify rendering logic and clean up ImportCatalogWizard

## Testing
- `npm test` *(fails: jest not found)*
- `pytest -q` *(fails: could not install reportlab)*

------
https://chatgpt.com/codex/tasks/task_e_6853f583e0fc832f96074e61afc4daee