### PR TITLE
Remove duplicate preview error handler

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -1,6 +1,6 @@
 // Caminho: Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
 
-import React, { useState, useEffect, useCallback } from 'react';
+import React, { useState } from 'react';
 import * as fornecedorService from '../../services/fornecedorService';
 import LoadingPopup from '../common/LoadingPopup';
 import PdfRegionSelector from '../common/PdfRegionSelector';
@@ -121,10 +121,6 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         }
     };
 
-    const handlePreviewError = (error) => {
-        console.error('Falha ao carregar a pré-visualização do PDF:', error);
-        setPdfPreviewError('Não foi possível carregar a pré-visualização do PDF. O arquivo pode estar corrompido ou em um formato não suportado. Por favor, tente com outro arquivo.');
-    };
 
     return (
         <div className="wizard-container">


### PR DESCRIPTION
## Summary
- clean up duplicate preview error handler
- trim React imports

## Testing
- `npm test` *(fails: jest not found)*
- `./scripts/run_tests.sh` *(fails: could not fetch fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_6853f8d953d8832f8001b526e92b33e9