### PR TITLE
Add OCR packages to backend requirements

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -28,3 +28,6 @@ psycopg2-binary
 jinja2
 pytest==8.2.1
 pytest-asyncio==0.23.6
+PyMuPDF
+pytesseract
+Pillow

--- a/requirements-backend.txt
+++ b/requirements-backend.txt
@@ -28,3 +28,6 @@ psycopg2-binary
 jinja2
 pytest==8.2.1
 pytest-asyncio==0.23.6
+PyMuPDF
+pytesseract
+Pillow

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -26,3 +26,6 @@ psycopg2-binary
 jinja2
 pytest
 pytest-asyncio
+PyMuPDF
+pytesseract
+Pillow


### PR DESCRIPTION
## Summary
- add PyMuPDF, pytesseract and Pillow to the backend requirement files

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68542a9ce690832f934546b92c62f6a1