### PR TITLE
Add previews folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,9 @@ Frontend/app/.env.*.local
 !Frontend/app/.env.sample
 
 Backend/static/uploads/
+Backend/static/previews/*
+!Backend/static/previews/
+!Backend/static/previews/.gitkeep
 static/uploads/
 # Arquivos específicos de IDEs para o frontend (se não cobertos pelo geral)
 # .project

--- a/Backend/core/config.py
+++ b/Backend/core/config.py
@@ -85,6 +85,7 @@ class Settings(BaseSettings):
 
     FRONTEND_URL: str = os.getenv("FRONTEND_URL", "http://localhost:5173")
     UPLOAD_DIRECTORY: str = os.getenv("UPLOAD_DIRECTORY", "static/uploads")
+    PREVIEW_DIRECTORY: str = os.getenv("PREVIEW_DIRECTORY", "static/previews")
     POPPLER_PATH: Optional[str] = os.getenv("POPPLER_PATH")
 
     OPENAI_API_KEY: Optional[str] = os.getenv("OPENAI_API_KEY")

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -665,7 +665,12 @@ def pdf_pages_to_images(db: Session, file: UploadFile, fornecedor_id: int, user_
     """
     upload_dir = Path(settings.UPLOAD_DIRECTORY)
     catalogs_dir = upload_dir / "catalogs"
-    previews_dir = upload_dir / "previews"
+    previews_dir = Path(settings.PREVIEW_DIRECTORY)
+
+    if not catalogs_dir.is_absolute():
+        catalogs_dir = Path(__file__).resolve().parent.parent / catalogs_dir
+    if not previews_dir.is_absolute():
+        previews_dir = Path(__file__).resolve().parent.parent / previews_dir
     
     catalogs_dir.mkdir(parents=True, exist_ok=True)
     previews_dir.mkdir(parents=True, exist_ok=True)
@@ -731,7 +736,7 @@ def pdf_pages_to_images(db: Session, file: UploadFile, fornecedor_id: int, user_
                 image_path = previews_dir / image_filename
                 image.save(image_path, "PNG")
                 
-                image_url = f"/static/uploads/previews/{image_filename}"
+                image_url = f"/static/previews/{image_filename}"
                 image_urls.append(image_url)
 
         except Exception as e:


### PR DESCRIPTION
## Summary
- add Backend/static/previews to `.gitignore`
- store PDF preview images in `Backend/static/previews`
- keep the folder using a `.gitkeep` placeholder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas/fastapi/reportlab due to no internet)*

------
https://chatgpt.com/codex/tasks/task_e_68542a9df8f0832f9f57459168595b11