### PR TITLE
Implement preview-pages endpoint

### DIFF
--- a/Backend/routers/fornecedores.py
+++ b/Backend/routers/fornecedores.py
@@ -5,6 +5,9 @@ from sqlalchemy import func
 from fastapi import APIRouter, Depends, HTTPException, Query, status, UploadFile, File
 from sqlalchemy.orm import Session
 import logging
+import uuid
+import os
+from pathlib import Path
 
 
 from Backend import crud_fornecedores
@@ -176,6 +179,27 @@ def update_mapping(
     db.commit()
     db.refresh(fornecedor)
     return fornecedor
+
+
+@router.post("/import/preview-pages")
+async def preview_pages(file: UploadFile = File(...)):
+    """Gera imagens de todas as páginas de um PDF enviado."""
+
+    if not file.filename.lower().endswith(".pdf"):
+        raise HTTPException(status_code=400, detail="Apenas arquivos PDF são permitidos.")
+
+    file_id = uuid.uuid4().hex
+    tmp_dir = Path(os.getenv("TMPDIR", "/tmp"))
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+    pdf_path = tmp_dir / f"{file_id}.pdf"
+
+    contents = await file.read()
+    with open(pdf_path, "wb") as out_file:
+        out_file.write(contents)
+
+    page_image_urls = file_processing_service.generate_pdf_page_images(str(pdf_path))
+
+    return {"file_id": file_id, "page_image_urls": page_image_urls}
 
 
 @router.post("/{fornecedor_id}/preview-pdf", response_model=schemas.PdfPreviewResponse)

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -857,3 +857,26 @@ async def extrair_pagina_pdf(
             pass
 
     return {"image": f"data:image/png;base64,{image_b64}", "text": text, "table": table}
+
+
+def generate_pdf_page_images(pdf_path: str) -> List[str]:
+    """Gera imagens PNG para todas as páginas de um PDF.
+
+    As imagens são salvas no mesmo diretório do arquivo e os caminhos
+    completos são retornados em uma lista.
+    """
+
+    poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
+    kwargs = {"poppler_path": poppler_dir} if poppler_dir else {}
+
+    images = convert_from_path(pdf_path, dpi=200, **kwargs)
+    base_dir = Path(pdf_path).parent
+    base_name = Path(pdf_path).stem
+    urls: List[str] = []
+
+    for idx, image in enumerate(images, start=1):
+        img_path = base_dir / f"{base_name}_{idx}.png"
+        image.save(img_path, "PNG")
+        urls.append(str(img_path))
+
+    return urls


### PR DESCRIPTION
## Summary
- add `/fornecedores/import/preview-pages` endpoint
- generate PDF page images using new `generate_pdf_page_images`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, fastapi, jose, reportlab)*

------
https://chatgpt.com/codex/tasks/task_e_68542aa2c91c832f841d728d1fc263d0