### PR TITLE
Add PDF job processing helper

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -857,3 +857,105 @@ async def extrair_pagina_pdf(
             pass
 
     return {"image": f"data:image/png;base64,{image_b64}", "text": text, "table": table}
+
+
+def extract_data_from_single_page(file_path: str, page_number: int) -> List[Dict[str, Any]]:
+    """Return raw row dictionaries extracted from a single PDF page."""
+
+    rows: List[Dict[str, Any]] = []
+    with pdfplumber.open(file_path) as pdf:
+        if not (1 <= page_number <= len(pdf.pages)):
+            raise ValueError(
+                f"Número de página inválido: {page_number}. PDF tem {len(pdf.pages)} páginas."
+            )
+
+        page = pdf.pages[page_number - 1]
+
+        tables = page.extract_tables(
+            table_settings={"vertical_strategy": "lines", "horizontal_strategy": "lines"}
+        )
+
+        if tables:
+            for table in tables:
+                if not table or len(table) < 2:
+                    continue
+
+                headers_raw = table[0]
+                headers = [
+                    _limpar_valor_extraido(h) or f"coluna_{idx}"
+                    for idx, h in enumerate(headers_raw)
+                ]
+
+                for row in table[1:]:
+                    if len(row) != len(headers):
+                        continue
+                    rows.append({headers[i]: row[i] for i in range(len(headers))})
+
+        if not rows:
+            text = page.extract_text(x_tolerance=2, y_tolerance=2) or ""
+            if text:
+                lines = [l.strip() for l in text.splitlines() if l.strip()]
+                data_dict: Dict[str, Any] = {}
+                for line in lines:
+                    if ":" in line:
+                        k, v = line.split(":", 1)
+                        data_dict[k.strip()] = v.strip()
+                if data_dict:
+                    rows.append(data_dict)
+                elif lines:
+                    rows.append({f"col_{i}": v for i, v in enumerate(lines)})
+
+    return rows
+
+
+async def process_pdf_job(
+    job_id: int, pdf_path: str, start_page: int = 1, mapping: Optional[Dict[str, str]] = None
+) -> None:
+    """Process remaining pages of a PDF catalog import job."""
+
+    db: Optional[Session] = None
+    catalog_file: Optional[models.CatalogImportFile] = None
+    try:
+        db = SessionLocal()
+        catalog_file = db.query(models.CatalogImportFile).filter_by(id=job_id).first()
+        if not catalog_file:
+            logger.error("CatalogImportFile %s not found", job_id)
+            return
+
+        with pdfplumber.open(pdf_path) as pdf:
+            total_pages = len(pdf.pages)
+
+        catalog_file.status = "PROCESSING"
+        catalog_file.total_pages = total_pages
+        catalog_file.pages_processed = 0
+        db.commit()
+
+        products: List[Dict[str, Any]] = []
+
+        for page in range(start_page, total_pages + 1):
+            try:
+                raw_rows = extract_data_from_single_page(pdf_path, page)
+            except Exception as e:  # pragma: no cover - robustness
+                logger.error("Erro ao extrair dados da pagina %s: %s", page, e)
+                continue
+
+            for row in raw_rows:
+                produto = _processar_linha_padronizada(row, mapping)
+                if produto:
+                    products.append(produto)
+
+            catalog_file.pages_processed += 1
+            if catalog_file.pages_processed % 5 == 0:
+                db.commit()
+
+        catalog_file.result_summary = {"products": products}
+        catalog_file.status = "PENDING_REVIEW"
+        db.commit()
+    except Exception:
+        logger.exception("Erro ao processar job de PDF")
+        if db and catalog_file:
+            catalog_file.status = "FAILED"
+            db.commit()
+    finally:
+        if db:
+            db.close()


### PR DESCRIPTION
## Summary
- extract rows from a single PDF page
- add async `process_pdf_job` for catalog PDF import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_68542aa36910832fa6a3d79350027c14