### PR TITLE
Implement page selection import wizard

### DIFF
--- a/Frontend/app/src/components/common/ImportProgress.jsx
+++ b/Frontend/app/src/components/common/ImportProgress.jsx
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+import fornecedorService from '../../services/fornecedorService';
+
+function ImportProgress({ fileId, onDone }) {
+  const [status, setStatus] = useState(null);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let timer;
+    const poll = async () => {
+      try {
+        const s = await fornecedorService.getImportacaoStatus(fileId);
+        setStatus(s);
+        if (s.status === 'IMPORTED' || s.status === 'DONE') {
+          clearInterval(timer);
+          try {
+            const result = await fornecedorService.getImportacaoResult(fileId);
+            if (onDone) onDone(result);
+          } catch (e) {
+            if (onDone) onDone(null);
+          }
+        }
+      } catch (e) {
+        setError(e.message || 'Erro ao consultar status');
+        clearInterval(timer);
+      }
+    };
+    poll();
+    timer = setInterval(poll, 3000);
+    return () => clearInterval(timer);
+  }, [fileId, onDone]);
+
+  if (error) {
+    return <p style={{ color: 'red' }}>{error}</p>;
+  }
+  if (!status) {
+    return <p>Iniciando processamento...</p>;
+  }
+  return (
+    <div>
+      <p>
+        Processando {status.pages_processed} de {status.pages_total} páginas...
+      </p>
+    </div>
+  );
+}
+
+export default ImportProgress;

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -3,178 +3,212 @@
 import React, { useState } from 'react';
 import * as fornecedorService from '../../services/fornecedorService';
 import LoadingPopup from '../common/LoadingPopup';
-import PdfRegionSelector from '../common/PdfRegionSelector';
+import ColumnMappingModal from '../common/ColumnMappingModal.jsx';
+import ImportProgress from '../common/ImportProgress.jsx';
+import getBackendBaseUrl from '../../utils/backend.js';
+
+const FIELD_OPTIONS = [
+  { value: 'nome_base', label: 'Nome Base' },
+  { value: 'sku', label: 'SKU' },
+  { value: 'preco_venda', label: 'Preço' },
+];
 
 const ImportCatalogWizard = ({ fornecedor, onClose }) => {
-    // Estados para controlar o fluxo passo a passo
-    const [step, setStep] = useState(1);
-    const [selectedFile, setSelectedFile] = useState(null);
-    const [loading, setLoading] = useState(false);
-    const [loadingMessage, setLoadingMessage] = useState('');
-    const [error, setError] = useState('');
-    const [pdfPreviewError, setPdfPreviewError] = useState(null);
+  const [step, setStep] = useState('upload');
+  const [selectedFile, setSelectedFile] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [loadingMessage, setLoadingMessage] = useState('');
+  const [error, setError] = useState('');
 
-    // Estados para a nossa lógica de pré-visualização paginada
-    const [previewImages, setPreviewImages] = useState([]);
-    const [totalPages, setTotalPages] = useState(0);
-    const [loadedPages, setLoadedPages] = useState(0);
+  const [fileId, setFileId] = useState(null);
+  const [pageImages, setPageImages] = useState([]);
+  const [totalPages, setTotalPages] = useState(0);
 
-    // Informações retornadas após upload inicial do PDF
-    const [uploadedFile, setUploadedFile] = useState(null);
+  const [mappingHeaders, setMappingHeaders] = useState([]);
+  const [mappingRows, setMappingRows] = useState([]);
+  const [showMappingModal, setShowMappingModal] = useState(false);
+  const [mapping, setMapping] = useState(null);
+  const [importResult, setImportResult] = useState(null);
 
-    // Dados extraídos da seleção de região
-    const [extractedColumns, setExtractedColumns] = useState([]);
-    const [previewRows, setPreviewRows] = useState([]);
+  const backendBaseUrl = getBackendBaseUrl();
 
-    const handleFileChange = (event) => {
-        const file = event.target.files[0];
-        if (file && file.type === 'application/pdf') {
-            setSelectedFile(file);
-            setError('');
-            setPdfPreviewError('');
-            setPreviewImages([]);
-            setTotalPages(0);
-            setLoadedPages(0);
-            setStep(1);
-        } else {
-            setError('Por favor, selecione um ficheiro PDF válido.');
-            setSelectedFile(null);
-        }
-    };
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    if (file && file.type === 'application/pdf') {
+      setSelectedFile(file);
+      setError('');
+    } else {
+      setError('Por favor, selecione um ficheiro PDF válido.');
+      setSelectedFile(null);
+    }
+  };
 
-    const handleGeneratePreview = async () => {
-        if (!selectedFile) return;
-        setLoading(true);
-        setLoadingMessage('A gerar pré-visualização inicial...');
-        setError('');
-        setPdfPreviewError('');
-        try {
-            const response = await fornecedorService.previewPdf(fornecedor.id, selectedFile);
+  const handleGeneratePreview = async () => {
+    if (!selectedFile) return;
+    setLoading(true);
+    setLoadingMessage('A gerar pré-visualização inicial...');
+    setError('');
+    try {
+      const response = await fornecedorService.previewPdf(
+        fornecedor.id,
+        selectedFile,
+      );
+      setFileId(response.import_file_id);
+      setPageImages(response.image_urls || []);
+      setTotalPages(response.total_pages || 0);
+      setStep('select_page');
+    } catch (err) {
+      const detail = err.response?.data?.detail || err.message;
+      setError(`Erro: ${detail}`);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-            // CORREÇÃO CRÍTICA: Usa 'image_urls' e 'total_pages' como vem da API
-            setPreviewImages(response.image_urls || []);
-            setTotalPages(response.total_pages || 0);
-            setLoadedPages((response.image_urls || []).length);
-            if (response.import_file_id) {
-                setUploadedFile({ id: response.import_file_id });
-            }
+  const handleLoadMore = async () => {
+    if (!selectedFile) return;
+    setLoading(true);
+    setLoadingMessage('A carregar mais páginas...');
+    try {
+      const response = await fornecedorService.previewPdf(
+        fornecedor.id,
+        selectedFile,
+        pageImages.length,
+        20,
+      );
+      setPageImages((prev) => [...prev, ...(response.image_urls || [])]);
+    } catch (err) {
+      const detail = err.response?.data?.detail || err.message;
+      setError(`Erro: ${detail}`);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-            setStep(2); // Avança para o passo de visualização
-        } catch (err) {
-            console.error("Erro ao gerar pré-visualização:", err);
-            const errorDetail = err.response?.data?.detail || err.message || 'Falha ao gerar pré-visualização.';
-            setError(`Erro: ${errorDetail}`);
-        } finally {
-            setLoading(false);
-        }
-    };
+  const handlePageClick = async (page) => {
+    if (!fileId) return;
+    setLoading(true);
+    setLoadingMessage('Extraindo dados da página...');
+    try {
+      const data = await fornecedorService.fetchPageDataForMapping(fileId, page);
+      if (data.table && data.table.length > 0) {
+        const headers = data.table[0].map((h) => String(h));
+        const rows = data.table.slice(1).map((r) => {
+          const obj = {};
+          headers.forEach((h, idx) => {
+            obj[h] = r[idx];
+          });
+          return obj;
+        });
+        setMappingHeaders(headers);
+        setMappingRows(rows.slice(0, 5));
+      } else {
+        setMappingHeaders([]);
+        setMappingRows([]);
+      }
+      setShowMappingModal(true);
+    } catch (err) {
+      const detail = err.response?.data?.detail || err.message;
+      setError(`Erro: ${detail}`);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-    const handleLoadMore = async () => {
-        if (!selectedFile) return;
-        setLoading(true);
-        setLoadingMessage('A carregar mais páginas...');
-        setError('');
-        setPdfPreviewError('');
-        try {
-            const response = await fornecedorService.previewPdf(
-                fornecedor.id,
-                selectedFile,
-                loadedPages, // Offset
-                20          // Limit
-            );
-            setPreviewImages(prev => [...prev, ...(response.image_urls || [])]);
-            setLoadedPages(prev => prev + (response.image_urls || []).length);
-        } catch (err) {
-            console.error("Erro ao carregar mais páginas:", err);
-            const errorDetail = err.response?.data?.detail || err.message || 'Não foi possível carregar mais páginas.';
-            setError(`Erro: ${errorDetail}`);
-        } finally {
-            setLoading(false);
-        }
-    };
+  const handleConfirmMapping = async (map) => {
+    setShowMappingModal(false);
+    setMapping(map);
+    setLoading(true);
+    setLoadingMessage('Iniciando processamento...');
+    try {
+      await fornecedorService.finalizarImportacaoCatalogo(
+        fileId,
+        fornecedor.id,
+        map,
+      );
+      setStep('processing');
+    } catch (err) {
+      const detail = err.response?.data?.detail || err.message;
+      setError(`Erro: ${detail}`);
+    } finally {
+      setLoading(false);
+    }
+  };
 
-    const handlePreviewError = (err) => {
-        console.error('Erro ao carregar PDF para seleção de região:', err);
-        const msg = err?.message || 'Falha ao carregar visualização do PDF.';
-        setPdfPreviewError(msg);
-    };
-
-    const handleRegionSelect = async (selection) => {
-        // selection deve conter { page: number, bbox: [x0, y0, x1, y1] }
-        if (!uploadedFile) return;
-        setLoading(true);
-        try {
-            const requestBody = {
-                file_id: uploadedFile.id,
-                page_number: selection.page,
-                region: selection.bbox,
-            };
-            const previewData = await fornecedorService.previewCatalogRegion(requestBody);
-            setExtractedColumns(previewData.columns);
-            setPreviewRows(previewData.data);
-            setStep(3);
-        } catch (error) {
-            console.error('Erro ao pré-visualizar dados da região:', error);
-            alert('Não foi possível extrair dados. Tente selecionar novamente.');
-        } finally {
-            setLoading(false);
-        }
-    };
+  const handleProcessDone = (result) => {
+    setImportResult(result);
+    setStep('review');
+  };
 
 
-    return (
-        <div className="wizard-container">
-            {loading && <LoadingPopup message={loadingMessage} isOpen={loading} />}
-            {error && <p style={{ color: 'red', fontWeight: 'bold', border: '1px solid red', padding: '10px', marginTop: '10px' }}>{error}</p>}
-            {pdfPreviewError && (
-                <p style={{ color: 'red', fontWeight: 'bold', border: '1px solid red', padding: '10px', marginTop: '10px' }}>{pdfPreviewError}</p>
-            )}
-            
-            {step === 1 && (
-                <div>
-                    <h3>Passo 1: Selecione o Catálogo PDF</h3>
-                    <input type="file" accept=".pdf" onChange={handleFileChange} />
-                    {selectedFile && <p>Ficheiro selecionado: {selectedFile.name}</p>}
-                    <button onClick={handleGeneratePreview} disabled={!selectedFile || loading}>
-                        Gerar Amostra de Preview
-                    </button>
-                </div>
-            )}
+  return (
+    <div className="wizard-container">
+      {loading && <LoadingPopup message={loadingMessage} isOpen={loading} />}
+      {error && (
+        <p style={{ color: 'red', fontWeight: 'bold', border: '1px solid red', padding: '10px', marginTop: '10px' }}>
+          {error}
+        </p>
+      )}
 
-            {step === 2 && (
-                <div>
-                    <h3>Passo 2: Selecione a Região da Tabela</h3>
-                    {pdfPreviewError ? (
-                        <div style={{ color: 'red', textAlign: 'center' }}>
-                            <p>Erro ao carregar PDF</p>
-                            <p>{pdfPreviewError}</p>
-                            <button onClick={() => setStep(1)}>Voltar</button>
-                        </div>
-                    ) : (
-                        <PdfRegionSelector
-                            imageUrls={previewImages}
-                            onSelect={handleRegionSelect}
-                            onLoadError={handlePreviewError}
-                        />
-                    )}
-                    
-                    {loadedPages > 0 && (
-                        <div style={{ textAlign: 'center', marginTop: '1rem' }}>
-                            <p>Mostrando {loadedPages} de {totalPages} páginas.</p>
-                            {loadedPages < totalPages && (
-                                <button onClick={handleLoadMore} disabled={loading}>
-                                    {loading ? 'A carregar...' : 'Carregar mais páginas'}
-                                </button>
-                            )}
-                        </div>
-                    )}
-                </div>
-            )}
-            
-            <hr style={{ margin: '20px 0' }} />
-            <button type="button" onClick={onClose}>Fechar</button>
+      {step === 'upload' && (
+        <div>
+          <h3>Passo 1: Selecione o Catálogo PDF</h3>
+          <input type="file" accept=".pdf" onChange={handleFileChange} />
+          {selectedFile && <p>Ficheiro selecionado: {selectedFile.name}</p>}
+          <button onClick={handleGeneratePreview} disabled={!selectedFile || loading}>
+            Gerar Preview
+          </button>
         </div>
-    );
+      )}
+
+      {step === 'select_page' && (
+        <div>
+          <h3>Passo 2: Escolha a página da tabela</h3>
+          <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+            {pageImages.map((url, idx) => (
+              <img
+                key={idx}
+                src={`${backendBaseUrl}${url}`}
+                alt={`Página ${idx + 1}`}
+                style={{ maxWidth: '120px', margin: '0.5em', cursor: 'pointer' }}
+                onClick={() => handlePageClick(idx + 1)}
+              />
+            ))}
+          </div>
+          {pageImages.length < totalPages && (
+            <button onClick={handleLoadMore} disabled={loading}>
+              Carregar mais páginas
+            </button>
+          )}
+        </div>
+      )}
+
+      {step === 'processing' && fileId && (
+        <ImportProgress fileId={fileId} onDone={handleProcessDone} />
+      )}
+
+      {step === 'review' && importResult && (
+        <div>
+          <h3>Importação Concluída</h3>
+          <pre>{JSON.stringify(importResult, null, 2)}</pre>
+        </div>
+      )}
+
+      <ColumnMappingModal
+        isOpen={showMappingModal}
+        onClose={() => setShowMappingModal(false)}
+        headers={mappingHeaders}
+        rows={mappingRows}
+        fieldOptions={FIELD_OPTIONS}
+        onConfirm={handleConfirmMapping}
+      />
+
+      <hr style={{ margin: '20px 0' }} />
+      <button type="button" onClick={onClose}>
+        Fechar
+      </button>
+    </div>
+  );
 };
 
 export default ImportCatalogWizard;

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -319,6 +319,25 @@ export const previewCatalogRegion = async (previewRequest) => {
   }
 };
 
+export const fetchPageDataForMapping = async (fileId, pageNumber) => {
+  try {
+    const response = await apiClient.post('/produtos/extrair-pagina-unica/', {
+      file_id: fileId,
+      page_number: pageNumber,
+    });
+    return response.data;
+  } catch (error) {
+    console.error(
+      'Erro ao extrair pagina:',
+      JSON.stringify(error.response?.data || error.message || error),
+    );
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao extrair dados da pagina');
+  }
+};
+
 export default {
   getFornecedores,
   getFornecedorById,
@@ -334,6 +353,7 @@ export default {
   getImportacaoStatus,
   getImportacaoResult,
   previewPdf,
+  fetchPageDataForMapping,
   selecionarRegiao,
   previewCatalogRegion,
 };


### PR DESCRIPTION
## Summary
- add ImportProgress component to show processing status
- extend fornecedor service with fetchPageDataForMapping
- overhaul ImportCatalogWizard to support page selection and mapping flow

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68542aa72560832faad6d42689f06f5d