### PR TITLE
Update requirements.txt with PDF packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,6 @@ psycopg2-binary
 jinja2
 pytest==8.2.1
 pytest-asyncio==0.23.6
+PyMuPDF
+pytesseract
+Pillow


### PR DESCRIPTION
## Summary
- add PyMuPDF, pytesseract and Pillow to requirements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for packages, internet disabled)*

------
https://chatgpt.com/codex/tasks/task_e_685430e57b6c832f96a921f01ca9aef5