### PR TITLE
Fix PDF page utils

### DIFF
--- a/Backend/routers/fornecedores.py
+++ b/Backend/routers/fornecedores.py
@@ -268,7 +268,9 @@ async def preview_pages(file: UploadFile = File(...)):
     with open(pdf_path, "wb") as out_file:
         out_file.write(contents)
 
-    page_image_urls = file_processing_service.generate_pdf_page_images(str(pdf_path))
+    page_image_urls = file_processing_service.generate_pdf_page_images(
+        str(pdf_path), file_id
+    )
 
     return {"file_id": file_id, "page_image_urls": page_image_urls}
 


### PR DESCRIPTION
## Summary
- clean up duplicate PDF helpers
- add OCR fallback to `extract_data_from_single_page`
- update preview endpoints for new API

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas, fastapi, reportlab)*

------
https://chatgpt.com/codex/tasks/task_e_685430e7321c832fb25fa801d07aa996