### PR TITLE
Update PDF import docs

### DIFF
--- a/README Backend.md
+++ b/README Backend.md
@@ -25,7 +25,9 @@
 ## Dependência para conversão de PDF
 
 * Para gerar previews de PDF é necessário instalar o pacote `poppler-utils` (ex.: `apt install poppler-utils`). Sem ele o backend não conseguirá converter PDFs em imagens, e o preview de PDF não será gerado.
-* Instale também `PyMuPDF`, `pytesseract` e `Pillow` via `pip`, além do executável **Tesseract OCR** (`apt install tesseract-ocr`). Estes componentes são usados para extrair texto de PDFs e imagens.
+* Instale também `PyMuPDF`, `pytesseract` e `Pillow` via `pip` – bibliotecas necessárias para extrair texto e gerar previews.
+* Certifique-se de que o diretório `Backend/static/previews/` exista (ou ajuste `PREVIEW_DIRECTORY` no `.env`) para armazenar as miniaturas.
+* Executável **Tesseract OCR** (`apt install tesseract-ocr`). Estes componentes são usados para extrair texto de PDFs e imagens.
 
 ### Poppler no Windows
 
@@ -260,10 +262,10 @@ os.cpu_count() + 4)`` se nenhuma outra configuração for informada.
 
 ### Fluxo completo de importação de PDF
 
-1. **Pré-visualização** – `POST /produtos/importar-catalogo-preview/` salva o arquivo e retorna `file_id` com miniaturas das páginas.
-2. **Seleção de região** – `POST /produtos/selecionar-regiao/` identifica colunas e amostras a partir de uma área escolhida. O endpoint `POST /fornecedores/preview-catalog-region` pode auxiliar nessa etapa.
-3. **Finalização** – `POST /produtos/importar-catalogo-finalizar/{file_id}/` processa o PDF por completo usando o mapeamento definido.
-4. **Acompanhamento** – `GET /produtos/importar-catalogo-status/{file_id}/` e `GET /produtos/importar-catalogo-result/{file_id}/` permitem consultar o progresso e o resumo da importação.
+1. **Pré-visualização** – `POST /fornecedores/import/preview-pages` salva o arquivo e retorna `file_id` com miniaturas das páginas.
+2. **Seleção de região** – `GET /fornecedores/import/extract-page-data` usa `file_id` e `page_number` para identificar colunas e amostras de uma página.
+3. **Finalização** – `POST /fornecedores/import/process-full-catalog` processa o PDF por completo usando o mapeamento definido.
+4. **Acompanhamento** – `GET /fornecedores/import/progress/{job_id}` e `GET /fornecedores/import/review/{job_id}` permitem consultar o progresso e o resumo da importação.
 
 ## Backend/routers/social\_auth.py
 

--- a/README.md
+++ b/README.md
@@ -190,7 +190,10 @@ CatalogAI-0525-Dev/
 * PostgreSQL 12+ (obrigatório em produção; SQLite pode ser usado apenas para desenvolvimento e testes)
 * Git
 * Pacote `poppler-utils` (ex.: `apt install poppler-utils`) para que a conversão de PDFs em imagens funcione. Sem ele o preview de PDF não será gerado
-* Bibliotecas **PyMuPDF**, **pytesseract** e **Pillow** – instaladas via `pip`
+* Bibliotecas **PyMuPDF**, **pytesseract** e **Pillow** – instaladas via `pip`,
+  necessárias para extrair texto e gerar previews de PDFs
+* Diretório `Backend/static/previews/` (ou defina `PREVIEW_DIRECTORY` no `.env`)
+  para armazenar as miniaturas geradas
 * Ferramenta **Tesseract OCR** no sistema (`apt install tesseract-ocr`)
 * Navegadores Playwright (para scraping):
   `playwright install`
@@ -472,17 +475,16 @@ paginação.
 #### Processo de importação de PDF em quatro etapas
 
 1. **Pré-visualizar** – envie o arquivo pelo endpoint
-   `POST /produtos/importar-catalogo-preview/`. A resposta traz o `file_id`
+   `POST /fornecedores/import/preview-pages`. A resposta traz o `file_id`
    e miniaturas das páginas.
-2. **Selecionar região** – com o `file_id` em mãos, chame
-   `POST /produtos/selecionar-regiao/` definindo página e `bbox` para extrair
-   colunas e linhas de amostra. O endpoint `POST /fornecedores/preview-catalog-region`
-   pode ser usado para testar diferentes áreas.
+2. **Selecionar região** – utilize
+   `GET /fornecedores/import/extract-page-data` informando `file_id` e
+   `page_number` para obter colunas e linhas de amostra.
 3. **Finalizar** – confirme o processamento com
-   `POST /produtos/importar-catalogo-finalizar/{file_id}/`, enviando o mapeamento,
-   `fornecedor_id`, `product_type_id` e as páginas desejadas.
-4. **Acompanhar** – consulte `GET /produtos/importar-catalogo-status/{file_id}/`
-   ou `GET /produtos/importar-catalogo-result/{file_id}/` para verificar o resumo
+   `POST /fornecedores/import/process-full-catalog`, enviando o `file_id`,
+   `fornecedor_id` e `tipo_produto_id`.
+4. **Acompanhar** – consulte `GET /fornecedores/import/progress/{job_id}` ou
+   `GET /fornecedores/import/review/{job_id}` para verificar o status e o resumo
    final da importação.
 
 ---


### PR DESCRIPTION
## Summary
- document PyMuPDF, pytesseract and Pillow in README
- mention `/static/previews/` directory
- update PDF import instructions to reference new `/fornecedores/import/...` routes

## Testing
- `./scripts/run_tests.sh` *(fails: Could not install packages)*

------
https://chatgpt.com/codex/tasks/task_e_685430edbbcc832f8a06e96c0f5723db