### PR TITLE
Refactor fornecedor import service endpoints

### DIFF
--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -34,7 +34,8 @@ jest.mock('../../../contexts/ProductTypeContext', () => ({
 jest.mock('../../../services/fornecedorService', () => ({
   __esModule: true,
   default: {
-    previewPdf: jest.fn(),
+    uploadForPagePreview: jest.fn(),
+    startFullProcess: jest.fn(() => Promise.resolve({ job_id: 1 })),
   },
 }));
 import fornecedorService from '../../../services/fornecedorService';
@@ -44,10 +45,11 @@ describe('ImportCatalogWizard', () => {
     jest.clearAllMocks();
   });
 
-  test('generates preview and loads more pages', async () => {
-    fornecedorService.previewPdf
-      .mockResolvedValueOnce({ pages: ['a', 'b'], totalPages: 3 })
-      .mockResolvedValueOnce({ pages: ['c'], totalPages: 3 });
+  test('generates preview', async () => {
+    fornecedorService.uploadForPagePreview.mockResolvedValue({
+      file_id: 1,
+      page_image_urls: ['a', 'b'],
+    });
 
     render(<ImportCatalogWizard fornecedor={{ id: 1 }} onClose={() => {}} />);
     render(<ImportCatalogWizard onClose={() => {}} fornecedor={{ id: 1 }} />);
@@ -58,10 +60,7 @@ describe('ImportCatalogWizard', () => {
     await userEvent.upload(fileInput, file);
     await userEvent.click(screen.getByText('Gerar Preview'));
 
-    expect(fornecedorService.previewPdf).toHaveBeenCalledWith(1, file, 0, 20);
+    expect(fornecedorService.uploadForPagePreview).toHaveBeenCalledWith(file);
     await screen.findByAltText('Página 1');
-
-    await userEvent.click(screen.getByText('Carregar mais páginas'));
-    expect(fornecedorService.previewPdf).toHaveBeenLastCalledWith(1, file, 2, 20);
   });
 });


### PR DESCRIPTION
## Summary
- point pdf import helpers to new /fornecedores/import API
- clean fornecedorService duplicates
- switch wizard to new service calls
- update ImportCatalogWizard tests

## Testing
- `npm test --silent` *(fails: jest not found)*
- `pytest -q` *(fails: ModuleNotFoundError: 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_685430e90f9c832f85d03c10b97a259d