### PR TITLE
Add pinned pytesseract version

### DIFF
--- a/Backend/requirements.txt
+++ b/Backend/requirements.txt
@@ -31,3 +31,4 @@ pytest-asyncio==0.23.6
 PyMuPDF
 pytesseract
 Pillow
+pytesseract==0.3.10


### PR DESCRIPTION
## Summary
- add pytesseract==0.3.10 to backend requirements

## Testing
- `./scripts/run_tests.sh` *(fails: Could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6854a00235e4832f9b3b1c2ca87031c8