### PR TITLE
Fix catalog file path retrieval

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -757,7 +757,7 @@ def get_file_path_by_id(db: Session, file_id: str) -> str:
         return None
 
     base_dir = os.path.join("Backend", "static", "uploads", "catalogs")
-    return os.path.join(base_dir, import_file.file_name)
+    return os.path.join(base_dir, import_file.stored_filename)
 
 
 def extract_data_from_pdf_region(


### PR DESCRIPTION
## Summary
- fix `get_file_path_by_id` to return the path built from `stored_filename`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_6857491dbd80832fa3dbbf782c16f9b3