### PR TITLE
Add pdf_bytes_to_images wrapper

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -659,6 +659,41 @@ async def gerar_preview(
     raise ValueError("Formato de arquivo não suportado para preview")
 
 
+async def pdf_bytes_to_images(
+    conteudo_arquivo: bytes,
+    max_pages: int = 1,
+    start_page: int = 1,
+    dpi: int = 200,
+) -> List[str]:
+    """Convert PDF bytes to base64 encoded PNG images."""
+
+    loop = asyncio.get_running_loop()
+
+    def _convert() -> List[str]:
+        poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
+        kwargs = {"poppler_path": poppler_dir} if poppler_dir else {}
+
+        last_page = None if max_pages == 0 else start_page + max_pages - 1
+
+        images = convert_from_bytes(
+            conteudo_arquivo,
+            first_page=start_page,
+            last_page=last_page,
+            dpi=dpi,
+            fmt="png",
+            **kwargs,
+        )
+
+        result: List[str] = []
+        for img in images:
+            buf = io.BytesIO()
+            img.save(buf, format="PNG")
+            result.append(base64.b64encode(buf.getvalue()).decode())
+        return result
+
+    return await loop.run_in_executor(None, _convert)
+
+
 def pdf_pages_to_images(db: Session, file: UploadFile, fornecedor_id: int, user_id: int, offset: int, limit: int) -> Dict[str, Any]:
     """
     Salva um ficheiro PDF, cria um registo na base de dados, e converte um lote de páginas em imagens.

--- a/tests/test_file_processing_service.py
+++ b/tests/test_file_processing_service.py
@@ -42,7 +42,7 @@ async def test_pdf_pages_to_images_returns_base64():
     c.save()
     pdf_bytes = buf.getvalue()
 
-    images = await file_processing_service.pdf_pages_to_images(pdf_bytes, max_pages=1)
+    images = await file_processing_service.pdf_bytes_to_images(pdf_bytes, max_pages=1)
     assert len(images) == 1
     decoded = base64.b64decode(images[0])
     assert decoded.startswith(b"\x89PNG")

--- a/tests/test_pdf_pages_to_images.py
+++ b/tests/test_pdf_pages_to_images.py
@@ -12,7 +12,7 @@ except ImportError:  # pragma: no cover - install at runtime
 
 import pytest
 
-from Backend.services.file_processing_service import pdf_pages_to_images
+from Backend.services.file_processing_service import pdf_bytes_to_images
 
 
 def _create_pdf(pages: int = 1) -> bytes:
@@ -30,7 +30,7 @@ def _create_pdf(pages: int = 1) -> bytes:
 @pytest.mark.asyncio
 async def test_pdf_pages_to_images_basic():
     pdf_bytes = _create_pdf()
-    images = await pdf_pages_to_images(pdf_bytes)
+    images = await pdf_bytes_to_images(pdf_bytes)
     assert len(images) >= 1
     decoded = base64.b64decode(images[0])
     assert decoded.startswith(b"\x89PNG")
@@ -39,13 +39,13 @@ async def test_pdf_pages_to_images_basic():
 @pytest.mark.asyncio
 async def test_pdf_pages_to_images_respects_max_pages():
     pdf_bytes = _create_pdf(pages=3)
-    images = await pdf_pages_to_images(pdf_bytes, max_pages=2)
+    images = await pdf_bytes_to_images(pdf_bytes, max_pages=2)
     assert len(images) == 2
 
 
 @pytest.mark.asyncio
 async def test_pdf_pages_to_images_start_page():
     pdf_bytes = _create_pdf(pages=5)
-    first_page_img = await pdf_pages_to_images(pdf_bytes, max_pages=1, start_page=1)
-    third_page_img = await pdf_pages_to_images(pdf_bytes, max_pages=1, start_page=3)
+    first_page_img = await pdf_bytes_to_images(pdf_bytes, max_pages=1, start_page=1)
+    third_page_img = await pdf_bytes_to_images(pdf_bytes, max_pages=1, start_page=3)
     assert first_page_img[0] != third_page_img[0]


### PR DESCRIPTION
## Summary
- add async `pdf_bytes_to_images` helper that converts PDF bytes into images
- update file processing service tests to use the new helper
- adjust PDF page tests to call the wrapper

## Testing
- `pytest tests/test_file_processing_service.py::test_pdf_pages_to_images_returns_base64 tests/test_pdf_pages_to_images.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68574bf47d30832faa59bdaf51e5c5c3