### PR TITLE
Document Poppler dependency and improve test setup

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Build test image
         run: docker build -f Dockerfile.test -t catalogai-test .
       - name: Run tests
-        run: docker run --rm catalogai-test
+        run: docker run --rm -e POPPLER_PATH=/usr/bin catalogai-test

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -12,6 +12,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pdf2image import convert_from_bytes, convert_from_path
 import time
 from typing import List, Dict, Any, Union, Optional
+import shutil
 from pathlib import Path
 from uuid import uuid4
 from fastapi import UploadFile, HTTPException
@@ -541,6 +542,12 @@ async def preview_arquivo_pdf(
 
     start = time.perf_counter()
 
+    poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
+    if shutil.which("pdftoppm", path=poppler_dir) is None:
+        msg = "Poppler pdftoppm executable not found. Install poppler-utils or set POPPLER_PATH."
+        logger.error(msg)
+        return {"error": msg}
+
     try:
         with pdf_open(io.BytesIO(conteudo_arquivo)) as reader:
             num_pages = len(reader.pages)
@@ -674,6 +681,12 @@ def pdf_pages_to_images(db: Session, file: UploadFile, fornecedor_id: int, user_
     
     catalogs_dir.mkdir(parents=True, exist_ok=True)
     previews_dir.mkdir(parents=True, exist_ok=True)
+
+    poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
+    if shutil.which("pdftoppm", path=poppler_dir) is None:
+        msg = "Poppler pdftoppm executable not found. Install poppler-utils or set POPPLER_PATH."
+        logger.error(msg)
+        raise HTTPException(status_code=500, detail=msg)
     
     random_filename = f"{uuid.uuid4().hex}.pdf"
     file_location = catalogs_dir / random_filename

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,7 +1,11 @@
 FROM python:3.11-slim
 WORKDIR /app
 COPY requirements-backend.txt .
-RUN pip install --no-cache-dir -r requirements-backend.txt
+# install poppler-utils for pdftoppm
+RUN apt-get update && \
+    apt-get install -y poppler-utils && \
+    pip install --no-cache-dir -r requirements-backend.txt && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 COPY . .
 ENV FIRST_SUPERUSER_EMAIL="admin@example.com" \
     FIRST_SUPERUSER_PASSWORD="adminpass" \

--- a/README Backend.md
+++ b/README Backend.md
@@ -24,7 +24,7 @@
 
 ## Dependência para conversão de PDF
 
-* Para gerar previews de PDF é necessário instalar o pacote `poppler-utils` (ex.: `apt install poppler-utils`). Sem ele o backend não conseguirá converter PDFs em imagens, e o preview de PDF não será gerado.
+* Para gerar previews de PDF é necessário instalar o pacote `poppler-utils` (ex.: `apt install poppler-utils`). Sem ele o backend não conseguirá converter PDFs em imagens, o preview não será gerado e os testes que lidam com PDFs irão falhar.
 * Instale também `PyMuPDF`, `pytesseract` e `Pillow` via `pip` – bibliotecas necessárias para extrair texto e gerar previews.
 * Certifique-se de que o diretório `Backend/static/previews/` exista (ou ajuste `PREVIEW_DIRECTORY` no `.env`) para armazenar as miniaturas.
 * Executável **Tesseract OCR** (`apt install tesseract-ocr`). Estes componentes são usados para extrair texto de PDFs e imagens.

--- a/README Frontend.md
+++ b/README Frontend.md
@@ -7,7 +7,7 @@
 
 ## Dependência para pré-visualização de PDF
 
-* A geração de previews de PDF depende do pacote `poppler-utils` instalado no sistema (por exemplo, `apt install poppler-utils`). Sem ele o backend não consegue converter PDFs em imagens, e o frontend não exibirá a pré-visualização do arquivo.
+* A geração de previews de PDF depende do pacote `poppler-utils` instalado no sistema (por exemplo, `apt install poppler-utils`). Sem ele o backend não consegue converter PDFs em imagens, o frontend não exibirá a pré-visualização do arquivo e os testes relacionados a PDF irão falhar.
 
 ### Poppler no Windows
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ CatalogAI-0525-Dev/
 * Node.js 18+
 * PostgreSQL 12+ (obrigatório em produção; SQLite pode ser usado apenas para desenvolvimento e testes)
 * Git
-* Pacote `poppler-utils` (ex.: `apt install poppler-utils`) para que a conversão de PDFs em imagens funcione. Sem ele o preview de PDF não será gerado
+* Pacote `poppler-utils` (ex.: `apt install poppler-utils`) para que a conversão de PDFs em imagens funcione. Sem ele o preview de PDF não será gerado e os testes relacionados a PDF falharão
 * Bibliotecas **PyMuPDF**, **pytesseract** e **Pillow** – instaladas via `pip`,
   necessárias para extrair texto e gerar previews de PDFs
 * Diretório `Backend/static/previews/` (ou defina `PREVIEW_DIRECTORY` no `.env`)
@@ -298,6 +298,11 @@ dependências de testes `pytest` e `pytest-asyncio`. Para isso, rode:
 ```sh
 pip install -r requirements-backend.txt
 ```
+
+Para que os testes que lidam com PDFs funcionem é necessário ter o Poppler instalados.
+Em distribuições Linux instale o pacote `poppler-utils` (`apt install poppler-utils`).
+Em outros sistemas, disponibilize o executável `pdftoppm` e defina a variável de
+ambiente `POPPLER_PATH` apontando para seu diretório.
 
 Você também pode utilizar o script abaixo, que instala as dependências e executa
 o `pytest` automaticamente:

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,4 +5,12 @@ export FIRST_SUPERUSER_EMAIL="admin@example.com"
 export FIRST_SUPERUSER_PASSWORD="adminpass"
 export ADMIN_EMAIL="admin@example.com"
 export ADMIN_PASSWORD="adminpass"
+if ! command -v pdftoppm >/dev/null 2>&1; then
+    if [ -n "$POPPLER_PATH" ] && [ -x "$POPPLER_PATH/pdftoppm" ]; then
+        export PATH="$POPPLER_PATH:$PATH"
+    else
+        echo "pdftoppm not found. Install poppler-utils or set POPPLER_PATH." >&2
+        exit 1
+    fi
+fi
 pytest "$@"


### PR DESCRIPTION
## Summary
- mention poppler-utils as required dependency and for running tests
- document Poppler setup in README Backend/Frontend
- update Dockerfile and CI to install poppler-utils
- check for missing pdftoppm in PDF helper functions
- make test script verify pdftoppm presence

## Testing
- `pip install -r requirements-backend.txt`
- `pytest -q` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68574bf33680832fb02029876e3c6ba1