### PR TITLE
Document Poppler requirement

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -19,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install poppler-utils
+        run: sudo apt-get update && sudo apt-get install -y poppler-utils
       - name: Install backend requirements
         run: pip install -r requirements-backend.txt
       - name: Build test image

--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -544,7 +544,10 @@ async def preview_arquivo_pdf(
 
     poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
     if shutil.which("pdftoppm", path=poppler_dir) is None:
-        msg = "Poppler pdftoppm executable not found. Install poppler-utils or set POPPLER_PATH."
+        msg = (
+            "Poppler (pdftoppm) executable not found. Install poppler-utils on Linux "
+            "or set POPPLER_PATH to its directory."
+        )
         logger.error(msg)
         return {"error": msg}
 
@@ -678,6 +681,13 @@ async def pdf_bytes_to_images(
 
     def _convert() -> List[str]:
         poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
+        if shutil.which("pdftoppm", path=poppler_dir) is None:
+            msg = (
+                "Poppler (pdftoppm) executable not found. Install poppler-utils "
+                "on Linux or set POPPLER_PATH to its directory."
+            )
+            logger.error(msg)
+            raise RuntimeError(msg)
         kwargs = {"poppler_path": poppler_dir} if poppler_dir else {}
 
         last_page = None if max_pages == 0 else start_page + max_pages - 1
@@ -719,7 +729,10 @@ def pdf_pages_to_images(db: Session, file: UploadFile, fornecedor_id: int, user_
 
     poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
     if shutil.which("pdftoppm", path=poppler_dir) is None:
-        msg = "Poppler pdftoppm executable not found. Install poppler-utils or set POPPLER_PATH."
+        msg = (
+            "Poppler (pdftoppm) executable not found. Install poppler-utils on Linux "
+            "or set POPPLER_PATH to its directory."
+        )
         logger.error(msg)
         raise HTTPException(status_code=500, detail=msg)
     

--- a/README Backend.md
+++ b/README Backend.md
@@ -24,7 +24,7 @@
 
 ## Dependência para conversão de PDF
 
-* Para gerar previews de PDF é necessário instalar o pacote `poppler-utils` (ex.: `apt install poppler-utils`). Sem ele o backend não conseguirá converter PDFs em imagens, o preview não será gerado e os testes que lidam com PDFs irão falhar.
+* Para gerar previews de PDF é necessário instalar o pacote `poppler-utils` (ex.: `apt install poppler-utils`). Sem ele o backend não conseguirá converter PDFs em imagens, o preview não será gerado e os testes que lidam com PDFs irão falhar. Se utilizar binários externos, defina a variável `POPPLER_PATH` apontando para o diretório que contém `pdftoppm`. Nos pipelines de CI essa variável é configurada como `/usr/bin`.
 * Instale também `PyMuPDF`, `pytesseract` e `Pillow` via `pip` – bibliotecas necessárias para extrair texto e gerar previews.
 * Certifique-se de que o diretório `Backend/static/previews/` exista (ou ajuste `PREVIEW_DIRECTORY` no `.env`) para armazenar as miniaturas.
 * Executável **Tesseract OCR** (`apt install tesseract-ocr`). Estes componentes são usados para extrair texto de PDFs e imagens.

--- a/README Frontend.md
+++ b/README Frontend.md
@@ -7,7 +7,7 @@
 
 ## Dependência para pré-visualização de PDF
 
-* A geração de previews de PDF depende do pacote `poppler-utils` instalado no sistema (por exemplo, `apt install poppler-utils`). Sem ele o backend não consegue converter PDFs em imagens, o frontend não exibirá a pré-visualização do arquivo e os testes relacionados a PDF irão falhar.
+* A geração de previews de PDF depende do pacote `poppler-utils` instalado no sistema (por exemplo, `apt install poppler-utils`). Sem ele o backend não consegue converter PDFs em imagens, o frontend não exibirá a pré-visualização do arquivo e os testes relacionados a PDF irão falhar. Caso utilize binários externos, defina `POPPLER_PATH` apontando para o diretório que contém `pdftoppm`. Nos pipelines de CI essa variável é configurada como `/usr/bin`.
 
 ### Poppler no Windows
 

--- a/README.md
+++ b/README.md
@@ -189,7 +189,8 @@ CatalogAI-0525-Dev/
 * Node.js 18+
 * PostgreSQL 12+ (obrigatório em produção; SQLite pode ser usado apenas para desenvolvimento e testes)
 * Git
-* Pacote `poppler-utils` (ex.: `apt install poppler-utils`) para que a conversão de PDFs em imagens funcione. Sem ele o preview de PDF não será gerado e os testes relacionados a PDF falharão
+* Pacote `poppler-utils` (ex.: `apt install poppler-utils`) para que a conversão de PDFs em imagens funcione. Sem ele o preview de PDF não será gerado e os testes relacionados a PDF falharão. Caso utilize binários próprios, defina `POPPLER_PATH` apontando para o diretório que contém `pdftoppm`.
+  O Dockerfile de testes e os workflows de CI já instalam esse pacote por padrão.
 * Bibliotecas **PyMuPDF**, **pytesseract** e **Pillow** – instaladas via `pip`,
   necessárias para extrair texto e gerar previews de PDFs
 * Diretório `Backend/static/previews/` (ou defina `PREVIEW_DIRECTORY` no `.env`)
@@ -287,6 +288,7 @@ Principais variáveis obrigatórias:
 - `MAIL_USERNAME`, `MAIL_PASSWORD`, `MAIL_FROM` e `MAIL_SERVER`
 
 Em ambientes Windows, defina também `POPPLER_PATH` apontando para os binários do Poppler para que a conversão de PDFs funcione.
+Nos pipelines de CI, essa variável é configurada como `/usr/bin`.
 
 
 ### 6. **Testes**
@@ -303,6 +305,8 @@ Para que os testes que lidam com PDFs funcionem é necessário ter o Poppler ins
 Em distribuições Linux instale o pacote `poppler-utils` (`apt install poppler-utils`).
 Em outros sistemas, disponibilize o executável `pdftoppm` e defina a variável de
 ambiente `POPPLER_PATH` apontando para seu diretório.
+
+Nos pipelines de **CI** o pacote `poppler-utils` é instalado automaticamente e a variável `POPPLER_PATH` é definida para `/usr/bin`.
 
 Você também pode utilizar o script abaixo, que instala as dependências e executa
 o `pytest` automaticamente:
@@ -326,6 +330,8 @@ E execute os testes via container:
 ```sh
 docker run --rm catalogai-test
 ```
+
+O workflow de **CI** deste repositório também utiliza essa imagem para rodar os testes.
 
 ---
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,9 +8,12 @@ export ADMIN_PASSWORD="adminpass"
 if ! command -v pdftoppm >/dev/null 2>&1; then
     if [ -n "$POPPLER_PATH" ] && [ -x "$POPPLER_PATH/pdftoppm" ]; then
         export PATH="$POPPLER_PATH:$PATH"
-    else
-        echo "pdftoppm not found. Install poppler-utils or set POPPLER_PATH." >&2
-        exit 1
+    elif command -v apt-get >/dev/null 2>&1; then
+        apt-get update && apt-get install -y poppler-utils
     fi
+fi
+if ! command -v pdftoppm >/dev/null 2>&1; then
+    echo "pdftoppm not found. Install poppler-utils or set POPPLER_PATH." >&2
+    exit 1
 fi
 pytest "$@"


### PR DESCRIPTION
## Summary
- clarify Poppler requirement across docs
- note CI usage of `POPPLER_PATH`
- auto-install Poppler in test script and workflow
- raise clearer errors when Poppler is missing

## Testing
- `./scripts/run_tests.sh` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_685752c9c020832fba1db4196193f161