### PR TITLE
Fix pdftoppm lookup without POPPLER_PATH

### DIFF
--- a/Backend/services/file_processing_service.py
+++ b/Backend/services/file_processing_service.py
@@ -543,7 +543,12 @@ async def preview_arquivo_pdf(
     start = time.perf_counter()
 
     poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
-    if shutil.which("pdftoppm", path=poppler_dir) is None:
+    pdftoppm_path = (
+        shutil.which("pdftoppm", path=poppler_dir)
+        if poppler_dir
+        else shutil.which("pdftoppm")
+    )
+    if pdftoppm_path is None:
         msg = (
             "Poppler (pdftoppm) executable not found. Install poppler-utils on Linux "
             "or set POPPLER_PATH to its directory."
@@ -681,9 +686,14 @@ async def pdf_bytes_to_images(
 
     def _convert() -> List[str]:
         poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
-        if shutil.which("pdftoppm", path=poppler_dir) is None:
+        pdftoppm_path = (
+            shutil.which("pdftoppm", path=poppler_dir)
+            if poppler_dir
+            else shutil.which("pdftoppm")
+        )
+        if pdftoppm_path is None:
             msg = (
-                "Poppler (pdftoppm) executable not found. Install poppler-utils "
+                "Poppler (pdftoppm) executable not found. Install poppler-utils"
                 "on Linux or set POPPLER_PATH to its directory."
             )
             logger.error(msg)
@@ -728,7 +738,12 @@ def pdf_pages_to_images(db: Session, file: UploadFile, fornecedor_id: int, user_
     previews_dir.mkdir(parents=True, exist_ok=True)
 
     poppler_dir = os.getenv("POPPLER_PATH") or settings.POPPLER_PATH
-    if shutil.which("pdftoppm", path=poppler_dir) is None:
+    pdftoppm_path = (
+        shutil.which("pdftoppm", path=poppler_dir)
+        if poppler_dir
+        else shutil.which("pdftoppm")
+    )
+    if pdftoppm_path is None:
         msg = (
             "Poppler (pdftoppm) executable not found. Install poppler-utils on Linux "
             "or set POPPLER_PATH to its directory."


### PR DESCRIPTION
## Summary
- support running without `POPPLER_PATH` by only using the parameter when defined
- keep passing `poppler_path` to pdf2image only when configured

## Testing
- `env POPPLER_PATH=/usr/bin pytest tests/test_preview_pdf.py::test_preview_pdf_extracts_all tests/test_pdf_pages_to_images.py::test_pdf_pages_to_images_basic -q`
- `env -u POPPLER_PATH pytest tests/test_preview_pdf.py::test_preview_pdf_extracts_all tests/test_pdf_pages_to_images.py::test_pdf_pages_to_images_basic -q`


------
https://chatgpt.com/codex/tasks/task_e_68576da9e100832f950fe35cc1dd39d7