### PR TITLE
Update PDF preview endpoint

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -48,9 +48,12 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
     setLoadingMessage('A gerar pré-visualização inicial...');
     setError('');
     try {
-      const response = await fornecedorService.uploadForPagePreview(selectedFile);
-      setFileId(response.file_id);
-      setPageImages(response.page_image_urls || []);
+      const response = await fornecedorService.uploadForPagePreview(
+        selectedFile,
+        fornecedor.id,
+      );
+      setFileId(response.fileId);
+      setPageImages(response.image_urls || []);
       setStep('select_page');
     } catch (err) {
       const detail = err.response?.data?.detail || err.message;

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -47,8 +47,8 @@ describe('ImportCatalogWizard', () => {
 
   test('generates preview', async () => {
     fornecedorService.uploadForPagePreview.mockResolvedValue({
-      file_id: 1,
-      page_image_urls: ['a', 'b'],
+      fileId: 1,
+      image_urls: ['a', 'b'],
     });
 
     render(<ImportCatalogWizard fornecedor={{ id: 1 }} onClose={() => {}} />);
@@ -60,7 +60,7 @@ describe('ImportCatalogWizard', () => {
     await userEvent.upload(fileInput, file);
     await userEvent.click(screen.getByText('Gerar Preview'));
 
-    expect(fornecedorService.uploadForPagePreview).toHaveBeenCalledWith(file);
+    expect(fornecedorService.uploadForPagePreview).toHaveBeenCalledWith(file, 1);
     await screen.findByAltText('Página 1');
   });
 });

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -227,12 +227,16 @@ export const getImportacaoResult = async (fileId) => {
 // -------- NOVAS FUNÇÕES ---------
 
 // Envia um PDF e obtém imagens de todas as páginas
-export const uploadForPagePreview = async (file) => {
+export const uploadForPagePreview = async (file, fornecedorId) => {
   try {
     const formData = new FormData();
     formData.append('file', file);
-    const response = await apiClient.post('/fornecedores/import/preview-pages', formData);
-    return response.data;
+    const response = await apiClient.post(
+      `/fornecedores/${fornecedorId}/preview-pdf`,
+      formData,
+    );
+    const { import_file_id, image_urls } = response.data;
+    return { fileId: import_file_id, image_urls };
   } catch (error) {
     console.error(
       'Erro ao enviar arquivo para preview de páginas:',

--- a/README Backend.md
+++ b/README Backend.md
@@ -262,7 +262,7 @@ os.cpu_count() + 4)`` se nenhuma outra configuração for informada.
 
 ### Fluxo completo de importação de PDF
 
-1. **Pré-visualização** – `POST /fornecedores/import/preview-pages` salva o arquivo e retorna `file_id` com miniaturas das páginas.
+1. **Pré-visualização** – `POST /fornecedores/{fornecedor_id}/preview-pdf` salva o arquivo e retorna `import_file_id` com miniaturas das páginas.
 2. **Seleção de região** – `GET /fornecedores/import/extract-page-data` usa `file_id` e `page_number` para identificar colunas e amostras de uma página.
 3. **Finalização** – `POST /fornecedores/import/process-full-catalog` processa o PDF por completo usando o mapeamento definido.
 4. **Acompanhamento** – `GET /fornecedores/import/progress/{job_id}` e `GET /fornecedores/import/review/{job_id}` permitem consultar o progresso e o resumo da importação.

--- a/README.md
+++ b/README.md
@@ -486,8 +486,8 @@ paginação.
 #### Processo de importação de PDF em quatro etapas
 
 1. **Pré-visualizar** – envie o arquivo pelo endpoint
-   `POST /fornecedores/import/preview-pages`. A resposta traz o `file_id`
-   e miniaturas das páginas.
+   `POST /fornecedores/{fornecedor_id}/preview-pdf`. A resposta traz o
+   `import_file_id` e miniaturas das páginas.
 2. **Selecionar região** – utilize
    `GET /fornecedores/import/extract-page-data` informando `file_id` e
    `page_number` para obter colunas e linhas de amostra.

--- a/tests/test_fornecedor_import_endpoints.py
+++ b/tests/test_fornecedor_import_endpoints.py
@@ -52,7 +52,7 @@ def test_preview_pages():
     headers = get_admin_headers()
     csv_content = "nome,sku\nA,1\n"
     files = {"file": ("catalog.csv", io.BytesIO(csv_content.encode()), "text/csv")}
-    resp = client.post("/api/v1/fornecedores/import/preview-pages", files=files, headers=headers)
+    resp = client.post("/api/v1/fornecedores/1/preview-pdf", files=files, headers=headers)
     assert resp.status_code < 500
 
 


### PR DESCRIPTION
## Summary
- update fornecedorService to use POST `/fornecedores/{fornecedor_id}/preview-pdf`
- adjust ImportCatalogWizard to send `fornecedor.id` and read `fileId`
- update related unit tests
- document new endpoint in READMEs
- tweak integration test for preview endpoint

## Testing
- `./scripts/run_tests.sh` *(fails: test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68591d0440bc832f896fb1dbb13d23cc