### PR TITLE
Add PDF region preview to catalog import wizard

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -4,6 +4,8 @@ import React, { useState } from 'react';
 import * as fornecedorService from '../../services/fornecedorService';
 import LoadingPopup from '../common/LoadingPopup';
 import ColumnMappingModal from '../common/ColumnMappingModal.jsx';
+import PdfRegionSelector from '../common/PdfRegionSelector.jsx';
+import Modal from '../common/Modal.jsx';
 import ImportProgress from './ImportProgress.jsx';
 import getBackendBaseUrl from '../../utils/backend.js';
 
@@ -28,6 +30,12 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [mappingRows, setMappingRows] = useState([]);
   const [showMappingModal, setShowMappingModal] = useState(false);
   const [mapping, setMapping] = useState(null);
+
+  const [showRegionModal, setShowRegionModal] = useState(false);
+  const [regionPreview, setRegionPreview] = useState(null);
+  const [regionError, setRegionError] = useState('');
+  const [currentPage, setCurrentPage] = useState(null);
+  const [pdfBytes, setPdfBytes] = useState(null);
 
   const backendBaseUrl = getBackendBaseUrl();
 
@@ -62,33 +70,44 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
 
 
   const handlePageClick = async (page) => {
+    if (!fileId || !selectedFile) return;
+    const buffer = await selectedFile.arrayBuffer();
+    setPdfBytes(new Uint8Array(buffer));
+    setCurrentPage(page);
+    setRegionPreview(null);
+    setRegionError('');
+    setShowRegionModal(true);
+  };
+
+  const handleRegionSelect = async ({ page, bbox }) => {
     if (!fileId) return;
     setLoading(true);
-    setLoadingMessage('Extraindo dados da página...');
+    setLoadingMessage('Extraindo região selecionada...');
     try {
-      const data = await fornecedorService.fetchPageDataForMapping(fileId, page);
-      if (data.table && data.table.length > 0) {
-        const headers = data.table[0].map((h) => String(h));
-        const rows = data.table.slice(1).map((r) => {
-          const obj = {};
-          headers.forEach((h, idx) => {
-            obj[h] = r[idx];
-          });
-          return obj;
-        });
-        setMappingHeaders(headers);
-        setMappingRows(rows.slice(0, 5));
-      } else {
-        setMappingHeaders([]);
-        setMappingRows([]);
-      }
-      setShowMappingModal(true);
+      const data = await fornecedorService.selecionarRegiao({
+        fileId,
+        pageNumber: page,
+        bbox,
+      });
+      const headers = data.columns.map((h) => String(h));
+      setRegionPreview({
+        headers,
+        rows: data.data,
+      });
     } catch (err) {
       const detail = err.response?.data?.detail || err.message;
-      setError(`Erro: ${detail}`);
+      setRegionError(`Erro: ${detail}`);
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleUseRegion = () => {
+    if (!regionPreview) return;
+    setShowRegionModal(false);
+    setMappingHeaders(regionPreview.headers);
+    setMappingRows(regionPreview.rows.slice(0, 5));
+    setShowMappingModal(true);
   };
 
   const handleConfirmMapping = async (map) => {
@@ -156,6 +175,48 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
       )}
 
       {step === 'review' && <p>Processamento concluído. Revise os dados.</p>}
+
+      <Modal
+        isOpen={showRegionModal}
+        onClose={() => setShowRegionModal(false)}
+        title="Selecione a região da tabela"
+      >
+        {pdfBytes && (
+          <PdfRegionSelector
+            file={pdfBytes}
+            onSelect={handleRegionSelect}
+            initialPage={currentPage}
+          />
+        )}
+        {regionError && (
+          <p style={{ color: 'red', marginTop: '0.5em' }}>{regionError}</p>
+        )}
+        {regionPreview && (
+          <div style={{ marginTop: '1em' }}>
+            <table className="preview-table">
+              <thead>
+                <tr>
+                  {regionPreview.headers.map((h) => (
+                    <th key={h}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {regionPreview.rows.slice(0, 5).map((row, idx) => (
+                  <tr key={idx}>
+                    {regionPreview.headers.map((h) => (
+                      <td key={h}>{row[h]}</td>
+                    ))}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+            <button type="button" onClick={handleUseRegion} style={{ marginTop: '0.5em' }}>
+              Usar Esta Região
+            </button>
+          </div>
+        )}
+      </Modal>
 
       <ColumnMappingModal
         isOpen={showMappingModal}

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -298,6 +298,28 @@ export const getImportProgress = async (jobId) => {
   }
 };
 
+// Pré-visualiza os dados contidos em uma região específica do PDF
+export const selecionarRegiao = async ({ fileId, pageNumber, bbox }) => {
+  try {
+    const payload = {
+      file_id: fileId,
+      page_number: pageNumber,
+      region: bbox,
+    };
+    const response = await apiClient.post('/fornecedores/preview-catalog-region', payload);
+    return response.data;
+  } catch (error) {
+    console.error(
+      'Erro ao pré-visualizar região do catálogo:',
+      JSON.stringify(error.response?.data || error.message || error),
+    );
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao pré-visualizar região do catálogo');
+  }
+};
+
 // Obtém os dados para revisão após o processamento
 export const getReviewData = async (jobId, params = {}) => {
   try {
@@ -351,4 +373,5 @@ export default {
   getImportProgress,
   getReviewData,
   commitImport,
+  selecionarRegiao,
 };


### PR DESCRIPTION
## Summary
- add `selecionarRegiao` to fornecedorService for `/preview-catalog-region`
- integrate PdfRegionSelector into ImportCatalogWizard
- show returned table preview before mapping

## Testing
- `./scripts/run_tests.sh` *(fails: AttributeError / 401 errors)*
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68591d04c98c832fa3ebb08b5e9d1973