### PR TITLE
Implement bulk PDF region extraction

### DIFF
--- a/Backend/routers/fornecedores.py
+++ b/Backend/routers/fornecedores.py
@@ -340,6 +340,38 @@ def preview_catalog_from_region(
     return schemas.CatalogPreview(columns=columns, data=sample_data)
 
 
+@router.post("/extract_data_from_pdf_bulk", status_code=status.HTTP_202_ACCEPTED)
+def extract_data_from_pdf_bulk(
+    background_tasks: BackgroundTasks,
+    request: schemas.PdfRegionBulkRequest,
+    db: Session = Depends(database.get_db),
+    current_user: models.User = Depends(auth_utils.get_current_active_user),
+):
+    """Inicia a extração de uma região do PDF em várias páginas."""
+    file_path = file_processing_service.get_file_path_by_id(db, file_id=request.file_id)
+    if not file_path:
+        raise HTTPException(status_code=404, detail="Arquivo de catálogo não encontrado")
+
+    import pdfplumber
+    with pdfplumber.open(file_path) as pdf:
+        total_pages = len(pdf.pages)
+
+    pages = request.pages
+    if request.all_pages or not pages:
+        pages = list(range(1, total_pages + 1))
+
+    for pg in pages:
+        if 1 <= pg <= total_pages:
+            background_tasks.add_task(
+                file_processing_service.extract_data_from_pdf_region,
+                file_path=file_path,
+                page_number=pg,
+                region=request.region,
+            )
+
+    return {"detail": "Batch processing started", "total_pages": total_pages}
+
+
 # Endpoint para consultar progresso de importação de catálogo
 @router.get("/import/progress/{job_id}")
 def get_import_progress(

--- a/Backend/schemas.py
+++ b/Backend/schemas.py
@@ -728,6 +728,13 @@ class CatalogRegionPreviewRequest(BaseModel):
     region: Optional[List[float]] = None
 
 
+class PdfRegionBulkRequest(BaseModel):
+    file_id: int
+    region: List[float]
+    pages: Optional[List[int]] = None
+    all_pages: Optional[bool] = False
+
+
 class CatalogPreview(BaseModel):
     columns: List[str]
     data: List[Dict[str, Any]]
@@ -753,3 +760,4 @@ UserActivity.model_rebuild()
 SocialLoginConfig.model_rebuild()
 PdfPreviewResponse.model_rebuild()
 CatalogPreview.model_rebuild()
+PdfRegionBulkRequest.model_rebuild()

--- a/Frontend/app/src/components/common/PdfRegionSelector.jsx
+++ b/Frontend/app/src/components/common/PdfRegionSelector.jsx
@@ -13,13 +13,20 @@ try {
   // Ignore errors during tests or if the worker cannot be resolved.
 }
 
-function PdfRegionSelector({ file, onSelect, initialPage = 1, onLoadError }) {
+function PdfRegionSelector({
+  file,
+  onSelect,
+  initialPage = 1,
+  onLoadError,
+  onApplyAllChange,
+}) {
   const canvasRef = useRef(null);
   const pdfDocumentRef = useRef(null);
   const [pageNum, setPageNum] = useState(initialPage);
   const startPos = useRef(null);
   const [rect, setRect] = useState(null);
   const [isDrawing, setIsDrawing] = useState(false);
+  const [applyAll, setApplyAll] = useState(false);
 
   useEffect(() => {
     setPageNum(initialPage);
@@ -102,7 +109,11 @@ function PdfRegionSelector({ file, onSelect, initialPage = 1, onLoadError }) {
 
   const handleMouseUp = () => {
     if (isDrawing && rect) {
-      onSelect({ page: pageNum, bbox: [rect.x0, rect.y0, rect.x1, rect.y1] });
+      onSelect({
+        page: pageNum,
+        bbox: [rect.x0, rect.y0, rect.x1, rect.y1],
+        applyAllPages: applyAll,
+      });
     }
     setIsDrawing(false);
     startPos.current = null;
@@ -129,6 +140,17 @@ function PdfRegionSelector({ file, onSelect, initialPage = 1, onLoadError }) {
           }}
         />
       )}
+      <label style={{ display: 'block', marginTop: '0.5em' }}>
+        <input
+          type="checkbox"
+          checked={applyAll}
+          onChange={(e) => {
+            setApplyAll(e.target.checked);
+            if (onApplyAllChange) onApplyAllChange(e.target.checked);
+          }}
+        />{' '}
+        Aplicar esta seleção a todas as páginas
+      </label>
     </div>
   );
 }

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -36,6 +36,8 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [regionError, setRegionError] = useState('');
   const [currentPage, setCurrentPage] = useState(null);
   const [pdfBytes, setPdfBytes] = useState(null);
+  const [applyAllPages, setApplyAllPages] = useState(false);
+  const [selectedBbox, setSelectedBbox] = useState(null);
 
   const backendBaseUrl = getBackendBaseUrl();
 
@@ -82,10 +84,12 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
     setShowRegionModal(true);
   };
 
-  const handleRegionSelect = async ({ page, bbox }) => {
+  const handleRegionSelect = async ({ page, bbox, applyAllPages }) => {
     if (!fileId) return;
     setLoading(true);
     setLoadingMessage('Extraindo região selecionada...');
+    setApplyAllPages(!!applyAllPages);
+    setSelectedBbox(bbox);
     try {
       const data = await fornecedorService.selecionarRegiao({
         fileId,
@@ -119,11 +123,20 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
     setLoading(true);
     setLoadingMessage('Iniciando processamento...');
     try {
-      const resp = await fornecedorService.startFullProcess({
-        file_id: fileId,
-        fornecedor_id: fornecedor.id,
-        mapping: map,
-      });
+      let resp;
+      if (applyAllPages) {
+        resp = await fornecedorService.extractRegionBulk({
+          fileId,
+          bbox: selectedBbox,
+          allPages: true,
+        });
+      } else {
+        resp = await fornecedorService.startFullProcess({
+          file_id: fileId,
+          fornecedor_id: fornecedor.id,
+          mapping: map,
+        });
+      }
       setJobId(resp.job_id);
       setStep('processing');
     } catch (err) {
@@ -189,6 +202,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
             file={pdfBytes}
             onSelect={handleRegionSelect}
             initialPage={currentPage}
+            onApplyAllChange={setApplyAllPages}
           />
         )}
         {regionError && (

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -324,6 +324,29 @@ export const selecionarRegiao = async ({ fileId, pageNumber, bbox }) => {
   }
 };
 
+// Inicia extração em lote de uma região do PDF
+export const extractRegionBulk = async ({ fileId, bbox, pages = null, allPages = false }) => {
+  try {
+    const payload = {
+      file_id: fileId,
+      region: bbox,
+      pages,
+      all_pages: allPages,
+    };
+    const response = await apiClient.post('/fornecedores/extract_data_from_pdf_bulk', payload);
+    return response.data;
+  } catch (error) {
+    console.error(
+      'Erro ao iniciar extração em lote:',
+      JSON.stringify(error.response?.data || error.message || error),
+    );
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao iniciar extração em lote');
+  }
+};
+
 // Obtém os dados para revisão após o processamento
 export const getReviewData = async (jobId, params = {}) => {
   try {
@@ -378,4 +401,5 @@ export default {
   getReviewData,
   commitImport,
   selecionarRegiao,
+  extractRegionBulk,
 };


### PR DESCRIPTION
## Summary
- enable multi-page selection checkbox in `PdfRegionSelector`
- record checkbox state and region bbox in `ImportCatalogWizard`
- add service call and hook to start bulk extraction
- expose new `extract_data_from_pdf_bulk` API endpoint
- define `PdfRegionBulkRequest` schema

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6859641b19f8832f93f463baa1fde2b6