### PR TITLE
Implement async PDF extraction job

### DIFF
--- a/Backend/models.py
+++ b/Backend/models.py
@@ -511,6 +511,7 @@ class CatalogImportFile(Base):
     pages_processed = Column(Integer, nullable=False, server_default="0")
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     result_summary = Column(MutableDict.as_mutable(JSON), nullable=True)
+    resultado_json = Column(JSON, nullable=True)
 
     user = relationship("User")
     fornecedor = relationship("Fornecedor")

--- a/Backend/routers/fornecedores.py
+++ b/Backend/routers/fornecedores.py
@@ -29,6 +29,7 @@ from Backend import schemas
 from Backend import crud_historico
 from Backend import database
 from Backend.services import file_processing_service
+from Backend.tasks import process_pdf_extraction_task
 from . import auth_utils  # Para obter o usuário
 from Backend.core.config import settings
 from . import auth_utils  # Para obter o usuário
@@ -433,14 +434,15 @@ async def process_full_catalog(
     return {"job_id": job.id, "status": "PROCESSING"}
 
 
-@router.get("/import/extract-page-data", response_model=schemas.CatalogPreview)
+@router.get("/import/extract-page-data", status_code=status.HTTP_202_ACCEPTED)
 def extract_page_data(
+    background_tasks: BackgroundTasks,
     file_id: int = Query(..., description="ID do arquivo importado"),
     page_number: int = Query(..., ge=1, description="Número da página a extrair"),
     db: Session = Depends(database.get_db),
     current_user: models.User = Depends(auth_utils.get_current_active_user),
 ):
-    """Extrai dados tabulares de uma única página de um catálogo PDF armazenado."""
+    """Agenda a extração de dados de uma página de um catálogo PDF."""
 
     record = (
         db.query(models.CatalogImportFile)
@@ -450,22 +452,14 @@ def extract_page_data(
     if not record:
         raise HTTPException(status_code=404, detail="Arquivo não encontrado")
 
-    file_path = Path(settings.UPLOAD_DIRECTORY) / "catalogs" / record.stored_filename
-    if not file_path.is_absolute():
-        file_path = Path(__file__).resolve().parent.parent / file_path
-    if not file_path.exists():
-        raise HTTPException(status_code=404, detail="Arquivo não encontrado")
+    background_tasks.add_task(
+        process_pdf_extraction_task,
+        import_job_id=record.id,
+        page_number=page_number,
+        db_url=str(database.engine.url),
+    )
 
-    try:
-        result = file_processing_service.extract_data_from_single_page(
-            str(file_path), page_number
-        )
-    except ValueError as e:
-        raise HTTPException(status_code=400, detail=str(e))
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
-
-    return result
+    return {"job_id": record.id, "status": "PROCESSING"}
 
 
 # Endpoint para deletar um fornecedor
@@ -559,3 +553,24 @@ def commit_import_job(
         user_id=current_user.id,
     )
     return {"status": "PROCESSING", "job_id": job_id}
+
+
+@router.get("/import_job/{job_id}/status")
+def get_import_job_status(
+    job_id: int,
+    db: Session = Depends(database.get_db),
+    current_user: models.User = Depends(auth_utils.get_current_active_user),
+):
+    """Retorna o status de processamento de um job de importação."""
+    record = (
+        db.query(models.CatalogImportFile)
+        .filter_by(id=job_id, user_id=current_user.id)
+        .first()
+    )
+    if not record:
+        raise HTTPException(status_code=404, detail="Job não encontrado")
+
+    response = {"status": record.status}
+    if record.status == "COMPLETED":
+        response["resultado_json"] = record.resultado_json
+    return response

--- a/Backend/tasks.py
+++ b/Backend/tasks.py
@@ -1,0 +1,44 @@
+import logging
+from pathlib import Path
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from Backend.core.config import settings
+from Backend import models
+from Backend.services import file_processing_service
+
+logger = logging.getLogger(__name__)
+
+
+def process_pdf_extraction_task(import_job_id: int, page_number: int, db_url: str) -> None:
+    """Processa extração de dados de uma página de PDF em segundo plano."""
+    engine = create_engine(db_url)
+    SessionLocal = sessionmaker(bind=engine)
+    db = SessionLocal()
+    job = None
+    try:
+        job = db.query(models.CatalogImportFile).filter(models.CatalogImportFile.id == import_job_id).first()
+        if not job:
+            logger.error("CatalogImportFile %s not found", import_job_id)
+            return
+        job.status = "PROCESSING"
+        db.commit()
+
+        file_path = Path(settings.UPLOAD_DIRECTORY) / "catalogs" / job.stored_filename
+        if not file_path.is_absolute():
+            file_path = Path(__file__).resolve().parent / "static" / "uploads" / "catalogs" / job.stored_filename
+        if not file_path.exists():
+            raise FileNotFoundError(str(file_path))
+
+        result = file_processing_service.extract_data_from_single_page(str(file_path), page_number)
+        job.resultado_json = result
+        job.status = "COMPLETED"
+        db.commit()
+    except Exception as exc:
+        logger.exception("Failed to process PDF extraction job")
+        if job:
+            job.status = "FAILED"
+            job.result_summary = {"error": str(exc)}
+            db.commit()
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary
- support storing extraction JSON on catalog import jobs
- add background task handler for PDF page extraction
- trigger page data extraction in the background and provide status endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68596410cf8c832fb7cbf18230f61472