### PR TITLE
Fix catalog status endpoint path

### DIFF
--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -199,7 +199,7 @@ export const reprocessCatalogFile = async (fileId) => {
 export const getImportacaoStatus = async (fileId) => {
   try {
     const response = await apiClient.get(
-      `/produtos/importar-catalogo-status/${fileId}`
+      `/produtos/importar-catalogo-status/${fileId}/`
     );
     return response.data;
   } catch (error) {


### PR DESCRIPTION
## Summary
- correct `getImportacaoStatus` endpoint URL in `fornecedorService`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685966d56d80832fa270d0480ca36eb3