### PR TITLE
Add resultado_json migration

### DIFF
--- a/Backend/alembic/versions/7e98d5d6d0a1_add_resultado_json_column.py
+++ b/Backend/alembic/versions/7e98d5d6d0a1_add_resultado_json_column.py
@@ -1,0 +1,24 @@
+"""add resultado_json column to catalog_import_files
+
+Revision ID: 7e98d5d6d0a1
+Revises: 999999999999
+Create Date: 2025-07-02 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '7e98d5d6d0a1'
+down_revision: Union[str, None] = '999999999999'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('catalog_import_files', sa.Column('resultado_json', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('catalog_import_files', 'resultado_json')

--- a/README Backend.md
+++ b/README Backend.md
@@ -75,6 +75,7 @@ os.cpu_count() + 4)`` se nenhuma outra configuração for informada.
 * `downgrade()`: Remove as tabelas criadas na migration.
 
 * Nova migration cria a tabela `registros_historico` para armazenar ações.
+* Nova migration `7e98d5d6d0a1_add_resultado_json_column.py` adiciona a coluna `resultado_json` em `catalog_import_files`. Após atualizar o projeto, execute `alembic upgrade head` para aplicar a mudança.
 
 ---
 


### PR DESCRIPTION
## Summary
- create `resultado_json` migration for `catalog_import_files`
- document how to apply the new migration in README Backend.md

## Testing
- `./scripts/run_tests.sh` *(fails: Could not fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68596f183a68832fb0bf416c386e0aa8