### PR TITLE
Fix Alembic instructions

### DIFF
--- a/README Backend.md
+++ b/README Backend.md
@@ -75,7 +75,7 @@ os.cpu_count() + 4)`` se nenhuma outra configuração for informada.
 * `downgrade()`: Remove as tabelas criadas na migration.
 
 * Nova migration cria a tabela `registros_historico` para armazenar ações.
-* Nova migration `7e98d5d6d0a1_add_resultado_json_column.py` adiciona a coluna `resultado_json` em `catalog_import_files`. Após atualizar o projeto, execute `alembic upgrade head` para aplicar a mudança.
+* Nova migration `7e98d5d6d0a1_add_resultado_json_column.py` adiciona a coluna `resultado_json` em `catalog_import_files`. Após atualizar o projeto, execute `alembic -c Backend/alembic.ini upgrade head` para aplicar a mudança (rode a partir da raiz do projeto ou defina `PYTHONPATH=..` se estiver dentro de `Backend/`).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -228,9 +228,7 @@ As dependências Python necessárias estão listadas em `requirements-backend.tx
 python -m venv venv
 source venv/bin/activate    # Ou .\venv\Scripts\activate no Windows
 pip install -r requirements-backend.txt   # dependências fixas do backend
-cd Backend
-alembic upgrade head        # Cria/atualiza tabelas, incluindo RegistroHistorico
-cd ..
+alembic -c Backend/alembic.ini upgrade head  # Cria/atualiza tabelas, incluindo RegistroHistorico
 python run_backend.py       # Inicia o backend (http://localhost:8000)
 ```
 
@@ -426,7 +424,7 @@ que coincidam.
   (ou configure `BACKEND_HOST`, `BACKEND_PORT`, `BACKEND_RELOAD` e `BACKEND_WORKERS`)
 
 * **Rodar Migrations:**
-  `cd Backend && alembic upgrade head`  # aplica migrações, inclusive a tabela RegistroHistorico
+  `alembic -c Backend/alembic.ini upgrade head`  # aplica migrações, inclusive a tabela RegistroHistorico
   (obrigatório antes do primeiro `python run_backend.py`; use `AUTO_CREATE_TABLES=true` no `.env` apenas em desenvolvimento)
 
 * **Instalar navegadores Playwright:**

--- a/README.txt
+++ b/README.txt
@@ -214,9 +214,9 @@ Este projeto utiliza SQLAlchemy.
 Se estiver usando Alembic (recomendado para produção): Certifique-se de que o Alembic está configurado (normalmente com alembic.ini e uma pasta alembic/ dentro de Backend/). Execute as migrações:
 Bash
 
-cd Backend  # Navegue para a pasta Backend onde alembic.ini geralmente reside
-alembic upgrade head
-cd ..     # Volte para a raiz do projeto
+alembic -c Backend/alembic.ini upgrade head
+
+(Se preferir rodar o comando dentro de `Backend/`, defina `PYTHONPATH=..`.)
 Se NÃO estiver usando Alembic: A linha models.Base.metadata.create_all(bind=engine) em Backend/main.py (atualmente comentada) precisaria ser descomentada para criar as tabelas automaticamente ao iniciar a aplicação. No entanto, isso não é recomendado para gerenciamento de schema a longo prazo.
 7. Executar a Aplicação Backend:
 


### PR DESCRIPTION
## Summary
- fix Alembic commands in README files
- mention running from project root or using PYTHONPATH

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68598000000c832fb20024e877072bbd