### PR TITLE
Fix Alembic Base import order

### DIFF
--- a/Backend/alembic/env.py
+++ b/Backend/alembic/env.py
@@ -6,7 +6,6 @@ import logging
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 from alembic import context
-from Backend.models import Base
 
 # Initialize logger for this module
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- adjust `Backend/alembic/env.py` so that `sys.path` is updated before any `Backend` imports
- remove outdated top-level `Base` import

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68597ffef8e4832f88087570ff936af6