### PR TITLE
Implement paginated PDF previews

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -1,6 +1,6 @@
 // Caminho: Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import * as fornecedorService from '../../services/fornecedorService';
 import LoadingPopup from '../common/LoadingPopup';
 import ColumnMappingModal from '../common/ColumnMappingModal.jsx';
@@ -24,6 +24,9 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
 
   const [fileId, setFileId] = useState(null);
   const [jobId, setJobId] = useState(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [limit, setLimit] = useState(5);
+  const [totalPdfPages, setTotalPdfPages] = useState(0);
   const [pageImages, setPageImages] = useState([]);
 
   const [mappingHeaders, setMappingHeaders] = useState([]);
@@ -34,7 +37,6 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [showRegionModal, setShowRegionModal] = useState(false);
   const [regionPreview, setRegionPreview] = useState(null);
   const [regionError, setRegionError] = useState('');
-  const [currentPage, setCurrentPage] = useState(null);
   const [pdfBytes, setPdfBytes] = useState(null);
   const [applyAllPages, setApplyAllPages] = useState(false);
   const [selectedBbox, setSelectedBbox] = useState(null);
@@ -58,12 +60,16 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
     setLoadingMessage('A gerar pré-visualização inicial...');
     setError('');
     try {
-      const response = await fornecedorService.uploadForPagePreview(
+      const offset = (currentPage - 1) * limit;
+      const response = await fornecedorService.getPdfPreview(
         selectedFile,
         fornecedor.id,
+        offset,
+        limit,
       );
-      setFileId(response.fileId);
+      setFileId(response.import_file_id);
       setPageImages(response.image_urls || []);
+      setTotalPdfPages(response.total_pages || 0);
       setStep('select_page');
     } catch (err) {
       const detail = err.response?.data?.detail || err.message;
@@ -147,6 +153,34 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
     }
   };
 
+  useEffect(() => {
+    const fetchPreview = async () => {
+      if (!selectedFile || step !== 'select_page') return;
+      setLoading(true);
+      setLoadingMessage('A gerar pré-visualização...');
+      setError('');
+      try {
+        const offset = (currentPage - 1) * limit;
+        const response = await fornecedorService.getPdfPreview(
+          selectedFile,
+          fornecedor.id,
+          offset,
+          limit,
+        );
+        setFileId(response.import_file_id);
+        setPageImages(response.image_urls || []);
+        setTotalPdfPages(response.total_pages || 0);
+      } catch (err) {
+        const detail = err.response?.data?.detail || err.message;
+        setError(`Erro: ${detail}`);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPreview();
+  }, [currentPage, selectedFile]);
+
 
 
   return (
@@ -173,15 +207,22 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         <div>
           <h3>Passo 2: Escolha a página da tabela</h3>
           <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-            {pageImages.map((url, idx) => (
-              <img
-                key={idx}
-                src={`${backendBaseUrl}${url}`}
-                alt={`Página ${idx + 1}`}
-                style={{ maxWidth: '120px', margin: '0.5em', cursor: 'pointer' }}
-                onClick={() => handlePageClick(idx + 1)}
-              />
-            ))}
+            {pageImages.map((url, idx) => {
+              const pageNumber = (currentPage - 1) * limit + idx + 1;
+              return (
+                <img
+                  key={idx}
+                  src={`${backendBaseUrl}${url}`}
+                  alt={`Página ${pageNumber}`}
+                  style={{
+                    maxWidth: '120px',
+                    margin: '0.5em',
+                    cursor: 'pointer',
+                  }}
+                  onClick={() => handlePageClick(pageNumber)}
+                />
+              );
+            })}
           </div>
         </div>
       )}

--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -34,7 +34,7 @@ jest.mock('../../../contexts/ProductTypeContext', () => ({
 jest.mock('../../../services/fornecedorService', () => ({
   __esModule: true,
   default: {
-    uploadForPagePreview: jest.fn(),
+    getPdfPreview: jest.fn(),
     startFullProcess: jest.fn(() => Promise.resolve({ job_id: 1 })),
   },
 }));
@@ -46,9 +46,10 @@ describe('ImportCatalogWizard', () => {
   });
 
   test('generates preview', async () => {
-    fornecedorService.uploadForPagePreview.mockResolvedValue({
-      fileId: 1,
+    fornecedorService.getPdfPreview.mockResolvedValue({
+      import_file_id: 1,
       image_urls: ['a', 'b'],
+      total_pages: 10,
     });
 
     render(<ImportCatalogWizard fornecedor={{ id: 1 }} onClose={() => {}} />);
@@ -60,7 +61,7 @@ describe('ImportCatalogWizard', () => {
     await userEvent.upload(fileInput, file);
     await userEvent.click(screen.getByText('Gerar Preview'));
 
-    expect(fornecedorService.uploadForPagePreview).toHaveBeenCalledWith(file, 1);
+    expect(fornecedorService.getPdfPreview).toHaveBeenCalledWith(file, 1, 0, 5);
     await screen.findByAltText('Página 1');
   });
 });

--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -249,6 +249,29 @@ export const uploadForPagePreview = async (file, fornecedorId) => {
   }
 };
 
+// Obtém miniaturas de páginas de um PDF com suporte a offset e limit
+export const getPdfPreview = async (file, fornecedorId, offset = 0, limit = 5) => {
+  try {
+    const formData = new FormData();
+    formData.append('file', file);
+    const response = await apiClient.post(
+      `/fornecedores/${fornecedorId}/preview-pdf`,
+      formData,
+      { params: { offset, limit } },
+    );
+    return response.data;
+  } catch (error) {
+    console.error(
+      'Erro ao obter preview do PDF:',
+      JSON.stringify(error.response?.data || error.message || error),
+    );
+    if (error.response && error.response.data) {
+      throw error.response.data;
+    }
+    throw new Error(error.message || 'Falha ao obter preview do PDF');
+  }
+};
+
 // Extrai dados de uma página específica de um PDF já enviado
 export const fetchPageDataForMapping = async (fileId, pageNumber) => {
   try {
@@ -395,6 +418,7 @@ export default {
   getImportacaoStatus,
   getImportacaoResult,
   uploadForPagePreview,
+  getPdfPreview,
   fetchPageDataForMapping,
   startFullProcess,
   getImportProgress,


### PR DESCRIPTION
## Summary
- update ImportCatalogWizard to support paginated preview
- create `getPdfPreview` service for offset/limit support
- update unit test for new service usage

## Testing
- `./scripts/run_tests.sh` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685a9a9e44c4832faaa295b684e5c911