### PR TITLE
Add pagination to catalog wizard

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -7,6 +7,7 @@ import ColumnMappingModal from '../common/ColumnMappingModal.jsx';
 import PdfRegionSelector from '../common/PdfRegionSelector.jsx';
 import Modal from '../common/Modal.jsx';
 import ImportProgress from './ImportProgress.jsx';
+import PaginationControls from '../common/PaginationControls';
 import getBackendBaseUrl from '../../utils/backend.js';
 
 const FIELD_OPTIONS = [
@@ -35,6 +36,8 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [regionPreview, setRegionPreview] = useState(null);
   const [regionError, setRegionError] = useState('');
   const [currentPage, setCurrentPage] = useState(null);
+  const [limit, setLimit] = useState(10);
+  const [totalPdfPages, setTotalPdfPages] = useState(0);
   const [pdfBytes, setPdfBytes] = useState(null);
   const [applyAllPages, setApplyAllPages] = useState(false);
   const [selectedBbox, setSelectedBbox] = useState(null);
@@ -64,6 +67,8 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
       );
       setFileId(response.fileId);
       setPageImages(response.image_urls || []);
+      setTotalPdfPages((response.image_urls || []).length);
+      setCurrentPage(1);
       setStep('select_page');
     } catch (err) {
       const detail = err.response?.data?.detail || err.message;
@@ -173,16 +178,35 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         <div>
           <h3>Passo 2: Escolha a página da tabela</h3>
           <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-            {pageImages.map((url, idx) => (
-              <img
-                key={idx}
-                src={`${backendBaseUrl}${url}`}
-                alt={`Página ${idx + 1}`}
-                style={{ maxWidth: '120px', margin: '0.5em', cursor: 'pointer' }}
-                onClick={() => handlePageClick(idx + 1)}
-              />
-            ))}
+            {pageImages
+              .slice(
+                (currentPage ? currentPage - 1 : 0) * limit,
+                (currentPage ? currentPage - 1 : 0) * limit + limit,
+              )
+              .map((url, idx) => {
+                const realIndex = (currentPage ? currentPage - 1 : 0) * limit + idx;
+                return (
+                  <img
+                    key={realIndex}
+                    src={`${backendBaseUrl}${url}`}
+                    alt={`Página ${realIndex + 1}`}
+                    style={{ maxWidth: '120px', margin: '0.5em', cursor: 'pointer' }}
+                    onClick={() => handlePageClick(realIndex + 1)}
+                  />
+                );
+              })}
           </div>
+          <PaginationControls
+            currentPage={currentPage ? currentPage - 1 : 0}
+            totalPages={Math.ceil(totalPdfPages / limit)}
+            onPageChange={(page) => setCurrentPage(page + 1)}
+            itemsPerPage={limit}
+            onItemsPerPageChange={(value) => {
+              setLimit(parseInt(value, 10));
+              setCurrentPage(1);
+            }}
+            totalItems={totalPdfPages}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- enable page navigation for PDF previews in `ImportCatalogWizard`

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a9a9f4890832f92b866b46a3b91a2