### PR TITLE
Fix fornecedor service syntax error

### DIFF
--- a/Frontend/app/src/services/fornecedorService.js
+++ b/Frontend/app/src/services/fornecedorService.js
@@ -250,9 +250,8 @@ export const uploadForPagePreview = async (file, fornecedorId) => {
 };
 
 // Obtém miniaturas de páginas de um PDF com suporte a offset e limit
-export const getPdfPreview = async (file, fornecedorId, offset = 0, limit = 5) => {
 // Gera pré-visualizações do PDF com suporte a paginação
-export const getPdfPreview = async (file, fornecedorId, offset, limit) => {
+export const getPdfPreview = async (file, fornecedorId, offset = 0, limit = 5) => {
   try {
     const formData = new FormData();
     formData.append('file', file);
@@ -260,14 +259,6 @@ export const getPdfPreview = async (file, fornecedorId, offset, limit) => {
       `/fornecedores/${fornecedorId}/preview-pdf`,
       formData,
       { params: { offset, limit } },
-    );
-    return response.data;
-  } catch (error) {
-    console.error(
-      'Erro ao obter preview do PDF:',
-      {
-        params: { offset, limit },
-      },
     );
     const { image_urls, total_pages } = response.data;
     return { image_urls, total_pages };
@@ -279,7 +270,6 @@ export const getPdfPreview = async (file, fornecedorId, offset, limit) => {
     if (error.response && error.response.data) {
       throw error.response.data;
     }
-    throw new Error(error.message || 'Falha ao obter preview do PDF');
     throw new Error(error.message || 'Falha ao obter pré-visualização do PDF');
   }
 };


### PR DESCRIPTION
## Summary
- remove a duplicate `getPdfPreview` function in the frontend service

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q` *(fails: Could not find a version that satisfies the requirement reportlab)*

------
https://chatgpt.com/codex/tasks/task_e_685aa8f026ac832fa99a59d9a18a2d8a