### PR TITLE
Fix duplicate currentPage declarations

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -38,9 +38,6 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [showRegionModal, setShowRegionModal] = useState(false);
   const [regionPreview, setRegionPreview] = useState(null);
   const [regionError, setRegionError] = useState('');
-  const [currentPage, setCurrentPage] = useState(null);
-  const [limit, setLimit] = useState(10);
-  const [totalPdfPages, setTotalPdfPages] = useState(0);
   const [pdfBytes, setPdfBytes] = useState(null);
   const [applyAllPages, setApplyAllPages] = useState(false);
   const [selectedBbox, setSelectedBbox] = useState(null);


### PR DESCRIPTION
## Summary
- remove duplicate `currentPage`, `limit` and `totalPdfPages` state declarations from `ImportCatalogWizard.jsx`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685aab247134832f86d73d04a7d217c5