### PR TITLE
Remove duplicate page iteration

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -227,22 +227,6 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
                   />
                 );
               })}
-            {pageImages.map((url, idx) => {
-              const pageNumber = (currentPage - 1) * limit + idx + 1;
-              return (
-                <img
-                  key={idx}
-                  src={`${backendBaseUrl}${url}`}
-                  alt={`Página ${pageNumber}`}
-                  style={{
-                    maxWidth: '120px',
-                    margin: '0.5em',
-                    cursor: 'pointer',
-                  }}
-                  onClick={() => handlePageClick(pageNumber)}
-                />
-              );
-            })}
           </div>
           <PaginationControls
             currentPage={currentPage ? currentPage - 1 : 0}


### PR DESCRIPTION
## Summary
- clean up duplicated page rendering loop in ImportCatalogWizard

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab3b8a6a4832fad5d7f480d09b0cd