### PR TITLE
Remove redundant PDF page count setter

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -70,7 +70,6 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
       );
       setFileId(response.import_file_id);
       setPageImages(response.image_urls || []);
-      setTotalPdfPages((response.image_urls || []).length);
       setCurrentPage(1);
       setTotalPdfPages(response.total_pages || 0);
       setStep('select_page');


### PR DESCRIPTION
## Summary
- remove duplicated `setTotalPdfPages` call in `ImportCatalogWizard`

## Testing
- `./scripts/run_tests.sh` *(fails: Could not find fastapi due to no internet)*
- `npm test` in `Frontend/app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab3b944b0832fa4689cc5d14369b0