### PR TITLE
Add API response logging for PDF previews

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -68,6 +68,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         offset,
         limit,
       );
+      console.log('DADOS RECEBIDOS DA API:', response);
       setFileId(response.import_file_id);
       setPageImages(response.image_urls || []);
       setTotalPdfPages((response.image_urls || []).length);
@@ -170,6 +171,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
           offset,
           limit,
         );
+        console.log('DADOS RECEBIDOS DA API:', response);
         setFileId(response.import_file_id);
         setPageImages(response.image_urls || []);
         setTotalPdfPages(response.total_pages || 0);


### PR DESCRIPTION
## Summary
- log API responses after generating PDF previews

## Testing
- `npm test --prefix Frontend/app` *(fails: jest not found)*
- `pytest -q` *(fails: missing Python dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ab3ba3bbc832f8efb4e5cdcf70ccc