### PR TITLE
Add API response logging

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -68,6 +68,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         offset,
         limit,
       );
+      console.log('DADOS RECEBIDOS DA API:', response);
       setFileId(response.import_file_id);
       setPageImages(response.image_urls || []);
       setTotalPdfPages((response.image_urls || []).length);
@@ -170,6 +171,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
           offset,
           limit,
         );
+        console.log('DADOS RECEBIDOS DA API:', response);
         setFileId(response.import_file_id);
         setPageImages(response.image_urls || []);
         setTotalPdfPages(response.total_pages || 0);


### PR DESCRIPTION
## Summary
- log API responses when generating PDF previews

## Testing
- `./scripts/run_tests.sh` *(fails: Could not install fastapi)*
- `npm test` in `Frontend/app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab3c644e8832f8953ea1fd323e663