### PR TITLE
Implement fetchPages preview logic

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -188,6 +188,12 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   return (
     <div className="wizard-container">
       {loading && <LoadingPopup message={loadingMessage} isOpen={loading} />}
+      {isLoadingPreview && (
+        <LoadingPopup
+          message="A gerar pré-visualização..."
+          isOpen={isLoadingPreview}
+        />
+      )}
       {error && (
         <p style={{ color: 'red', fontWeight: 'bold', border: '1px solid red', padding: '10px', marginTop: '10px' }}>
           {error}

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -27,8 +27,9 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [jobId, setJobId] = useState(null);
   const [currentPage, setCurrentPage] = useState(1);
   const [limit, setLimit] = useState(5);
-  const [totalPdfPages, setTotalPdfPages] = useState(0);
-  const [pageImages, setPageImages] = useState([]);
+  const [previewPages, setPreviewPages] = useState([]);
+  const [totalPages, setTotalPages] = useState(0);
+  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
 
   const [mappingHeaders, setMappingHeaders] = useState([]);
   const [mappingRows, setMappingRows] = useState([]);
@@ -70,9 +71,9 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
       );
       console.log('DADOS RECEBIDOS DA API:', response);
       setFileId(response.import_file_id);
-      setPageImages(response.image_urls || []);
+      setPreviewPages(response.image_urls || []);
       setCurrentPage(1);
-      setTotalPdfPages(response.total_pages || 0);
+      setTotalPages(response.total_pages || 0);
       setStep('select_page');
     } catch (err) {
       const detail = err.response?.data?.detail || err.message;
@@ -156,34 +157,31 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
     }
   };
 
-  useEffect(() => {
-    const fetchPreview = async () => {
-      if (!selectedFile || step !== 'select_page') return;
-      setLoading(true);
-      setLoadingMessage('A gerar pré-visualização...');
-      setError('');
-      try {
-        const offset = (currentPage - 1) * limit;
-        const response = await fornecedorService.getPdfPreview(
-          selectedFile,
-          fornecedor.id,
-          offset,
-          limit,
-        );
-        console.log('DADOS RECEBIDOS DA API:', response);
-        setFileId(response.import_file_id);
-        setPageImages(response.image_urls || []);
-        setTotalPdfPages(response.total_pages || 0);
-      } catch (err) {
-        const detail = err.response?.data?.detail || err.message;
-        setError(`Erro: ${detail}`);
-      } finally {
-        setLoading(false);
-      }
-    };
+  const fetchPages = async () => {
+    if (!selectedFile) return;
+    const offset = (currentPage - 1) * limit;
+    setIsLoadingPreview(true);
+    setError('');
+    try {
+      const response = await fornecedorService.getPdfPreview(
+        selectedFile,
+        fornecedor.id,
+        offset,
+        limit,
+      );
+      setPreviewPages(response.image_urls || []);
+      setTotalPages(response.total_pages || 0);
+    } catch (err) {
+      const detail = err.response?.data?.detail || err.message;
+      setError(`Erro: ${detail}`);
+    } finally {
+      setIsLoadingPreview(false);
+    }
+  };
 
-    fetchPreview();
-  }, [currentPage, selectedFile]);
+  useEffect(() => {
+    fetchPages();
+  }, [currentPage, selectedFile, fornecedor.id, limit]);
 
 
 
@@ -211,7 +209,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
         <div>
           <h3>Passo 2: Escolha a página da tabela</h3>
           <div style={{ display: 'flex', flexWrap: 'wrap' }}>
-            {pageImages
+            {previewPages
               .slice(
                 (currentPage ? currentPage - 1 : 0) * limit,
                 (currentPage ? currentPage - 1 : 0) * limit + limit,
@@ -231,14 +229,14 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
           </div>
           <PaginationControls
             currentPage={currentPage ? currentPage - 1 : 0}
-            totalPages={Math.ceil(totalPdfPages / limit)}
+            totalPages={Math.ceil(totalPages / limit)}
             onPageChange={(page) => setCurrentPage(page + 1)}
             itemsPerPage={limit}
             onItemsPerPageChange={(value) => {
               setLimit(parseInt(value, 10));
               setCurrentPage(1);
             }}
-            totalItems={totalPdfPages}
+            totalItems={totalPages}
           />
         </div>
       )}

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -194,6 +194,12 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
           isOpen={isLoadingPreview}
         />
       )}
+      {isLoadingPreview && (
+        <LoadingPopup
+          message="A gerar pré-visualização..."
+          isOpen={isLoadingPreview}
+        />
+      )}
       {error && (
         <p style={{ color: 'red', fontWeight: 'bold', border: '1px solid red', padding: '10px', marginTop: '10px' }}>
           {error}


### PR DESCRIPTION
## Summary
- add preview state management to ImportCatalogWizard
- load PDF preview pages via new `fetchPages` function
- trigger preview loading whenever current page or file changes

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab7dc4c58832fac15e982f6f9b6e5