### PR TITLE
Fix ImportCatalogWizard preview test

### DIFF
--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -61,7 +61,7 @@ describe('ImportCatalogWizard', () => {
     await userEvent.upload(fileInput, file);
     await userEvent.click(screen.getByText('Gerar Preview'));
 
-    expect(fornecedorService.getPdfPreview).toHaveBeenCalledWith(file, 1, 0, 5);
     await screen.findByAltText('Página 1');
+    expect(fornecedorService.getPdfPreview).toHaveBeenCalledWith(file, 1, 0, 5);
   });
 });


### PR DESCRIPTION
## Summary
- wait for preview image load before asserting API call

## Testing
- `./scripts/run_tests.sh` *(fails: could not install dependencies)*
- `npm test` in `Frontend/app` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ab7de4618832f9489b963d03d7080