### PR TITLE
Fix preview state variables

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -23,17 +23,13 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [loadingMessage, setLoadingMessage] = useState('');
   const [error, setError] = useState('');
 
-  const [fileId, setFileId] = useState(null);
-  const [jobId, setJobId] = useState(null);
   const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [previewPages, setPreviewPages] = useState([]);
   const [totalPages, setTotalPages] = useState(0);
   const [currentPage, setCurrentPage] = useState(1);
-  const [limit, setLimit] = useState(5);
-  const [previewPages, setPreviewPages] = useState([]);
-  const [totalPages, setTotalPages] = useState(0);
-  const [isLoadingPreview, setIsLoadingPreview] = useState(false);
   const [limit] = useState(5);
+  const [fileId, setFileId] = useState(null);
+  const [jobId, setJobId] = useState(null);
 
   const [mappingHeaders, setMappingHeaders] = useState([]);
   const [mappingRows, setMappingRows] = useState([]);
@@ -297,12 +293,6 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
             currentPage={currentPage ? currentPage - 1 : 0}
             totalPages={Math.ceil(totalPages / limit)}
             onPageChange={(page) => setCurrentPage(page + 1)}
-
-            itemsPerPage={limit}
-            onItemsPerPageChange={(value) => {
-              setLimit(parseInt(value, 10));
-              setCurrentPage(1);
-            }}
             isLoading={isLoadingPreview}
             totalItems={totalPages}
           />


### PR DESCRIPTION
## Summary
- deduplicate preview state declarations and expose individual state controls
- remove ability to set preview page limit dynamically

## Testing
- `pytest -q` *(fails: could not install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685ac701252c832fb38101a9890f8149