### PR TITLE
Add pagination trigger useEffect

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -9,6 +9,7 @@ import Modal from '../common/Modal.jsx';
 import ImportProgress from './ImportProgress.jsx';
 import PaginationControls from '../common/PaginationControls';
 import getBackendBaseUrl from '../../utils/backend.js';
+import { showErrorToast } from '../../utils/notifications';
 
 const FIELD_OPTIONS = [
   { value: 'nome_base', label: 'Nome Base' },
@@ -47,7 +48,39 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [applyAllPages, setApplyAllPages] = useState(false);
   const [selectedBbox, setSelectedBbox] = useState(null);
 
-  const backendBaseUrl = getBackendBaseUrl();
+const backendBaseUrl = getBackendBaseUrl();
+
+  useEffect(() => {
+    if (!selectedFile) return;
+
+    const fetchPages = async () => {
+      setIsLoadingPreview(true);
+      const offset = (currentPage - 1) * limit;
+      try {
+        const data = await fornecedorService.previewPdf(
+          fornecedor.id,
+          selectedFile,
+          offset,
+          limit,
+        );
+        if (data && data.pages) {
+          setPreviewPages(data.pages);
+          setTotalPages(data.total_pages);
+          if (data.file_id) setFileId(data.file_id);
+        } else {
+          setPreviewPages([]);
+          setTotalPages(0);
+        }
+      } catch (error) {
+        console.error("Falha ao carregar o preview do PDF:", error);
+        showErrorToast("Erro ao carregar o preview do PDF.");
+      } finally {
+        setIsLoadingPreview(false);
+      }
+    };
+
+    fetchPages();
+  }, [currentPage, selectedFile]);
 
   const handleFileChange = (e) => {
     const file = e.target.files[0];


### PR DESCRIPTION
## Summary
- add missing pagination trigger logic to `ImportCatalogWizard`
- import `showErrorToast`

## Testing
- `scripts/run_tests.sh` *(fails: Could not fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_685ac7161564832f900569404acd0e79