### PR TITLE
Add fetchPreviewPages hook

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -1,6 +1,6 @@
 // Caminho: Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import * as fornecedorService from '../../services/fornecedorService';
 import LoadingPopup from '../common/LoadingPopup';
 import ColumnMappingModal from '../common/ColumnMappingModal.jsx';
@@ -43,6 +43,33 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [pdfBytes, setPdfBytes] = useState(null);
   const [applyAllPages, setApplyAllPages] = useState(false);
   const [selectedBbox, setSelectedBbox] = useState(null);
+
+  const fetchPreviewPages = useCallback(async () => {
+    if (!selectedFile) return;
+    setIsLoadingPreview(true);
+    const offset = (currentPage - 1) * limit;
+    try {
+      const data = await fornecedorService.previewPdf(
+        fornecedor.id,
+        selectedFile,
+        offset,
+        limit,
+      );
+      if (data && data.pages) {
+        setPreviewPages(data.pages);
+        setTotalPages(data.total_pages);
+        if (data.file_id) setFileId(data.file_id);
+      } else {
+        setPreviewPages([]);
+        setTotalPages(0);
+      }
+    } catch (error) {
+      console.error("Falha ao carregar o preview do PDF:", error);
+      showErrorToast("Erro ao carregar o preview do PDF.");
+    } finally {
+      setIsLoadingPreview(false);
+    }
+  }, [currentPage, selectedFile, fornecedor.id, limit]);
 
 const backendBaseUrl = getBackendBaseUrl();
 


### PR DESCRIPTION
## Summary
- centralize PDF preview data fetching in `fetchPreviewPages`
- import `useCallback` for new function

## Testing
- `npm test` *(fails: jest not found)*
- `./scripts/run_tests.sh` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685acc1b4c68832fbeaeb87f82891815