### PR TITLE
Implement pagination trigger effect

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -1,6 +1,6 @@
 // Caminho: Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import * as fornecedorService from '../../services/fornecedorService';
 import LoadingPopup from '../common/LoadingPopup';
 import ColumnMappingModal from '../common/ColumnMappingModal.jsx';
@@ -44,39 +44,8 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [applyAllPages, setApplyAllPages] = useState(false);
   const [selectedBbox, setSelectedBbox] = useState(null);
 
+
 const backendBaseUrl = getBackendBaseUrl();
-
-  useEffect(() => {
-    if (!selectedFile) return;
-
-    const fetchPages = async () => {
-      setIsLoadingPreview(true);
-      const offset = (currentPage - 1) * limit;
-      try {
-        const data = await fornecedorService.previewPdf(
-          fornecedor.id,
-          selectedFile,
-          offset,
-          limit,
-        );
-        if (data && data.pages) {
-          setPreviewPages(data.pages);
-          setTotalPages(data.total_pages);
-          if (data.file_id) setFileId(data.file_id);
-        } else {
-          setPreviewPages([]);
-          setTotalPages(0);
-        }
-      } catch (error) {
-        console.error("Falha ao carregar o preview do PDF:", error);
-        showErrorToast("Erro ao carregar o preview do PDF.");
-      } finally {
-        setIsLoadingPreview(false);
-      }
-    };
-
-    fetchPages();
-  }, [currentPage, selectedFile]);
 
   const handleFileChange = (event) => {
     const file = event.target.files[0];
@@ -193,7 +162,7 @@ const backendBaseUrl = getBackendBaseUrl();
     }
   };
 
-  const fetchPages = async () => {
+  const fetchPreviewPages = useCallback(async () => {
     if (!selectedFile) return;
     const offset = (currentPage - 1) * limit;
     setIsLoadingPreview(true);
@@ -213,7 +182,11 @@ const backendBaseUrl = getBackendBaseUrl();
     } finally {
       setIsLoadingPreview(false);
     }
-  };
+  }, [selectedFile, currentPage, fornecedor.id, limit]);
+
+  useEffect(() => {
+    fetchPreviewPages();
+  }, [fetchPreviewPages]);
   useEffect(() => {
     const fetchPreview = async () => {
       if (!selectedFile || step !== 'select_page') return;
@@ -244,9 +217,6 @@ const backendBaseUrl = getBackendBaseUrl();
 
     fetchPreview();
   }, [currentPage, selectedFile, step]);
-  useEffect(() => {
-    fetchPages();
-  }, [currentPage, selectedFile, fornecedor.id, limit]);
 
 
 


### PR DESCRIPTION
## Summary
- add useCallback for preview page retrieval
- trigger preview page fetch on hook changes
- clean up old effect

## Testing
- `./scripts/run_tests.sh` *(fails: Could not install deps)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685acc2799d0832fa2b3b3ec75cec94e