### PR TITLE
Remove duplicate fetchPreviewPages

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -177,27 +177,6 @@ const backendBaseUrl = getBackendBaseUrl();
     }
   };
 
-  const fetchPreviewPages = useCallback(async () => {
-    if (!selectedFile) return;
-    const offset = (currentPage - 1) * limit;
-    setIsLoadingPreview(true);
-    setError('');
-    try {
-      const response = await fornecedorService.getPdfPreview(
-        selectedFile,
-        fornecedor.id,
-        offset,
-        limit,
-      );
-      setPreviewPages(response.image_urls || []);
-      setTotalPages(response.total_pages || 0);
-    } catch (err) {
-      const detail = err.response?.data?.detail || err.message;
-      setError(`Erro: ${detail}`);
-    } finally {
-      setIsLoadingPreview(false);
-    }
-  }, [selectedFile, currentPage, fornecedor.id, limit]);
 
   useEffect(() => {
     fetchPreviewPages();


### PR DESCRIPTION
## Summary
- centralize preview fetch logic in `ImportCatalogWizard.jsx`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jose')*

------
https://chatgpt.com/codex/tasks/task_e_685acfcb3434832f827c373c1061f58d