### PR TITLE
Fix loading state references in ImportCatalogWizard

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -145,7 +145,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
 
   return (
     <div className="wizard-container">
-      {loading && <LoadingPopup message={loadingMessage} isOpen={loading} />}
+      {isLoading && <LoadingPopup message={loadingMessage} isOpen={isLoading} />}
       {isLoadingPreview && (
         <LoadingPopup
           message="A gerar pré-visualização..."
@@ -179,7 +179,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
           {selectedFile && <p>Ficheiro selecionado: {selectedFile.name}</p>}
           <button
             onClick={() => setStep('select_page')}
-            disabled={!selectedFile || loading}
+            disabled={!selectedFile || isLoading}
           >
             Gerar Preview
           </button>


### PR DESCRIPTION
## Summary
- correct `loading` references in ImportCatalogWizard.jsx

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685affbc9f78832f9784b39ff9d84378