### PR TITLE
Fix missing error state in ImportCatalogWizard

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -27,6 +27,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [limit] = useState(5); // Define 5 páginas por vez
   const [fileId, setFileId] = useState(null);
+  const [error, setError] = useState('');
 
   const fetchPreviewPages = useCallback(async () => {
     if (!selectedFile) return;


### PR DESCRIPTION
## Summary
- add missing `error` state initialization in `ImportCatalogWizard`

## Testing
- `npm test` *(fails: `jest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685b05d56e10832fbedd78a05aa1ff38