### PR TITLE
Fix missing state in ImportCatalogWizard

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -28,6 +28,7 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [limit] = useState(5); // Define 5 páginas por vez
   const [fileId, setFileId] = useState(null);
   const [error, setError] = useState('');
+  const [showRegionModal, setShowRegionModal] = useState(false);
 
   const fetchPreviewPages = useCallback(async () => {
     if (!selectedFile) return;


### PR DESCRIPTION
## Summary
- declare missing `showRegionModal` state in `ImportCatalogWizard.jsx`

## Testing
- `./scripts/run_tests.sh` *(fails: Could not fetch deps)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b077e7c2c832facaee2ff3ee41b3b