### PR TITLE
Fix ImportCatalogWizard state setup

### DIFF
--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -29,6 +29,16 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [fileId, setFileId] = useState(null);
   const [error, setError] = useState('');
   const [showRegionModal, setShowRegionModal] = useState(false);
+  const [pdfBytes, setPdfBytes] = useState(null);
+  const [regionPreview, setRegionPreview] = useState(null);
+  const [regionError, setRegionError] = useState('');
+  const [mappingHeaders, setMappingHeaders] = useState([]);
+  const [mappingRows, setMappingRows] = useState([]);
+  const [showMappingModal, setShowMappingModal] = useState(false);
+  const [loadingMessage, setLoadingMessage] = useState('');
+  const [selectedBbox, setSelectedBbox] = useState(null);
+  const [applyAllPages, setApplyAllPages] = useState(false);
+  const [jobId, setJobId] = useState(null);
 
   const fetchPreviewPages = useCallback(async () => {
     if (!selectedFile) return;


### PR DESCRIPTION
## Summary
- add missing state variables in `ImportCatalogWizard`

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b0e77e090832fa8c5ab9d8539672b