### PR TITLE
Fix import catalog wizard visibility

### DIFF
--- a/Frontend/app/src/components/fornecedores/EditFornecedorModal.jsx
+++ b/Frontend/app/src/components/fornecedores/EditFornecedorModal.jsx
@@ -182,6 +182,7 @@ function EditFornecedorModal({ isOpen, onClose, fornecedorData, onSave, isLoadin
         <ImportCatalogWizard
           fornecedor={fornecedorData}
           onClose={() => setIsImportWizardOpen(false)}
+          isOpen={isImportWizardOpen}
         />
       </div>
     </div>

--- a/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
+++ b/Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
@@ -15,7 +15,7 @@ const FIELD_OPTIONS = [
   { value: 'preco_venda', label: 'Preço' },
 ];
 
-const ImportCatalogWizard = ({ fornecedor, onClose }) => {
+const ImportCatalogWizard = ({ fornecedor, onClose, isOpen }) => {
   const [step, setStep] = useState(1);
   const [selectedFile, setSelectedFile] = useState(null);
   const [mapping, setMapping] = useState(fornecedor.default_column_mapping || {});
@@ -39,6 +39,8 @@ const ImportCatalogWizard = ({ fornecedor, onClose }) => {
   const [selectedBbox, setSelectedBbox] = useState(null);
   const [applyAllPages, setApplyAllPages] = useState(false);
   const [jobId, setJobId] = useState(null);
+
+  if (!isOpen) return null;
 
   const fetchPreviewPages = useCallback(async () => {
     if (!selectedFile) return;

--- a/README Frontend.md
+++ b/README Frontend.md
@@ -84,7 +84,7 @@ Após instalar, inclua o diretório com `pdftoppm.exe` no `PATH` ou defina `POPP
 
 ## Frontend/app/src/components/fornecedores/ImportCatalogWizard.jsx
 
-* `ImportCatalogWizard({ fornecedor, onClose })`: Assistente em três passos para importar catálogos.
+* `ImportCatalogWizard({ fornecedor, onClose, isOpen })`: Assistente em três passos para importar catálogos. O wizard só é exibido quando `isOpen` é verdadeiro.
   1. **Pré-visualização e seleção do tipo** – upload do arquivo, exibição de amostras e escolha do tipo de produto. Agora é possível definir a **Página inicial** para filtrar as páginas a serem importadas.
   2. **Mapeamento de colunas** – associa colunas da planilha a campos padrão e atributos dinâmicos. Permite criar um novo tipo de produto caso não exista.
   3. **Confirmação** – revisão final e importação.


### PR DESCRIPTION
## Summary
- show ImportCatalogWizard only when open
- update docs on new prop

## Testing
- `./scripts/run_tests.sh` *(fails: Could not install fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685b13292208832fb2f5da4e49ed7f8c