### PR TITLE
Fix ImportCatalogWizard preview test

### DIFF
--- a/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
+++ b/Frontend/app/src/components/fornecedores/__tests__/ImportCatalogWizard.test.jsx
@@ -52,8 +52,13 @@ describe('ImportCatalogWizard', () => {
       total_pages: 10,
     });
 
-    render(<ImportCatalogWizard fornecedor={{ id: 1 }} onClose={() => {}} />);
-    render(<ImportCatalogWizard onClose={() => {}} fornecedor={{ id: 1 }} />);
+    render(
+      <ImportCatalogWizard
+        fornecedor={{ id: 1 }}
+        onClose={() => {}}
+        isOpen
+      />,
+    );
 
 
     const fileInput = document.querySelector('input[type="file"]');


### PR DESCRIPTION
## Summary
- fix `ImportCatalogWizard` test to render wizard only once with `isOpen`
- keep expectation on `fornecedorService.getPdfPreview`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b19d9d478832f91fb2ed9675e716c